### PR TITLE
Fixing keyboard support in Drawers

### DIFF
--- a/ios/FluentUI/Drawer/DrawerPresentationController.swift
+++ b/ios/FluentUI/Drawer/DrawerPresentationController.swift
@@ -225,7 +225,7 @@ class DrawerPresentationController: UIPresentationController {
             }
         case .up:
             if actualPresentationOrigin == containerView.bounds.maxY {
-                return containerView.safeAreaInsets.bottom + keyboardHeight
+                return keyboardHeight == 0 ? containerView.safeAreaInsets.bottom : keyboardHeight
             }
         case .fromLeading:
             if actualPresentationOrigin == containerView.bounds.minX {
@@ -344,6 +344,9 @@ class DrawerPresentationController: UIPresentationController {
     }
 
     private func frameForContentView(in bounds: CGRect) -> CGRect {
+        guard let containerView = containerView else {
+            return .zero
+        }
         var contentFrame = bounds.inset(by: marginsForContentView())
 
         var contentSize = presentedViewController.preferredContentSize
@@ -380,7 +383,8 @@ class DrawerPresentationController: UIPresentationController {
 
             contentFrame.origin.x += (contentFrame.width - contentSize.width) / 2
             if presentationDirection == .up {
-                contentFrame.origin.y = contentFrame.maxY - contentSize.height
+                contentFrame.origin.y = keyboardHeight != 0 ? max(landscapeMode ? 0 : sourceViewController.view.safeAreaInsets.top,
+                                                                  containerView.frame.maxY - keyboardHeight - contentSize.height) : contentFrame.maxY - contentSize.height
             }
         } else {
             if actualPresentationOffset == 0 {
@@ -510,7 +514,7 @@ class DrawerPresentationController: UIPresentationController {
         keyboardAnimationDuration = (notificationInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue
 
         keyboardFrame = containerView.convert(keyboardFrame, from: nil)
-        keyboardHeight = max(0, containerView.bounds.maxY - containerView.safeAreaInsets.bottom - keyboardFrame.minY)
+        keyboardHeight = max(0, containerView.bounds.maxY - keyboardFrame.minY)
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

In #1936 , there was a bug fix for drawers not being able to support expand with keyboard if the drawer was presented in a custom-set origin.  This is because we automatically calculate the frame origin on `contentFrame.maxY - contentSize.height`, which is not necessarily always the correct origin especially if a keyboard is in use. The keyboard height code is also simplified so that it is more accurate in the presentation calculations.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Manual tests below, no change should be observed. This should also only affect presentations that go `.up`.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/2cec69a4-103d-4e76-be96-adc96c6279c9) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/841c810d-95b2-4306-83de-74622cf9a9f9) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/d508cede-19da-4b5c-9897-fc9745bb04fb) | !![image](https://github.com/microsoft/fluentui-apple/assets/22566866/d508cede-19da-4b5c-9897-fc9745bb04fb) |
| ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/97bb7f7f-9be0-420c-bd81-6500d6589822) | ![image](https://github.com/microsoft/fluentui-apple/assets/22566866/147e1db2-4f28-4436-980b-e1a576256b68) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)