### PR TITLE
New API: `setSharedThemeColorProvider(_:)`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -65,6 +65,13 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
         self.modalPresentationStyle = .popover
         self.preferredContentSize.height = 400
         self.popoverPresentationController?.permittedArrowDirections = .up
+
+        // Different themes can have different overrides, so update our state when we detect a theme change.
+        self.themeObserver = NotificationCenter.default.addObserver(forName: .didChangeTheme, object: nil, queue: nil) { [weak self] _ in
+            DispatchQueue.main.async {
+                self?.updateToggleConfiguration()
+            }
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -89,6 +96,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
     private func updateToggleConfiguration() {
         configuration.userInterfaceStyle = view.window?.overrideUserInterfaceStyle ?? .unspecified
         configuration.windowTheme = currentDemoListViewController?.theme ?? .default
+        configuration.appWideTheme = DemoColorTheme.currentAppWideTheme
         if let isThemeOverrideEnabled = configuration.themeOverridePreviouslyApplied {
             let newValue = isThemeOverrideEnabled()
             configuration.themeWideOverride = newValue
@@ -103,14 +111,12 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
               }
         currentDemoListViewController.updateColorProviderFor(window: window, theme: theme)
 
-        // Different themes can have different overrides, so update as needed.
-        updateToggleConfiguration()
         rootView.fluentTheme = window.fluentTheme
     }
 
     /// Callback for handling app-wide theme changes
     private func onAppWideThemeChanged(_ theme: DemoColorTheme) {
-        FluentTheme.setSharedThemeColorProvider(theme.provider)
+        DemoColorTheme.currentAppWideTheme = theme
     }
 
     /// Callback for handling color scheme changes.
@@ -127,6 +133,7 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
     }
 
     private var configuration: DemoAppearanceView.Configuration
+    private var themeObserver: NSObjectProtocol?
 }
 
 extension DemoAppearanceView.Configuration {

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceController.swift
@@ -58,11 +58,12 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
 
         super.init(rootView: DemoAppearanceView(configuration: configuration))
 
-        configuration.onThemeChanged = self.onThemeChanged
-        configuration.onUserInterfaceStyleChanged = self.onUserInterfaceStyleChanged
+        configuration.onWindowThemeChanged = self.onWindowThemeChanged(_:)
+        configuration.onAppWideThemeChanged = self.onAppWideThemeChanged(_:)
+        configuration.onUserInterfaceStyleChanged = self.onUserInterfaceStyleChanged(_:)
 
         self.modalPresentationStyle = .popover
-        self.preferredContentSize.height = 375
+        self.preferredContentSize.height = 400
         self.popoverPresentationController?.permittedArrowDirections = .up
     }
 
@@ -87,15 +88,15 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
 
     private func updateToggleConfiguration() {
         configuration.userInterfaceStyle = view.window?.overrideUserInterfaceStyle ?? .unspecified
-        configuration.theme = currentDemoListViewController?.theme ?? .default
+        configuration.windowTheme = currentDemoListViewController?.theme ?? .default
         if let isThemeOverrideEnabled = configuration.themeOverridePreviouslyApplied {
             let newValue = isThemeOverrideEnabled()
             configuration.themeWideOverride = newValue
         }
     }
 
-    /// Callback for handling theme changes.
-    private func onThemeChanged(_ theme: DemoColorTheme) {
+    /// Callback for handling per-window theme changes.
+    private func onWindowThemeChanged(_ theme: DemoColorTheme) {
         guard let currentDemoListViewController = currentDemoListViewController,
               let window = view.window else {
                   return
@@ -105,6 +106,11 @@ class DemoAppearanceController: UIHostingController<DemoAppearanceView>, Observa
         // Different themes can have different overrides, so update as needed.
         updateToggleConfiguration()
         rootView.fluentTheme = window.fluentTheme
+    }
+
+    /// Callback for handling app-wide theme changes
+    private func onAppWideThemeChanged(_ theme: DemoColorTheme) {
+        FluentTheme.setSharedThemeColorProvider(theme.provider)
     }
 
     /// Callback for handling color scheme changes.

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoAppearanceView.swift
@@ -30,12 +30,13 @@ struct DemoAppearanceView: View {
 
     /// Picker for setting the current Fluent theme.
     @ViewBuilder
-    var themePicker: some View {
-        Text("Theme")
+    func themePicker(_ titleKey: String, selection: Binding<DemoColorTheme>) -> some View {
+        Text(titleKey)
             .font(.headline)
-        Picker("Theme", selection: $configuration.theme) {
+        Picker(titleKey, selection: selection) {
             Text("\(DemoColorTheme.default.name)").tag(DemoColorTheme.default)
             Text("\(DemoColorTheme.green.name)").tag(DemoColorTheme.green)
+            Text("\(DemoColorTheme.purple.name)").tag(DemoColorTheme.purple)
         }
         .pickerStyle(.segmented)
     }
@@ -45,10 +46,8 @@ struct DemoAppearanceView: View {
     var contents: some View {
         VStack {
             appColorSchemePicker
-            Divider()
-                .padding()
-
-            themePicker
+            themePicker("Window Theme", selection: $configuration.windowTheme)
+            themePicker("App-Wide Theme", selection: $configuration.appWideTheme)
             Divider()
                 .padding()
 
@@ -85,8 +84,11 @@ struct DemoAppearanceView: View {
                 .onChange(of: configuration.userInterfaceStyle) { newValue in
                     configuration.onUserInterfaceStyleChanged?(newValue)
                 }
-                .onChange(of: configuration.theme) { newValue in
-                    configuration.onThemeChanged?(newValue)
+                .onChange(of: configuration.windowTheme) { newValue in
+                    configuration.onWindowThemeChanged?(newValue)
+                }
+                .onChange(of: configuration.appWideTheme) { newValue in
+                    configuration.onAppWideThemeChanged?(newValue)
                 }
                 .onChange(of: configuration.themeWideOverride) { newValue in
                     configuration.onThemeWideOverrideChanged?(newValue)
@@ -110,16 +112,20 @@ struct DemoAppearanceView: View {
     class Configuration: ObservableObject {
         // Data
         @Published var userInterfaceStyle: UIUserInterfaceStyle = .unspecified
-        @Published var theme: DemoColorTheme = .default
+        @Published var windowTheme: DemoColorTheme = .default
+        @Published var appWideTheme: DemoColorTheme = .default
         @Published var themeWideOverride: Bool = false
         @Published var perControlOverride: Bool = false
 
         // Environment
         @Published var isConfigured: Bool = false
 
+        // Global callbacks
+        var onAppWideThemeChanged: ((_ theme: DemoColorTheme) -> Void)?
+
         // Window-specific callbacks
         var onUserInterfaceStyleChanged: ((_ userInterfaceStyle: UIUserInterfaceStyle) -> Void)?
-        var onThemeChanged: ((_ theme: DemoColorTheme) -> Void)?
+        var onWindowThemeChanged: ((_ theme: DemoColorTheme) -> Void)?
 
         // Control-specific callbacks
         var onThemeWideOverrideChanged: ((_ themeWideOverrideEnabled: Bool) -> Void)?
@@ -133,13 +139,5 @@ struct DemoAppearanceView: View {
 
     private var showPerControlOverrideToggle: Bool {
         return configuration.onPerControlOverrideChanged != nil
-    }
-}
-
-/// View modifiers
-extension DemoAppearanceView {
-    func theme(_ theme: DemoColorTheme) -> Self {
-        self.configuration.theme = theme
-        return self
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
@@ -9,7 +9,7 @@ import UIKit
 enum DemoColorTheme: CaseIterable {
     case `default`
     case green
-    case none
+    case purple
 
     var name: String {
         switch self {
@@ -17,123 +17,20 @@ enum DemoColorTheme: CaseIterable {
             return "Default"
         case .green:
             return "Green"
-        case .none:
-            return "None"
+        case .purple:
+            return "Purple"
         }
     }
 
     var provider: ColorProviding? {
         switch self {
         case .default:
-            return DemoColorDefaultTheme()
+            return nil
         case .green:
             return DemoColorGreenTheme()
-        case .none:
-            return nil
+        case .purple:
+            return DemoColorPurpleTheme()
         }
-    }
-}
-
-class DemoColorDefaultTheme: NSObject, ColorProviding {
-    var brandBackground1: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm80),
-                       dark: GlobalTokens.brandColor(.comm100))
-    }
-
-    var brandBackground1Pressed: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm50),
-                       dark: GlobalTokens.brandColor(.comm140))
-    }
-
-    var brandBackground1Selected: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm60),
-                       dark: GlobalTokens.brandColor(.comm120))
-    }
-
-    var brandBackground2: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm70))
-    }
-
-    var brandBackground2Pressed: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm40))
-    }
-
-    var brandBackground2Selected: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm80))
-    }
-
-    var brandBackground3: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm60),
-                       dark: GlobalTokens.brandColor(.comm120))
-    }
-
-    var brandBackgroundTint: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm150),
-                       dark: GlobalTokens.brandColor(.comm40))
-    }
-
-    var brandBackgroundDisabled: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm140),
-                       dark: GlobalTokens.brandColor(.comm40))
-    }
-
-    var brandForeground1: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm80),
-                       dark: GlobalTokens.brandColor(.comm100))
-    }
-
-    var brandForeground1Pressed: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm50),
-                       dark: GlobalTokens.brandColor(.comm140))
-    }
-
-    var brandForeground1Selected: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm60),
-                       dark: GlobalTokens.brandColor(.comm120))
-    }
-
-    var brandForegroundTint: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm60),
-                       dark: GlobalTokens.brandColor(.comm130))
-    }
-
-    var brandForegroundDisabled1: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm90))
-    }
-
-    var brandForegroundDisabled2: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm140),
-                       dark: GlobalTokens.brandColor(.comm40))
-    }
-
-    var brandStroke1: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm80),
-                       dark: GlobalTokens.brandColor(.comm100))
-    }
-
-    var brandStroke1Pressed: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm50),
-                       dark: GlobalTokens.brandColor(.comm140))
-    }
-
-    var brandStroke1Selected: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.comm60),
-                       dark: GlobalTokens.brandColor(.comm120))
-    }
-
-    var brandGradient1: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.gradientPrimaryLight),
-                       dark: GlobalTokens.brandColor(.gradientPrimaryDark))
-    }
-
-    var brandGradient2: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.gradientSecondaryLight),
-                       dark: GlobalTokens.brandColor(.gradientSecondaryDark))
-    }
-
-    var brandGradient3: UIColor {
-        return UIColor(light: GlobalTokens.brandColor(.gradientTertiaryLight),
-                       dark: GlobalTokens.brandColor(.gradientTertiaryDark))
     }
 }
 
@@ -235,5 +132,93 @@ class DemoColorGreenTheme: NSObject, ColorProviding {
 
     var brandGradient3: UIColor {
         return UIColor(hexValue: 0x42B8B2)
+    }
+}
+
+class DemoColorPurpleTheme: NSObject, ColorProviding {
+    var brandBackground1: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x822FFF),
+                       dark: UIColor(hexValue: 0xA275FF))
+    }
+
+    var brandBackground1Pressed: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x550FBE),
+                       dark: UIColor(hexValue: 0xC2AAFD))
+    }
+
+    var brandBackground1Selected: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x6415DB),
+                       dark: UIColor(hexValue: 0xB695FF))
+    }
+
+    var brandBackground2: UIColor {
+        return UIColor(hexValue: 0x6415DB)
+    }
+
+    var brandBackground2Pressed: UIColor {
+        return UIColor(hexValue: 0x410693)
+    }
+
+    var brandBackground2Selected: UIColor {
+        return UIColor(hexValue: 0x4B09A8)
+    }
+
+    var brandBackground3: UIColor {
+        return UIColor(hexValue: 0x4B09A8)
+    }
+
+    var brandBackgroundTint: UIColor {
+        return UIColor(light: UIColor(hexValue: 0xEDE8FF),
+                       dark: UIColor(hexValue: 0x4B09A8))
+    }
+
+    var brandBackgroundDisabled: UIColor {
+        return UIColor(light: UIColor(hexValue: 0xD0BDFD),
+                       dark: UIColor(hexValue: 0x4B09A8))
+    }
+
+    var brandForeground1: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x822FFF),
+                       dark: UIColor(hexValue: 0xA275FF))
+    }
+
+    var brandForeground1Pressed: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x550FBE),
+                       dark: UIColor(hexValue: 0xC2AAFD))
+    }
+
+    var brandForeground1Selected: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x6415DB),
+                       dark: UIColor(hexValue: 0xB695FF))
+    }
+
+    var brandForegroundTint: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x6415DB),
+                       dark: UIColor(hexValue: 0xC2AAFD))
+    }
+
+    var brandForegroundDisabled1: UIColor {
+        return UIColor(light: UIColor(hexValue: 0xB695FF),
+                       dark: UIColor(hexValue: 0x751FF5))
+    }
+
+    var brandForegroundDisabled2: UIColor {
+        return UIColor(light: UIColor(hexValue: 0xC2AAFD),
+                       dark: UIColor(hexValue: 0x4B09A8))
+    }
+
+    var brandStroke1: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x822FFF),
+                       dark: UIColor(hexValue: 0xA275FF))
+    }
+
+    var brandStroke1Pressed: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x550FBE),
+                       dark: UIColor(hexValue: 0xC2AAFD))
+    }
+
+    var brandStroke1Selected: UIColor {
+        return UIColor(light: UIColor(hexValue: 0x6415DB),
+                       dark: UIColor(hexValue: 0xB695FF))
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoColorThemes.swift
@@ -32,6 +32,13 @@ enum DemoColorTheme: CaseIterable {
             return DemoColorPurpleTheme()
         }
     }
+
+    /// Controls the app-wide theme and caches the value for later review.
+    static var currentAppWideTheme: DemoColorTheme = .default {
+        didSet {
+            FluentTheme.setSharedThemeColorProvider(currentAppWideTheme.provider)
+        }
+    }
 }
 
 class DemoColorGreenTheme: NSObject, ColorProviding {

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -35,6 +35,7 @@ class DemoListViewController: DemoTableViewController {
             let primaryColor = fluentTheme.color(.brandBackground1)
             FluentUIFramework.initializeAppearance(with: primaryColor, whenContainedInInstancesOf: [type(of: window)])
         } else {
+            window.resetFluentTheme()
             FluentUIFramework.initializeAppearance(with: UIColor(light: GlobalTokens.brandColor(.comm80), dark: GlobalTokens.brandColor(.comm90)))
         }
     }
@@ -140,6 +141,8 @@ class DemoListViewController: DemoTableViewController {
     }
 
     let cellReuseIdentifier: String = "TableViewCell"
+    var provider: ColorProviding? = DemoColorTheme.default.provider
+
     private static var isFirstLaunch: Bool = true
     private static let lastDemoControllerKey: String = "LastDemoController"
     private let cellTypeButton: UIButton = {
@@ -148,7 +151,6 @@ class DemoListViewController: DemoTableViewController {
         return button
     }()
     private var showGroupedTableViewCellStyle: Bool = true
-    private var provider: ColorProviding? = DemoColorTheme.default.provider
 
     private enum DemoControllerSection: CaseIterable {
         case fluent2Controls

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -86,21 +86,19 @@ private func brandColorOverrides(provider: ColorProviding) -> [FluentTheme.Color
         let fluentTheme = FluentTheme(colorOverrides: brandColors)
         self.fluentTheme = fluentTheme
     }
-
-    /// Removes any associated `ColorProvider` from the given `UIView`.
-    @objc(resetFluentTheme)
-    func resetFluentTheme() {
-        self.fluentTheme = FluentThemeKey.defaultValue
-    }
 }
 
 @objc public extension FluentTheme {
     /// Associates a `ColorProvider` with the default shared `FluentTheme` instance.
     ///
     /// - Parameters:
-    ///   - provider: The `ColorProvider` whose colors should be used for controls in `FluentTheme.shared`.
-    @objc static func setSharedThemeColorProvider(_ provider: ColorProviding) {
-        let brandColors = brandColorOverrides(provider: provider)
-        FluentTheme.shared = FluentTheme(colorOverrides: brandColors)
+    ///   - provider: The `ColorProvider` whose colors should be used for controls in `FluentTheme.shared`. Passing `nil` will reset to the default theme.
+    @objc static func setSharedThemeColorProvider(_ provider: ColorProviding?) {
+        if let provider {
+            let brandColors = brandColorOverrides(provider: provider)
+            FluentTheme.shared = FluentTheme(colorOverrides: brandColors)
+        } else {
+            FluentTheme.shared = FluentThemeKey.defaultValue
+        }
     }
 }

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -93,3 +93,14 @@ private func brandColorOverrides(provider: ColorProviding) -> [FluentTheme.Color
         self.fluentTheme = FluentThemeKey.defaultValue
     }
 }
+
+@objc public extension FluentTheme {
+    /// Associates a `ColorProvider` with the default shared `FluentTheme` instance.
+    ///
+    /// - Parameters:
+    ///   - provider: The `ColorProvider` whose colors should be used for controls in `FluentTheme.shared`.
+    @objc static func setSharedThemeColorProvider(_ provider: ColorProviding) {
+        let brandColors = brandColorOverrides(provider: provider)
+        FluentTheme.shared = FluentTheme(colorOverrides: brandColors)
+    }
+}

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -90,7 +90,7 @@ public class FluentTheme: NSObject, ObservableObject {
     /// the `ColorProviding` protocol will not be reflected here. As such, this should only be used in cases where the
     /// caller is certain that they are looking for the _default_ token values associated with Fluent.
     @objc(sharedTheme)
-    public internal(set) static var shared: FluentTheme = .init() {
+    public internal(set) static var shared: FluentTheme = FluentThemeKey.defaultValue {
         didSet {
             UIApplication.shared.connectedScenes
                 .compactMap {
@@ -160,6 +160,13 @@ public extension Notification.Name {
             NotificationCenter.default.post(name: .didChangeTheme, object: self)
         }
     }
+
+    /// Removes any associated `ColorProvider` from the given `UIView`.
+    @objc(resetFluentTheme)
+    public func resetFluentTheme() {
+        objc_setAssociatedObject(self, &Keys.fluentTheme, nil, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        NotificationCenter.default.post(name: .didChangeTheme, object: self)
+    }
 }
 
 // MARK: - Environment
@@ -185,7 +192,5 @@ public extension EnvironmentValues {
 }
 
 struct FluentThemeKey: EnvironmentKey {
-    static var defaultValue: FluentTheme {
-        return FluentTheme.shared
-    }
+    static let defaultValue: FluentTheme = .init()
 }

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -90,7 +90,20 @@ public class FluentTheme: NSObject, ObservableObject {
     /// the `ColorProviding` protocol will not be reflected here. As such, this should only be used in cases where the
     /// caller is certain that they are looking for the _default_ token values associated with Fluent.
     @objc(sharedTheme)
-    public static let shared: FluentTheme = .init()
+    public internal(set) static var shared: FluentTheme = .init() {
+        didSet {
+            UIApplication.shared.connectedScenes
+                .compactMap {
+                    $0 as? UIWindowScene
+                }
+                .flatMap {
+                    $0.windows
+                }
+                .forEach { window in
+                    NotificationCenter.default.post(name: .didChangeTheme, object: window)
+                }
+        }
+    }
 
     // Token storage
     let colorTokenSet: TokenSet<ColorToken, UIColor>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Adds a new API for changing the `ColorProviding` instance for the shared theme.

Usage:
```swift
// Swift
let colorProvider: ColorProviding = /* create your own instance of ColorProviding */
FluentTheme.setSharedThemeColorProvider(colorProvider)

// Now all calls to `FluentTheme.shared` will route through your color provider
```

```objc
// Objective-C
id<MSFColorProviding> colorProvider = /* create your own instance of ColorProviding */
[MSFFluentTheme setSharedThemeColorProvider:colorProvider];
```

This makes it possible to change the color scheme of an entire app at once, instead of solely per-window.

In order to test this, I overhauled the themes used by the FluentUI Demo app, removing the `default` theme (itself just a copy of the shared default theme) and replaced it with a new "purple" theme.

There's also a new picker in the appearance customization dropdown for changing the theme of the entire app, and the existing "Theme" picker is now called "Window Theme".

### Binary change

Total increase: 49,160 bytes
Total decrease: -2,424 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,935,680 bytes | 30,982,416 bytes | ⚠️ 46,736 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentTheme.o | 123,424 bytes | 155,144 bytes | ⚠️ 31,720 bytes |
| DateTimePickerController.o | 138,800 bytes | 144,016 bytes | ⚠️ 5,216 bytes |
| __.SYMDEF | 4,817,896 bytes | 4,821,272 bytes | ⚠️ 3,376 bytes |
| ColorProviding.o | 41,480 bytes | 43,416 bytes | ⚠️ 1,936 bytes |
| HUD.o | 257,784 bytes | 259,672 bytes | ⚠️ 1,888 bytes |
| FocusRingView.o | 817,288 bytes | 818,984 bytes | ⚠️ 1,696 bytes |
| PopupMenuController.o | 382,680 bytes | 383,856 bytes | ⚠️ 1,176 bytes |
| MultilineCommandBar.o | 140,592 bytes | 141,272 bytes | ⚠️ 680 bytes |
| FluentUIFramework.o | 104,320 bytes | 104,816 bytes | ⚠️ 496 bytes |
| AvatarGroup.o | 420,360 bytes | 420,632 bytes | ⚠️ 272 bytes |
| BottomCommandingController.o | 848,112 bytes | 848,376 bytes | ⚠️ 264 bytes |
| DateTimePickerViewComponentTableView.o | 67,800 bytes | 67,992 bytes | ⚠️ 192 bytes |
| DateTimePickerViewComponent.o | 138,048 bytes | 138,152 bytes | ⚠️ 104 bytes |
| DateTimePickerView.o | 207,920 bytes | 207,968 bytes | ⚠️ 48 bytes |
| DrawerController.o | 482,952 bytes | 482,992 bytes | ⚠️ 40 bytes |
| BadgeView.o | 625,304 bytes | 625,328 bytes | ⚠️ 24 bytes |
| NavigationBarTokenSet.o | 72,328 bytes | 72,344 bytes | ⚠️ 16 bytes |
| PopupMenuItem.o | 125,672 bytes | 125,688 bytes | ⚠️ 16 bytes |
| DateTimePickerViewLayout.o | 59,784 bytes | 57,360 bytes | 🎉 -2,424 bytes |

</details>

### Verification

<details>
<summary>Visual Verification</summary>

![Theme Changing p2](https://github.com/microsoft/fluentui-apple/assets/4934719/39f204f1-785b-44a9-b1fb-54afa0c908ec)

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)