### PR TITLE
Make FluentUI be iOS 17 safe

### DIFF
--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -277,6 +277,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
     }
 
+    @available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -162,6 +162,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         initialize()
     }
 
+	@available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -162,7 +162,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
         initialize()
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -378,7 +378,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if let previousTraitCollection = previousTraitCollection {

--- a/ios/FluentUI/Card/CardView.swift
+++ b/ios/FluentUI/Card/CardView.swift
@@ -378,6 +378,7 @@ open class CardView: UIView, Shadowable, TokenizedControlInternal {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+	@available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if let previousTraitCollection = previousTraitCollection {

--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -59,22 +59,22 @@ extension View {
         modifier(ShadowModifier(shadowInfo: shadowInfo))
     }
 
-	/// Abstracts away differences in pre-iOS 17 `onChange(of:perform:)` versus post-iOS 17 `onChange(of:_:)`.
-	///
-	/// This function will be removed once FluentUI moves to iOS 17 as a minimum target.
-	/// - Parameters:
-	///   - value: The value to check against when determining whether to run the closure.
-	///   - action: A closure to run when the value changes.
-	/// - Returns: A view that fires an action when the specified value changes.
-	func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
-		if #available(iOS 17, *) {
-			return self.onChange(of: value) { _, newValue in
-				return action(newValue)
-			}
-		} else {
-			return self.onChange(of: value, perform: action)
-		}
-	}
+    /// Abstracts away differences in pre-iOS 17 `onChange(of:perform:)` versus post-iOS 17 `onChange(of:_:)`.
+    ///
+    /// This function will be removed once FluentUI moves to iOS 17 as a minimum target.
+    /// - Parameters:
+    ///   - value: The value to check against when determining whether to run the closure.
+    ///   - action: A closure to run when the value changes.
+    /// - Returns: A view that fires an action when the specified value changes.
+    func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
+        if #available(iOS 17, *) {
+            return self.onChange(of: value) { _, newValue in
+                return action(newValue)
+            }
+        } else {
+            return self.onChange(of: value, perform: action)
+        }
+    }
 }
 
 /// PreferenceKey that will store the measured size of the view

--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -43,7 +43,7 @@ extension View {
 
     /// Adds a large content viewer for the view. If the text and image are both nil,
     /// the default large content viewer will be used.
-    /// - Parameters
+    /// - Parameters:
     ///  - text: Optional String to display in the large content viewer.
     ///  - image: Optional UIImage to display in the large content viewer.
     /// - Returns: The modified view.
@@ -52,12 +52,29 @@ extension View {
     }
 
     /// Applies multiple shadows on a View
-    /// - Parameters
+    /// - Parameters:
     ///  - shadowInfo: The values of the two shadows to be applied
     /// - Returns: The modified view.
     func applyShadow(shadowInfo: ShadowInfo) -> some View {
         modifier(ShadowModifier(shadowInfo: shadowInfo))
     }
+
+	/// Abstracts away differences in pre-iOS 17 `onChange(of:perform:)` versus post-iOS 17 `onChange(of:_:)`.
+	///
+	/// This function will be removed once FluentUI moves to iOS 17 as a minimum target.
+	/// - Parameters:
+	///   - value: The value to check against when determining whether to run the closure.
+	///   - action: A closure to run when the value changes.
+	/// - Returns: A view that fires an action when the specified value changes.
+	func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
+		if #available(iOS 17, *) {
+			return self.onChange(of: value) { _, newValue in
+				return action(newValue)
+			}
+		} else {
+			return self.onChange(of: value, perform: action)
+		}
+	}
 }
 
 /// PreferenceKey that will store the measured size of the view

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -224,6 +224,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         navigationItem.leftBarButtonItem?.tintColor = view.fluentTheme.color(.foreground2)
     }
 
+	@available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -224,7 +224,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
         navigationItem.leftBarButtonItem?.tintColor = view.fluentTheme.color(.foreground2)
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Extensions/UIColor+Extensions.swift
+++ b/ios/FluentUI/Extensions/UIColor+Extensions.swift
@@ -217,10 +217,19 @@ extension UIColor {
     private func resolvedColorValue(userInterfaceStyle: UIUserInterfaceStyle,
                                     accessibilityContrast: UIAccessibilityContrast = .unspecified,
                                     userInterfaceLevel: UIUserInterfaceLevel = .unspecified) -> UIColor {
-        let traitCollectionStyle = UITraitCollection(userInterfaceStyle: userInterfaceStyle)
-        let traitCollectionContrast = UITraitCollection(accessibilityContrast: accessibilityContrast)
-        let traitCollectionLevel = UITraitCollection(userInterfaceLevel: userInterfaceLevel)
-        let traitCollection = UITraitCollection(traitsFrom: [traitCollectionStyle, traitCollectionContrast, traitCollectionLevel])
+        let traitCollection: UITraitCollection
+        if #available(iOS 17, *) {
+            traitCollection = UITraitCollection { mutableTraits in
+                mutableTraits.userInterfaceStyle = userInterfaceStyle
+                mutableTraits.accessibilityContrast = accessibilityContrast
+                mutableTraits.userInterfaceLevel = userInterfaceLevel
+            }
+        } else {
+            let traitCollectionStyle = UITraitCollection(userInterfaceStyle: userInterfaceStyle)
+            let traitCollectionContrast = UITraitCollection(accessibilityContrast: accessibilityContrast)
+            let traitCollectionLevel = UITraitCollection(userInterfaceLevel: userInterfaceLevel)
+            traitCollection = UITraitCollection(traitsFrom: [traitCollectionStyle, traitCollectionContrast, traitCollectionLevel])
+        }
         let resolvedColor = self.resolvedColor(with: traitCollection)
         return resolvedColor
     }

--- a/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
+++ b/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
@@ -68,7 +68,7 @@ public class MultilineCommandBar: UIViewController {
         bottomSheetController = sheetController
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
+++ b/ios/FluentUI/MultilineCommandBar/MultilineCommandBar.swift
@@ -68,6 +68,7 @@ public class MultilineCommandBar: UIViewController {
         bottomSheetController = sheetController
     }
 
+	@available(iOS, deprecated: 17.0)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -564,7 +564,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             contentStackView.point(inside: convert(point, to: contentStackView), with: event)
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -564,6 +564,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
             contentStackView.point(inside: convert(point, to: contentStackView), with: event)
     }
 
+	@available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -213,7 +213,7 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
     /// e.g. should cancel a search on scroll
     private var cancelsContentFirstRespondingOnHide: Bool = false
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateContentInsets()

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -213,6 +213,7 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
     /// e.g. should cancel a search on scroll
     private var cancelsContentFirstRespondingOnHide: Bool = false
 
+	@available(iOS, deprecated: 17.0)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateContentInsets()

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -313,13 +313,13 @@ public struct FluentNotification: View, TokenizedControlView {
                     notification
                         .frame(idealWidth: isFlexibleWidthToast ? innerContentsSize.width - horizontalPadding : calculatedNotificationWidth,
                                maxWidth: isFlexibleWidthToast ? proposedWidth : calculatedNotificationWidth, alignment: .center)
-                        .onChange(of: isPresented, perform: { present in
-                            if present {
+                        .onChange_iOS17(of: isPresented) { newPresent in
+                            if newPresent {
                                 presentAnimated()
                             } else {
                                 dismissAnimated()
                             }
-                        })
+                        }
                         .padding(.bottom, tokenSet[.bottomPresentationPadding].float)
                         .onSizeChange { newSize in
                             bottomOffsetForDismissedState = newSize.height + (tokenSet[.shadow].shadowInfo.yKey / 2)

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -369,6 +369,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                                    height: CGFloat.greatestFiniteMagnitude))
     }
 
+	@available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         invalidateIntrinsicContentSize()

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -369,7 +369,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
                                    height: CGFloat.greatestFiniteMagnitude))
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         invalidateIntrinsicContentSize()

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -158,6 +158,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         return size
     }
 
+	@available(iOS, deprecated: 17.0)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -158,7 +158,7 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
         return size
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -122,7 +122,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -122,6 +122,7 @@ open class TabBarView: UIView, TokenizedControlInternal {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
+	@available(iOS, deprecated: 17.0)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.horizontalSizeClass != traitCollection.horizontalSizeClass || previousTraitCollection?.verticalSizeClass != traitCollection.verticalSizeClass {

--- a/ios/FluentUI/Tooltip/TooltipViewController.swift
+++ b/ios/FluentUI/Tooltip/TooltipViewController.swift
@@ -49,6 +49,7 @@ class TooltipViewController: UIViewController {
         }
     }
 
+	@available(iOS, deprecated: 17.0)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 

--- a/ios/FluentUI/Tooltip/TooltipViewController.swift
+++ b/ios/FluentUI/Tooltip/TooltipViewController.swift
@@ -49,7 +49,7 @@ class TooltipViewController: UIViewController {
         }
     }
 
-	@available(iOS, deprecated: 17.0)
+    @available(iOS, deprecated: 17.0)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Changes to the library to make it build against iOS 17, in case any clients are trying to do so:
- `traitCollectionDidChange(_:)` is deprecated, so add `@available(iOS, deprecated: 17.0)` to all overrides.
- `UITraitCollection(traitsFrom:)` is deprecated, so adding a conditional check and using the new `UITraitCollection(mutations:)` API when iOS 17 is available.
- `onChange(of:_:)` has changed signatures, so I added a new `onChange_iOS17(of:_:)` to abstract that difference away. Feel free to suggest a better name if you have one 🤠

Note: this change doesn't do anything for the demo app itself. There are some significant refactors I'd like to do there before we worry too much about API deprecations. Don't worry, this won't affect consumers who pull us via CocoaPods or SPM.

### Binary change

Total increase: 39,104 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,982,416 bytes | 31,021,520 bytes | ⚠️ 39,104 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentNotification.o | 676,088 bytes | 698,680 bytes | ⚠️ 22,592 bytes |
| __.SYMDEF | 4,821,272 bytes | 4,829,384 bytes | ⚠️ 8,112 bytes |
| UIColor+Extensions.o | 73,328 bytes | 78,896 bytes | ⚠️ 5,568 bytes |
| SwiftUI+ViewModifiers.o | 133,128 bytes | 135,960 bytes | ⚠️ 2,832 bytes |
</details>

### Verification

App builds and runs as expected -- no functional changes here.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1935)