### PR TITLE
Adding a search bar option to the PopupMenuController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift
@@ -17,6 +17,7 @@ class PopupMenuDemoController: DemoController {
 
     private let navButtonTitleSwitch = BrandedSwitch()
     private let navButtonSubtitleSwitch = BrandedSwitch()
+    private let toolbarSearchSwitch = BrandedSwitch()
     private let switchTextWidth: CGFloat = 150
 
     private var calendarLayout: CalendarLayout = .agenda
@@ -50,6 +51,8 @@ class PopupMenuDemoController: DemoController {
         navButtonTitleSwitch.addTarget(self, action: #selector(handleOnSwitchChanged), for: .valueChanged)
         addRow(text: "Show Subtitle", items: [navButtonSubtitleSwitch], textWidth: switchTextWidth)
         navButtonSubtitleSwitch.isEnabled = false
+        addTitle(text: "Toolbar Button Settings")
+        addRow(text: "Show Search Bar", items: [toolbarSearchSwitch], textWidth: switchTextWidth)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -105,6 +108,9 @@ class PopupMenuDemoController: DemoController {
         }
 
         let controller = PopupMenuController(barButtonItem: sender, presentationOrigin: origin, presentationDirection: .up)
+        if toolbarSearchSwitch.isOn {
+            controller.searchBar(isVisible: true, placeholderText: "test")
+        }
 
         if sender.title == "1-line description" {
             controller.headerItem = PopupMenuItem(title: "Pick a calendar layout")

--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -225,7 +225,7 @@ class DrawerPresentationController: UIPresentationController {
             }
         case .up:
             if actualPresentationOrigin == containerView.bounds.maxY {
-                return containerView.safeAreaInsets.bottom + keyboardHeight
+                return keyboardHeight == 0 ? containerView.safeAreaInsets.bottom : keyboardHeight
             }
         case .fromLeading:
             if actualPresentationOrigin == containerView.bounds.minX {
@@ -344,6 +344,9 @@ class DrawerPresentationController: UIPresentationController {
     }
 
     private func frameForContentView(in bounds: CGRect) -> CGRect {
+        guard let containerView = containerView else {
+            return .zero
+        }
         var contentFrame = bounds.inset(by: marginsForContentView())
 
         var contentSize = presentedViewController.preferredContentSize
@@ -380,7 +383,8 @@ class DrawerPresentationController: UIPresentationController {
 
             contentFrame.origin.x += (contentFrame.width - contentSize.width) / 2
             if presentationDirection == .up {
-                contentFrame.origin.y = contentFrame.maxY - contentSize.height
+                contentFrame.origin.y = keyboardHeight != 0 ? max(landscapeMode ? 0 : sourceViewController.view.safeAreaInsets.top, 
+                                                                  containerView.frame.maxY - keyboardHeight - contentSize.height) : contentFrame.maxY - contentSize.height
             }
         } else {
             if actualPresentationOffset == 0 {
@@ -510,7 +514,7 @@ class DrawerPresentationController: UIPresentationController {
         keyboardAnimationDuration = (notificationInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
 
         keyboardFrame = containerView.convert(keyboardFrame, from: nil)
-        keyboardHeight = max(0, containerView.bounds.maxY - containerView.safeAreaInsets.bottom - keyboardFrame.minY)
+        keyboardHeight = max(0, containerView.bounds.maxY - keyboardFrame.minY)
     }
 }
 

--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -64,6 +64,9 @@ open class PopupMenuController: DrawerController {
                 height += headerItem.cellClass.preferredHeight(for: headerItem)
             }
         }
+        if !searchView.isHidden {
+            height += searchView.frame.height
+        }
         for section in sections {
             height += PopupMenuSectionHeaderView.preferredHeight(for: section)
             for item in section.items {
@@ -98,6 +101,17 @@ open class PopupMenuController: DrawerController {
             }
         }
     }
+
+    @objc open func searchBar(isVisible: Bool, placeholderText: String? = "") {
+        searchBar.isHidden = !isVisible
+        searchBar.placeholderText = placeholderText
+        adjustsHeightForKeyboard = true
+    }
+
+    @objc open var searchText: String? {
+        return searchBar.isHidden ? nil : searchBar.searchText
+    }
+
     /// Use `selectedItemIndexPath` to get or set the selected menu item instead of doing this via `PopupMenuItem` directly
     @objc open var selectedItemIndexPath: IndexPath? {
         get {
@@ -144,6 +158,7 @@ open class PopupMenuController: DrawerController {
         view.axis = .vertical
         view.addArrangedSubview(descriptionView)
         view.addArrangedSubview(headerView)
+        view.addArrangedSubview(searchView)
         view.addArrangedSubview(tableView)
         return view
     }()
@@ -193,6 +208,21 @@ open class PopupMenuController: DrawerController {
         view.isHeader = true
         view.isHidden = true
         return view
+    }()
+    private lazy var searchView: UIView = {
+        let view = UIStackView()
+        view.axis = .vertical
+        view.addArrangedSubview(searchBar)
+        view.isHidden = searchBar.isHidden
+        view.isLayoutMarginsRelativeArrangement = true
+        view.layoutMargins = UIEdgeInsets(top: 16, left: 16, bottom: 12, right: 16)
+        return view
+    }()
+    private let searchBar: SearchBar = {
+        let searchBar = SearchBar()
+        searchBar.style = .onSystemNavigationBar
+        searchBar.isHidden = true
+        return searchBar
     }()
     private let tableView = UITableView(frame: .zero, style: .grouped)
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

- Added Search bar to PopupMenuController
- Fixed bug where Popup view would not move with keyboard
- Fixed Popup colors (all default background should match the drawer background)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)