### PR TITLE
Fix PopupMenuController colors

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuController.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuController.swift
@@ -257,7 +257,7 @@ open class PopupMenuController: DrawerController {
     }
 
     private func initTableView() {
-        tableView.backgroundColor = backgroundColor
+        tableView.backgroundColor = .clear
         tableView.separatorStyle = .none
         tableView.alwaysBounceVertical = false
         tableView.isAccessibilityElement = true

--- a/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemTokenSet.swift
@@ -20,7 +20,7 @@ class PopupMenuItemTokenSet: TableViewCellTokenSet {
                 self.fluentTheme.color(.foreground3)
             },
             .cellBackgroundColor: .uiColor {
-                self.fluentTheme.color(.background1)
+                .clear
             }
         ])
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Fixing PopupMenuController colors. Fix is taken from #1936.

The tableview + cells should adopt the same color as the background of the drawer. They are still overridable if client wishes to change the colors through tokens.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

| Colors before                                        | Colors after                                    |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/747d071e-706b-4f69-8a37-3664ba16b342) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/c6db464f-993d-4094-8ea0-c00a848e5c0f) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/f3c6af8c-71ee-4288-91d8-9abdd6003056) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/6c749fbd-0b9f-4bc2-bb4b-69059e2f701c) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/b43a15ab-cf0f-4997-b892-5648d6e380d5) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/4dcf603a-9fce-49ae-a03d-71d2a45056f5) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/873b59c6-d9dd-49e0-9af1-505ff2e5bdac) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/9f948c14-4651-4b45-b51f-0a29747221df) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/cd0941d1-1d56-4363-a1a9-c4130f9aeaa0) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/b638aab8-2fde-451a-9bad-7464f8b54a21) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/00737c12-45b8-4dc1-bb80-866638dff993) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/8f3185d4-51c1-4e7d-a52d-bad13827f3a0) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/8b99c2af-4df0-4b3b-a4ae-9166fc145c8d) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/c884b9ae-205a-4b48-883e-003197d2e5c8) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/91453b80-8d20-4125-a0c8-3a8a108c2987) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/56b57d63-9e73-478d-9b71-2a5c6b84319b) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/810f4402-22ff-49d9-8cca-013b9dc92bc9) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/4c33253a-d679-4103-bb9d-ecc7300da9ff) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/d5b38a70-6aa3-49a5-8aac-3d41edc395f3) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/e7662dc9-795e-44a4-8af2-396e64f5e148) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/15c2d812-5158-4032-9e43-4b78faa85a96) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/bbbca4f9-a41b-4481-9a7f-f82ead898e29) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/afd1a549-cc15-4888-a38d-2c9bc603fd06) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/b47bb9f0-571d-45a0-83bb-9069ab4edfcc) |

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1937)