### PR TITLE
Add SwiftUI Support for Button

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		92DD1E8D279F496300FDEE0F /* DemoAppearanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DD1E8C279F496300FDEE0F /* DemoAppearanceView.swift */; };
 		92E977B726C7144F008E10A8 /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E977B526C713F3008E10A8 /* UIResponder+Extensions.swift */; };
 		92E977B826C7144F008E10A8 /* DemoControllerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E977B426C713F3008E10A8 /* DemoControllerScrollView.swift */; };
+		A1DE38D92B66250400CB8FA7 /* ButtonDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DE38D82B66250400CB8FA7 /* ButtonDemoController_SwiftUI.swift */; };
 		A589F856211BA71000471C23 /* LabelDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A589F855211BA71000471C23 /* LabelDemoController.swift */; };
 		A591A3F420F429EB001ED23B /* Demos.swift in Sources */ = {isa = PBXBuildFile; fileRef = A591A3F320F429EB001ED23B /* Demos.swift */; };
 		A5CEC21020E436F10016922A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC20F20E436F10016922A /* AppDelegate.swift */; };
@@ -230,6 +231,7 @@
 		92E4784B2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselDemoController.swift; sourceTree = "<group>"; };
 		92E977B426C713F3008E10A8 /* DemoControllerScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoControllerScrollView.swift; sourceTree = "<group>"; };
 		92E977B526C713F3008E10A8 /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
+		A1DE38D82B66250400CB8FA7 /* ButtonDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		A589F855211BA71000471C23 /* LabelDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelDemoController.swift; sourceTree = "<group>"; };
 		A591A3F320F429EB001ED23B /* Demos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Demos.swift; sourceTree = "<group>"; };
 		A5961FA8218A61BB00E2A506 /* PopupMenuDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuDemoController.swift; sourceTree = "<group>"; };
@@ -517,6 +519,7 @@
 				80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */,
 				80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */,
 				B4D852DA225C010A004B1B29 /* ButtonDemoController.swift */,
+				A1DE38D82B66250400CB8FA7 /* ButtonDemoController_SwiftUI.swift */,
 				92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */,
 				CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */,
 				9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */,
@@ -808,6 +811,7 @@
 				9245E1F927BECDBB007616F3 /* GlobalColorTokensDemoController.swift in Sources */,
 				D6296DB1295B8E5E002E8EB6 /* ObjectiveCDemoColorProviding.m in Sources */,
 				6F453CA528AC536300ED91A4 /* ShadowTokensDemoController.swift in Sources */,
+				A1DE38D92B66250400CB8FA7 /* ButtonDemoController_SwiftUI.swift in Sources */,
 				6FEED93B28A6E5520099D178 /* AliasColorTokensDemoController.swift in Sources */,
 				A5DCA760211E3B4C005F4CB7 /* DemoController.swift in Sources */,
 				F30B74382A7DB177000F63A0 /* ListActionItemDemoController_SwiftUI.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -135,13 +135,11 @@ class ButtonDemoController: DemoController {
         swiftUIDemoButton.setTitle("Open SwiftUI Demo", for: .normal)
         swiftUIDemoButton.addTarget(self, action: #selector(openSwiftUIDemo), for: .touchUpInside)
         container.addArrangedSubview(swiftUIDemoButton)
-        let separator = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 2)))
+        let separator = Separator()
         container.addArrangedSubview(separator)
-        separator.heightAnchor.constraint(equalToConstant: 1.0).isActive = true
-        separator.widthAnchor.constraint(equalTo: container.widthAnchor).isActive = true
-        separator.backgroundColor = .separator
+        separator.widthAnchor.constraint(equalTo: container.widthAnchor, multiplier: 0.9).isActive = true
     }
-    
+
     @objc private func openSwiftUIDemo() {
         navigationController?.pushViewController(ButtonDemoControllerSwiftUI(), animated: true)
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -13,6 +13,8 @@ class ButtonDemoController: DemoController {
 
         container.alignment = .leading
 
+        addSwiftUIDemoButton()
+
         for style in ButtonStyle.allCases {
             for size in ButtonSizeCategory.allCases {
                 if style.isFloating && size == .medium {
@@ -125,6 +127,23 @@ class ButtonDemoController: DemoController {
         let action = UIAlertAction(title: "OK", style: .default)
         alert.addAction(action)
         present(alert, animated: true)
+    }
+
+    private func addSwiftUIDemoButton() {
+        let swiftUIDemoButton = Button(style: .outlineAccent)
+        swiftUIDemoButton.sizeCategory = .large
+        swiftUIDemoButton.setTitle("Open SwiftUI Demo", for: .normal)
+        swiftUIDemoButton.addTarget(self, action: #selector(openSwiftUIDemo), for: .touchUpInside)
+        container.addArrangedSubview(swiftUIDemoButton)
+        let separator = UIView(frame: CGRect(origin: .zero, size: CGSize(width: 100, height: 2)))
+        container.addArrangedSubview(separator)
+        separator.heightAnchor.constraint(equalToConstant: 1.0).isActive = true
+        separator.widthAnchor.constraint(equalTo: container.widthAnchor).isActive = true
+        separator.backgroundColor = .separator
+    }
+    
+    @objc private func openSwiftUIDemo() {
+        navigationController?.pushViewController(ButtonDemoControllerSwiftUI(), animated: true)
     }
 
     private var buttons: [Button] = []

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -137,7 +137,7 @@ class ButtonDemoController: DemoController {
         container.addArrangedSubview(swiftUIDemoButton)
         let separator = Separator()
         container.addArrangedSubview(separator)
-        separator.widthAnchor.constraint(equalTo: container.widthAnchor, multiplier: 0.9).isActive = true
+        separator.widthAnchor.constraint(equalTo: swiftUIDemoButton.widthAnchor).isActive = true
     }
 
     @objc private func openSwiftUIDemo() {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -31,32 +31,39 @@ class ButtonDemoControllerSwiftUI: UIHostingController<ButtonDemoView> {
 }
 
 struct ButtonDemoView: View {
-    @State private var style: FluentUI.ButtonStyle = .accent
+    @State private var style: FluentUI.ButtonStyle = .floatingAccent
     @State private var state: ButtonState = .default
     @State private var size: ButtonSizeCategory = .medium
     @State private var buttonContent: ButtonContent = .both
 
     @State private var showAlert: Bool = false
     @ObservedObject var fluentTheme: FluentTheme = .shared
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass: UserInterfaceSizeClass?
+    @Environment(\.verticalSizeClass) var verticalSizeClass: UserInterfaceSizeClass?
 
     var body: some View {
-      ScrollView {
-          VStack(spacing: 16) {
-              Divider()
-              button
-                  .frame(minHeight: 200)
-              Divider()
-              Text("Settings").font(.title2)
-              picker(selection: $style)
-                  .pickerStyle(.menu)
-              picker(selection: $state)
-              picker(selection: $size)
-              picker(selection: $buttonContent)
-          }
-          .padding()
-          .pickerStyle(.segmented)
-      }
-      .fluentTheme(fluentTheme)
+        dynamicView
+            .padding()
+            .fluentTheme(fluentTheme)
+    }
+
+    @ViewBuilder var dynamicView: some View {
+        if verticalSizeClass == .compact {
+            HStack {
+                button
+                    .frame(minWidth: 200)
+                Divider()
+                settingsStack
+            }
+        } else {
+            VStack(spacing: 24) {
+                Divider()
+                button
+                    .frame(minHeight: 200)
+                Divider()
+                settingsStack
+            }
+        }
     }
 
     var button: some View {
@@ -65,9 +72,21 @@ struct ButtonDemoView: View {
         }, label: {
             buttonContent.view
         })
-            .buttonStyle(FluentButtonStyle(style: style, size: size))
-            .environment(\.isEnabled, state != .disabled)
-            .alert("Button tapped", isPresented: $showAlert, actions: { EmptyView() })
+        .buttonStyle(FluentButtonStyle(style: style, size: size))
+        .environment(\.isEnabled, state != .disabled)
+        .alert("Button tapped", isPresented: $showAlert, actions: { EmptyView() })
+    }
+
+    var settingsStack: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings").font(.title2)
+            picker(selection: $style)
+                .pickerStyle(.menu)
+            picker(selection: $state)
+            picker(selection: $size)
+            picker(selection: $buttonContent)
+        }
+        .pickerStyle(.segmented)
     }
 
     @ViewBuilder private func picker<T: Describable & Hashable & CaseIterable>(selection: Binding<T>) -> some View {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -31,27 +31,95 @@ class ButtonDemoControllerSwiftUI: UIHostingController<ButtonDemoView> {
 }
 
 struct ButtonDemoView: View {
+    @State private var style: FluentUI.ButtonStyle = .accent
+    @State private var state: ButtonState = .default
+    @State private var size: ButtonSizeCategory = .medium
+    @State private var buttonContent: ButtonContent = .both
+
+    @State private var showAlert: Bool = false
     @ObservedObject var fluentTheme: FluentTheme = .shared
 
     var body: some View {
       ScrollView {
           VStack(spacing: 16) {
-              ForEach(ButtonStyle.allCases, id: \.self) { style in
-                  VStack(spacing: 16) {
-                      Text(style.description)
-                      ForEach(ButtonSizeCategory.allCases, id: \.self) { size in
-                          HStack {
-                              Text(size.description)
-                              Spacer()
-                              Button("Text") {}
-                                .buttonStyle(FluentButtonStyle(style: style, size: size))
-                          }
-                      }
-                  }
-              }
+              Divider()
+              button
+                  .frame(minHeight: 200)
+              Divider()
+              Text("Settings").font(.title2)
+              picker(selection: $style)
+                  .pickerStyle(.menu)
+              picker(selection: $state)
+              picker(selection: $size)
+              picker(selection: $buttonContent)
           }
           .padding()
+          .pickerStyle(.segmented)
       }
       .fluentTheme(fluentTheme)
+    }
+
+    var button: some View {
+        Button(action: {
+            showAlert = true
+        }, label: {
+            buttonContent.view
+        })
+            .buttonStyle(FluentButtonStyle(style: style, size: size))
+            .environment(\.isEnabled, state != .disabled)
+            .alert("Button tapped", isPresented: $showAlert, actions: { EmptyView() })
+    }
+
+    @ViewBuilder private func picker<T: Describable & Hashable & CaseIterable>(selection: Binding<T>) -> some View {
+        HStack(spacing: 8) {
+            Text(T.title)
+            Spacer()
+            Picker("", selection: selection) {
+                ForEach(Array(T.allCases), id: \.self) { state in
+                    Text(state.description).tag(state)
+                }
+            }
+            .frame(maxWidth: 200)
+        }
+    }
+}
+
+private protocol Describable {
+    static var title: String { get }
+    var description: String { get }
+}
+
+extension FluentUI.ButtonStyle: Describable {
+    static var title: String { "Style" }
+}
+extension ButtonSizeCategory: Describable {
+    static var title: String { "Size" }
+}
+
+private enum ButtonState: String, CaseIterable, Describable {
+    case `default`
+    case disabled
+
+    static var title: String { "State" }
+    var description: String { rawValue }
+}
+
+private enum ButtonContent: String, CaseIterable, Describable {
+    case text
+    case image
+    case both
+
+    static var title: String { "Content" }
+    var description: String { rawValue }
+
+    @ViewBuilder var view: some View {
+        switch self {
+        case .text:
+            Text("Text")
+        case .both:
+            Label("Text", systemImage: "circle")
+        case .image:
+            Image(systemName: "circle")
+        }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -1,0 +1,57 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import SwiftUI
+
+class ButtonDemoControllerSwiftUI: UIHostingController<ButtonDemoView> {
+    override init?(coder aDecoder: NSCoder, rootView: ButtonDemoView) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    init() {
+        super.init(rootView: ButtonDemoView())
+        self.title = "Button Fluent 2 (SwiftUI)"
+    }
+
+    override func willMove(toParent parent: UIViewController?) {
+        guard let parent,
+              let window = parent.view.window else {
+            return
+        }
+
+        rootView.fluentTheme = window.fluentTheme
+    }
+}
+
+struct ButtonDemoView: View {
+    @ObservedObject var fluentTheme: FluentTheme = .shared
+
+    var body: some View {
+      ScrollView {
+          VStack(spacing: 16) {
+              ForEach(ButtonStyle.allCases, id: \.self) { style in
+                  VStack(spacing: 16) {
+                      Text(style.description)
+                      ForEach(ButtonSizeCategory.allCases, id: \.self) { size in
+                          HStack {
+                              Text(size.description)
+                              Spacer()
+                              Button("Text") {}
+                                .buttonStyle(FluentButtonStyle(style: style, size: size))
+                          }
+                      }
+                  }
+              }
+          }
+          .padding()
+      }
+      .fluentTheme(fluentTheme)
+    }
+}

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
 		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
+		A1DE38D72B66126600CB8FA7 /* FluentButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DE38D62B66126600CB8FA7 /* FluentButtonStyle.swift */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
 		A542A9D8226FC01700204A52 /* Localizable.stringsdict in Resources */ = {isa = PBXBuildFile; fileRef = A5DF1EAD2213B26900CC741A /* Localizable.stringsdict */; };
@@ -370,6 +371,7 @@
 		92E7AD4E26FE51FF00AE7FF8 /* DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicColor.swift; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
 		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
+		A1DE38D62B66126600CB8FA7 /* FluentButtonStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentButtonStyle.swift; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
 		A5237ACC21ED6CA70040BF27 /* DrawerShadowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawerShadowView.swift; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 		5314DFEC25F0029C0099271A /* Button */ = {
 			isa = PBXGroup;
 			children = (
+				A1DE38D62B66126600CB8FA7 /* FluentButtonStyle.swift */,
 				A5CEC23020E451D00016922A /* Button.swift */,
 				EC65F78F292EDCEF002A1A23 /* ButtonTokenSet.swift */,
 			);
@@ -1708,6 +1711,7 @@
 				5314E1CD25F01B730099271A /* AnimationSynchronizer.swift in Sources */,
 				92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */,
 				9231491428BF026A001B033E /* MSFHeadsUpDisplay.swift in Sources */,
+				A1DE38D72B66126600CB8FA7 /* FluentButtonStyle.swift in Sources */,
 				5314E13425F016370099271A /* PopupMenuItem.swift in Sources */,
 				ECA9218A27A33A2D00B66117 /* AvatarGroupModifiers.swift in Sources */,
 				6F050B6B29D3D1900070D3D5 /* TabBarItemTokenSet.swift in Sources */,

--- a/ios/FluentUI/Button/Button.swift
+++ b/ios/FluentUI/Button/Button.swift
@@ -181,7 +181,7 @@ open class Button: UIButton, Shadowable, TokenizedControlInternal {
 
     public func defaultEdgeInsets() -> NSDirectionalEdgeInsets {
         let leadingPadding = ButtonTokenSet.horizontalPadding(style: style, size: sizeCategory)
-        let trailingPadding = style.isFloating && titleLabel?.text != nil && image != nil ? ButtonTokenSet.fabAlternativePadding(sizeCategory) : ButtonTokenSet.horizontalPadding(style: style, size: sizeCategory)
+        let trailingPadding = style.isFloating && titleLabel?.text != nil && image != nil ? ButtonTokenSet.fabAlternativePadding(sizeCategory) : leadingPadding
         return NSDirectionalEdgeInsets(top: 0, leading: leadingPadding, bottom: 0, trailing: trailingPadding)
     }
 

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -23,20 +23,37 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
         let colors: Colors = colors(for: configuration)
         let cornerRadius: CGFloat = tokenSet[.cornerRadius].float
         let shadowInfo = tokenSet[configuration.isPressed ? .shadowPressed : .shadowRest].shadowInfo
+
+        @ViewBuilder var backgroundView: some View {
+            if style.isFloating {
+                colors.background.clipShape(Capsule())
+            } else {
+                colors.background.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            }
+        }
+
+        @ViewBuilder var overlayView: some View {
+            if colors.border != .clear {
+                if style.isFloating {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
+                        .foregroundStyle(colors.border)
+                } else {
+                    Capsule()
+                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
+                        .foregroundStyle(colors.border)
+                }
+            }
+        }
+
         return configuration
             .label
             .font(tokenSet[.titleFont].font)
             .foregroundStyle(colors.foreground)
             .padding(EdgeInsets(directionalEdgeInsets))
             .frame(minHeight: minContainerHeight)
-            .background(colors.background.clipShape(RoundedRectangle(cornerRadius: cornerRadius)))
-            .overlay {
-                if colors.border != .clear {
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
-                        .foregroundStyle(colors.border)
-                }
-            }
+            .background(backgroundView)
+            .overlay { overlayView }
             .applyShadow(shadowInfo: shadowInfo)
     }
 

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 
 public struct FluentButtonStyle: SwiftUI.ButtonStyle {
-    private let tokenSet: ButtonTokenSet
+    let tokenSet: ButtonTokenSet
     let style: ButtonStyle
     let size: ButtonSizeCategory
 
@@ -20,13 +20,15 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     }
 
     public func makeBody(configuration: Configuration) -> some View {
-        // TODO: Apply padding, font, shadow based on style
         let colors: Colors = colors(for: configuration)
         let cornerRadius: CGFloat = tokenSet[.cornerRadius].float
+        let shadowInfo = tokenSet[configuration.isPressed ? .shadowPressed : .shadowRest].shadowInfo
         return configuration
             .label
+            .font(tokenSet[.titleFont].font)
             .foregroundStyle(colors.foreground)
-            .padding()
+            .padding(EdgeInsets(directionalEdgeInsets))
+            .frame(minHeight: minContainerHeight)
             .background(colors.background.clipShape(RoundedRectangle(cornerRadius: cornerRadius)))
             .overlay {
                 if colors.border != .clear {
@@ -35,6 +37,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
                         .foregroundStyle(colors.border)
                 }
             }
+            .applyShadow(shadowInfo: shadowInfo)
     }
 
     private func colors(for config: Configuration) -> Colors {
@@ -72,8 +75,76 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     }
 }
 
+protocol CustomizableButton {
+    var tokenSet: ButtonTokenSet { get }
+    var style: ButtonStyle { get }
+    var size: ButtonSizeCategory { get }
+}
+
+extension FluentButtonStyle: CustomizableButton {}
+
+extension CustomizableButton {
+    var directionalEdgeInsets: NSDirectionalEdgeInsets {
+        NSDirectionalEdgeInsets(
+            top: .zero,
+            leading: horizontalPadding,
+            bottom: .zero,
+            trailing: style.isFloating ? fabAlternativePadding : horizontalPadding
+        )
+    }
+
+    var horizontalPadding: CGFloat {
+        if style.isFloating {
+            switch size {
+            case .large:
+                return GlobalTokens.spacing(.size160)
+            case .medium, .small:
+                return GlobalTokens.spacing(.size120)
+            }
+        } else {
+            switch size {
+            case .large:
+                return GlobalTokens.spacing(.size200)
+            case .medium:
+                return GlobalTokens.spacing(.size120)
+            case .small:
+                return GlobalTokens.spacing(.size80)
+            }
+        }
+    }
+
+    var fabAlternativePadding: CGFloat {
+        switch size {
+        case .large:
+            return GlobalTokens.spacing(.size200)
+        case .medium, .small:
+            return GlobalTokens.spacing(.size160)
+        }
+    }
+
+    var minContainerHeight: CGFloat {
+        if style.isFloating {
+            switch size {
+            case .large:
+                return 56
+            case .medium, .small:
+                return 48
+            }
+        } else {
+            switch size {
+            case .large:
+                return 52
+            case .medium:
+                return 40
+            case .small:
+                return 28
+            }
+        }
+    }
+}
+
 extension ControlTokenValue {
-  var color: Color {
-    Color(uiColor: uiColor)
-  }
+    var color: Color { Color(uiColor: uiColor) }
+
+    var font: Font { Font(uiFont) }
 }

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -1,0 +1,79 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public struct FluentButtonStyle: SwiftUI.ButtonStyle {
+    private let tokenSet: ButtonTokenSet
+    let style: ButtonStyle
+    let size: ButtonSizeCategory
+
+    @Environment(\.isEnabled) var isEnabled: Bool
+    @Environment(\.isFocused) var isFocused: Bool
+
+    public init(style: ButtonStyle, size: ButtonSizeCategory) {
+        self.style = style
+        self.size = size
+        self.tokenSet = ButtonTokenSet(style: { style }, size: { size })
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        // TODO: Apply padding, font, shadow based on style
+        let colors: Colors = colors(for: configuration)
+        let cornerRadius: CGFloat = tokenSet[.cornerRadius].float
+        return configuration
+            .label
+            .foregroundStyle(colors.foreground)
+            .padding()
+            .background(colors.background.clipShape(RoundedRectangle(cornerRadius: cornerRadius)))
+            .overlay {
+                if colors.border != .clear {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
+                        .foregroundStyle(colors.border)
+                }
+            }
+    }
+
+    private func colors(for config: Configuration) -> Colors {
+        if !isEnabled {
+            Colors(
+                background: tokenSet[.backgroundDisabledColor].color,
+                foreground: tokenSet[.foregroundDisabledColor].color,
+                border: tokenSet[.borderDisabledColor].color
+            )
+        } else if config.isPressed {
+            Colors(
+                background: tokenSet[.backgroundPressedColor].color,
+                foreground: tokenSet[.foregroundPressedColor].color,
+                border: tokenSet[.borderPressedColor].color
+            )
+        } else if isFocused {
+            Colors(
+                background: tokenSet[.backgroundFocusedColor].color,
+                foreground: tokenSet[.foregroundColor].color,
+                border: tokenSet[.borderFocusedColor].color
+            )
+        } else {
+            Colors(
+                background: tokenSet[.backgroundColor].color,
+                foreground: tokenSet[.foregroundColor].color,
+                border: tokenSet[.borderColor].color
+            )
+        }
+    }
+
+    private struct Colors {
+        let background: Color
+        let foreground: Color
+        let border: Color
+    }
+}
+
+extension ControlTokenValue {
+  var color: Color {
+    Color(uiColor: uiColor)
+  }
+}

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -22,7 +22,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     public func makeBody(configuration: Configuration) -> some View {
         let colors: Colors = colors(for: configuration)
         let cornerRadius: CGFloat = tokenSet[.cornerRadius].float
-        let shadowInfo = tokenSet[configuration.isPressed ? .shadowPressed : .shadowRest].shadowInfo
+        let shadowInfo = tokenSet[!isEnabled || isFocused || configuration.isPressed ? .shadowPressed : .shadowRest].shadowInfo
 
         @ViewBuilder var backgroundView: some View {
             if style.isFloating {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Added a new `FluentButtonStyle` which confirms to `SwiftUI.ButtonStyle`. This makes it easy to apply fluent styles to any button in SwiftUI.

The behaviour of styles in SwiftUI is slightly different from how we work with custom components in UIKit. Hence, this new `FluentButtonStyle` does not affect the content inside the button, which can be text, image or both. We can create a separate custom SwiftUI view to mimic the behaviour of the custom UIKit button with regards to images and text. 

### Binary change

Total increase: 1,50,920 bytes
Total decrease: -920 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 3,11,49,392 bytes | 3,12,99,392 bytes | 🛑 1,50,000 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentButtonStyle.o | 0 bytes | 1,27,096 bytes | 🛑 1,27,096 bytes |
| __.SYMDEF | 48,86,280 bytes | 49,08,664 bytes | ⚠️ 22,384 bytes |
| FocusRingView.o | 8,23,392 bytes | 8,24,832 bytes | ⚠️ 1,440 bytes |
| Button.o | 2,12,528 bytes | 2,12,280 bytes | 🎉 -248 bytes |
| ListActionItem.o | 2,25,496 bytes | 2,24,824 bytes | 🎉 -672 bytes |
</details>

### Verification

Compared existing buttons in UIKit with SwiftUI. Looks similar.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1960)