### PR TITLE
Update onChange to use onChange_iOS17

### DIFF
--- a/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
+++ b/ios/FluentUI/ActivityIndicator/ActivityIndicator.swift
@@ -84,7 +84,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
             }
             .opacity(!state.isAnimating && state.hidesWhenStopped ? 0 : 1)
             .rotationEffect(.degrees(rotationAngle), anchor: .center)
-            .onChange(of: state.isAnimating) { newValue in
+            .onChange_iOS17(of: state.isAnimating) { newValue in
                 newValue ? startAnimation() : stopAnimation()
             }
             .frame(width: side,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] macOS

### Description of changes

#1957 added a new case of `onChange(of:_:)`, which is deprecated in visionOS. Use `onChange_iOS17(of:_:)` instead.

### Binary change

Total increase: 9,248 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,918,264 bytes | 30,927,512 bytes | ⚠️ 9,248 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ActivityIndicator.o | 155,232 bytes | 163,568 bytes | ⚠️ 8,336 bytes |
| __.SYMDEF | 4,770,720 bytes | 4,771,632 bytes | ⚠️ 912 bytes |
</details>

### Verification

visionOS builds again

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1965)