### PR TITLE
[Cherry Pick From Main] Respecting avatarOverrideStyle when setting TitleView style (#1949)

### DIFF
--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -76,7 +76,13 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
         didSet {
             updateAppearance()
             twoLineTitleView.currentStyle = style == .primary ? .primary : .system
-            avatar?.state.style = style == .primary ? .default : .accent
+            let avatarStyle: MSFAvatarStyle
+            if let avatarOverrideStyle {
+                avatarStyle = avatarOverrideStyle
+            } else {
+                avatarStyle = (style == .primary) ? .default : .accent
+            }
+            avatar?.state.style = avatarStyle
         }
     }
 


### PR DESCRIPTION
Respecting avatarOverrideStyle when setting TitleView style

### Platforms Impacted
- [X] iOS
- [X] macOS

### Description of changes

When setting the TitleView style, the Avatar style was set not considering if there was an override already. This change is to consider the override when setting the AvatarStyle.

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1954)