### PR TITLE
SwiftUI View Extension: Improve pointer interaction

### DIFF
--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -24,12 +24,14 @@ extension View {
     /// Enables iPad Pointer interaction for the view if available.
     /// - Parameter isEnabled: Whether the pointer interaction should be enabled.
     /// - Returns: The modified view.
-    func pointerInteraction(_ isEnabled: Bool) -> AnyView {
-        if isEnabled {
-            return AnyView(self.hoverEffect())
+    @ViewBuilder func pointerInteraction(_ isEnabled: Bool) -> some View {
+        if #available(iOS 17.0, *) {
+            hoverEffect(isEnabled: isEnabled)
+        } else if isEnabled {
+            hoverEffect()
+        } else {
+            self
         }
-
-        return AnyView(self)
     }
 
     /// Measures the size of a view, monitors when its size is updated, and takes a closure to be called when it does


### PR DESCRIPTION
Avoiding AnyView because it erases the identity of the View and can cause performance issues

### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Avoiding AnyView because it erases the identity of the View and causes performance issues. Using new `hoverEffect(_:)` modifier which accepts a boolean in iOS 17+.

### Binary change

Total increase: 3,74,192 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 3,11,49,392 bytes | 3,15,23,584 bytes | ⛔️ 3,74,192 bytes |

I don't fully understand how such a small changes causes 350kb difference.

<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| IndeterminateProgressBar.o | 2,33,984 bytes | 3,65,752 bytes | 🛑 1,31,768 bytes |
| __.SYMDEF | 48,86,280 bytes | 50,12,696 bytes | 🛑 1,26,416 bytes |
| Avatar.o | 6,02,160 bytes | 7,18,152 bytes | 🛑 1,15,992 bytes |
| SwiftUI+ViewModifiers.o | 1,36,096 bytes | 1,36,112 bytes | ⚠️ 16 bytes |
</details>

### Verification

https://github.com/microsoft/fluentui-apple/assets/46041492/593fdbc1-ff69-42ee-93a5-66ed29130ad9


Tested on the Avatar SwiftUI demo, the iPad pointer interaction works as before.

No Visual Change.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1961)