### PR TITLE
Bump Xcode version to 15.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Fluent UI Apple contains native UIKit and AppKit controls aligned with [Microsof
 #### Requirements
 
 - iOS 15+ or macOS 12+
-- Xcode 15.0.1+
+- Xcode 15.2+
 - Swift 5.9+
 
 #### Using Swift Package Manager

--- a/scripts/xcode_select_current_version.sh
+++ b/scripts/xcode_select_current_version.sh
@@ -3,7 +3,7 @@
 if [ -n "$XCODE_PATH_OVERRIDE" ]; then # If someone calls this with the XCODE_PATH_OVERRIDE variable set to a path to a developer dir, use it instead
     XCODE_PATH="$XCODE_PATH_OVERRIDE"
 else
-    XCODE_PATH='/Applications/Xcode_15.0.1.app/Contents/Developer'
+    XCODE_PATH='/Applications/Xcode_15.2.app/Contents/Developer'
 fi
 
 echo "Running command: sudo xcode-select --switch $XCODE_PATH"


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] macOS

### Description of changes

Increasing Xcode version to 15.2 in our Actions.

### Binary change

n/a

### Verification

Verified demo app has no obvious failures or regressions in new builds.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1953)