### PR TITLE
[cherry-pick] Revert "TableViewHeaderFooterView should not override any font or color provided as part of the AttributedString (#1929)" (#1945)

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -249,8 +249,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - accessoryButtonTitle: Optional accessory button title string.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     @objc open func setup(style: Style, title: String, accessoryButtonTitle: String = "", leadingView: UIView? = nil) {
-        resolvedTitleFont = tokenSet[.textFont].uiFont
-        resolvedTitleColor = tokenSet[.textColor].uiColor
         titleView.attributedText = NSAttributedString(string: " ") // to clear attributes
         titleView.text = title
         titleView.isSelectable = false
@@ -274,10 +272,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     @objc open func setup(style: Style, attributedTitle: NSAttributedString, accessoryButtonTitle: String = "", leadingView: UIView? = nil) {
         titleView.attributedText = attributedTitle
         titleView.isSelectable = true
-
-        let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
-        resolvedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
-        resolvedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
 
         setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
     }
@@ -436,19 +430,18 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     private func updateTitleViewFont() {
         if let window = window {
-            titleView.font = resolvedTitleFont
+            let titleFont = tokenSet[.textFont].uiFont
+            titleView.font = titleFont
             // offset text container to center its content
-            if let resolvedTitleFont = resolvedTitleFont {
-                let scale = window.rootViewController?.view.contentScaleFactor ?? window.screen.scale
-                let offset = (floor((abs(resolvedTitleFont.leading) / 2) * scale) / scale) / 2
-                titleView.textContainerInset.top = offset
-                titleView.textContainerInset.bottom = -offset
-            }
+            let scale = window.rootViewController?.view.contentScaleFactor ?? window.screen.scale
+            let offset = (floor((abs(titleFont.leading) / 2) * scale) / scale) / 2
+            titleView.textContainerInset.top = offset
+            titleView.textContainerInset.bottom = -offset
         }
     }
 
     private func updateTitleAndBackgroundColors() {
-        titleView.textColor = resolvedTitleColor
+        titleView.textColor = tokenSet[.textColor].uiColor
 
         if tableViewCellStyle == .grouped {
             backgroundView?.backgroundColor = tokenSet[.backgroundColorGrouped].uiColor
@@ -458,7 +451,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             backgroundView?.backgroundColor = .clear
         }
 
-        titleView.font = resolvedTitleFont
+        titleView.font = tokenSet[.textFont].uiFont
         titleView.linkColor = tokenSet[.linkTextColor].uiColor
     }
 
@@ -494,9 +487,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     @objc private func handleHeaderViewTapped() {
         onHeaderViewTapped?()
     }
-
-    private var resolvedTitleFont: UIFont?
-    private var resolvedTitleColor: UIColor?
 }
 
 // MARK: - TableViewHeaderFooterView: UITextViewDelegate


### PR DESCRIPTION
This reverts commit 559db7111c9fa8673d0fb31bf013c1c81e744158.

### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1947)