### PR TITLE
Truncate navigation bar title if too long

### DIFF
--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -220,8 +220,9 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
         titleButton.contentHorizontalAlignment = .left
         titleButton.titleLabel?.adjustsFontSizeToFitWidth = true
         titleButton.addTarget(self, action: #selector(AvatarTitleView.titleButtonTapped(sender:)), for: .touchUpInside)
-        titleButton.setContentCompressionResistancePriority(.required,
-                                                            for: .horizontal)
+        titleButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleButton.titleLabel?.lineBreakMode = .byTruncatingTail
+        titleButton.titleLabel?.adjustsFontSizeToFitWidth = false
 
         updateAppearance()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

This PR brings #1919 to main.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="490" alt="before_portrait" src="https://github.com/microsoft/fluentui-apple/assets/106181067/650d7ef6-2398-46ff-87ee-d92502148692"> | <img width="490" alt="after_portrait" src="https://github.com/microsoft/fluentui-apple/assets/106181067/d3c954e6-2287-4c2b-bfce-1dc4372e3f10"> |
| <img width="863" alt="before_landscape" src="https://github.com/microsoft/fluentui-apple/assets/106181067/8eb13b36-6327-4aee-8aad-1dee42139c37"> | <img width="863" alt="after_landscape" src="https://github.com/microsoft/fluentui-apple/assets/106181067/4604b797-9286-478f-bba4-1eb602aa3457"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1932)