### PR TITLE
Set segment pill button corner radius

### DIFF
--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -41,6 +41,7 @@ class SegmentPillButton: UIButton {
                                                               trailing: horizontalInset)
         configuration.background.backgroundColor = .clear
         configuration.baseForegroundColor = tokenSet[.restLabelColor].uiColor
+        configuration.background.cornerRadius = 16
         let titleTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
             var outgoing = incoming
             outgoing.font = self?.tokenSet[.font].uiFont

--- a/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentPillButton.swift
@@ -40,8 +40,8 @@ class SegmentPillButton: UIButton {
                                                               bottom: verticalInset,
                                                               trailing: horizontalInset)
         configuration.background.backgroundColor = .clear
+        configuration.background.cornerRadius = SegmentedControlTokenSet.pillButtonCornerRadius
         configuration.baseForegroundColor = tokenSet[.restLabelColor].uiColor
-        configuration.background.cornerRadius = 16
         let titleTransformer = UIConfigurationTextAttributesTransformer { [weak self] incoming in
             var outgoing = incoming
             outgoing.font = self?.tokenSet[.font].uiFont

--- a/ios/FluentUI/SegmentedControl/SegmentedControl.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControl.swift
@@ -9,9 +9,6 @@ import UIKit
 @objc(MSFSegmentedControl)
 open class SegmentedControl: UIView, TokenizedControlInternal {
     private struct Constants {
-        static let selectionBarHeight: CGFloat = 1.5
-        static let pillContainerHorizontalInset: CGFloat = 16
-        static let pillButtonCornerRadius: CGFloat = 16
         static let iPadMinimumWidth: CGFloat = 375
     }
 
@@ -56,7 +53,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
     }
 
     /// only used for pill style segment control. It is used to define the inset of the pillContainerView
-    @objc public var contentInset: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 0, leading: Constants.pillContainerHorizontalInset, bottom: 0, trailing: Constants.pillContainerHorizontalInset) {
+    @objc public var contentInset: NSDirectionalEdgeInsets = NSDirectionalEdgeInsets(top: 0, leading: SegmentedControlTokenSet.pillContainerHorizontalInset, bottom: 0, trailing: SegmentedControlTokenSet.pillContainerHorizontalInset) {
         didSet {
             guard oldValue != contentInset else {
                 return
@@ -197,7 +194,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         super.init(frame: .zero)
         scrollView.delegate = self
 
-        stackView.layer.cornerRadius = Constants.pillButtonCornerRadius
+        stackView.layer.cornerRadius = SegmentedControlTokenSet.pillButtonCornerRadius
         pillContainerView.addSubview(stackView)
         selectionView.backgroundColor = .black
         pillContainerView.addSubview(selectionView)
@@ -585,7 +582,7 @@ open class SegmentedControl: UIView, TokenizedControlInternal {
         let button = buttons[selectedSegmentIndex]
 
         selectionView.frame = button.frame
-        selectionView.layer.cornerRadius = Constants.pillButtonCornerRadius
+        selectionView.layer.cornerRadius = SegmentedControlTokenSet.pillButtonCornerRadius
     }
 
     private func updateTokenizedValues() {

--- a/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
+++ b/ios/FluentUI/SegmentedControl/SegmentedControlTokenSet.swift
@@ -212,6 +212,12 @@ public class SegmentedControlTokenSet: ControlTokenSet<SegmentedControlToken> {
     var style: () -> SegmentedControlStyle
 }
 
+// MARK: Constants
+extension SegmentedControlTokenSet {
+    static let pillButtonCornerRadius: CGFloat = 16
+    static let pillContainerHorizontalInset: CGFloat = 16
+}
+
 @objc(MSFSegmentedControlStyle)
 public enum SegmentedControlStyle: Int {
     /// Segments are shown as labels inside a pill for use with a neutral or white background. Selection is indicated by a thumb under the selected label.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

Currently, `SegmentedControl` sets the `cornerRadius`. On iOS, this trickles down to `SegmentPillButton` as well. This is not true on other platforms. To fix this, set the `cornerRadius` explicitly.

To avoid magic numbers, move `SegmentedControl.Constants` to `SegmentedControlTokenSet` and access the corner radius from there. While I'm here, remove `selectionBarHeight` since it's not being used anywhere.

### Binary change

Total increase: 2,224 bytes
Total decrease: -1,600 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,917,640 bytes | 30,918,264 bytes | ⚠️ 624 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| SegmentedControlTokenSet.o | 90,128 bytes | 91,448 bytes | ⚠️ 1,320 bytes |
| SegmentPillButton.o | 90,648 bytes | 91,552 bytes | ⚠️ 904 bytes |
| FocusRingView.o | 814,848 bytes | 814,688 bytes | 🎉 -160 bytes |
| __.SYMDEF | 4,770,960 bytes | 4,770,720 bytes | 🎉 -240 bytes |
| SegmentedControl.o | 333,384 bytes | 332,184 bytes | 🎉 -1,200 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/1518f1cf-f467-4647-8ad5-f43c8253e5c9) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/110bb13a-3805-4490-a3d7-39fe7d56fb95) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1963)