### PR TITLE
Respecting avatarOverrideStyle when setting TitleView style

### DIFF
--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -76,7 +76,8 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
         didSet {
             updateAppearance()
             twoLineTitleView.currentStyle = style == .primary ? .primary : .system
-            avatar?.state.style = style == .primary ? .default : .accent
+            let avatarStyle: MSFAvatarStyle = (style == .primary) ? .default : .accent
+            avatar?.state.style = avatarOverrideStyle ?? avatarStyle
         }
     }
 

--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -76,8 +76,13 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
         didSet {
             updateAppearance()
             twoLineTitleView.currentStyle = style == .primary ? .primary : .system
-            let avatarStyle: MSFAvatarStyle = (style == .primary) ? .default : .accent
-            avatar?.state.style = avatarOverrideStyle ?? avatarStyle
+            let avatarStyle: MSFAvatarStyle
+            if let overrideStyle = avatarOverrideStyle {
+                avatarStyle = overrideStyle
+            } else {
+                avatarStyle = (style == .primary) ? .default : .accent
+            }
+            avatar?.state.style = avatarStyle
         }
     }
 

--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -77,8 +77,8 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
             updateAppearance()
             twoLineTitleView.currentStyle = style == .primary ? .primary : .system
             let avatarStyle: MSFAvatarStyle
-            if let overrideStyle = avatarOverrideStyle {
-                avatarStyle = overrideStyle
+            if let avatarOverrideStyle {
+                avatarStyle = avatarOverrideStyle
             } else {
                 avatarStyle = (style == .primary) ? .default : .accent
             }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] macOS

### Description of changes

When setting the TitleView style, the Avatar style was set not considering if there was an override already. This change is to consider the override when setting the AvatarStyle. 

### Verification

When setting an override style, the Avatar maintains the same style even when changing view controllers. 

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1949)