### PR TITLE
Bump CI to macOS 14 and build visionOS debug simulator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   validation:
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: true
     steps:
@@ -24,7 +24,7 @@ jobs:
     - name: validation
       run: scripts/validation.sh
   xcodebuild:
-    runs-on: macos-13
+    runs-on: macos-14
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +33,7 @@ jobs:
           'macos_build FluentUITestApp-macOS Debug build -resultBundlePath TestResultsMac test -destination "platform=macOS,arch=x86_64"',
           'ios_simulator_build Demo.Development Debug build test -resultBundlePath TestResultsiOS -destination "platform=iOS Simulator,name=iPhone 14 Pro"',
           'ios_device_build Demo.Development Release build',
+          'visionos_simulator_build Demo.Development Debug build',
         ]
 
     steps:

--- a/.github/workflows/podPublish.yml
+++ b/.github/workflows/podPublish.yml
@@ -7,7 +7,7 @@ on:
       - 0.2.[0-9]+_main_0.2
 jobs:
   Pod-Publish:
-    runs-on: macos-13
+    runs-on: macos-14
     
     steps:
     - uses: actions/checkout@v3

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -49,6 +49,10 @@ echo "Building iOS Release Static Lib Device"
 $XCODEBUILD_WRAPPER_LOCATION ios_device_build FluentUI-iOS Release build
 handle_exit_code
 
+echo "Building visionOS Static Lib Debug Simulator"
+$XCODEBUILD_WRAPPER_LOCATION visionos_simulator_build FluentUI-iOS Debug build
+handle_exit_code
+
 echo "Building iOS Testapp Debug Simulator"
 $XCODEBUILD_WRAPPER_LOCATION ios_simulator_build Demo.Development Debug build
 handle_exit_code
@@ -67,6 +71,10 @@ handle_exit_code
 
 echo "Building iOS Testapp Release Device"
 $XCODEBUILD_WRAPPER_LOCATION ios_device_build Demo.Development Release build
+handle_exit_code
+
+echo "Building visionOS Testapp Debug Simulator"
+$XCODEBUILD_WRAPPER_LOCATION visionos_simulator_build Demo.Development Debug build
 handle_exit_code
 
 # Check if any of our individual build steps failed

--- a/scripts/xcodebuild_wrapper.sh
+++ b/scripts/xcodebuild_wrapper.sh
@@ -56,6 +56,17 @@ function macos_build()
     return $?
 }
 
+# Run a visionOS simulator xcodebuild invocation with the specified scheme, configuration, and build commands
+#
+# \param $1 scheme
+# \param $2 configuration
+# \param $3+ build commands
+function visionos_simulator_build()
+{
+    invoke_xcodebuild workspace "ios/FluentUI.xcworkspace" "$1" "$2" xrsimulator "${@:3}"
+    return $?
+}
+
 # Execute commands passed in to this script and forward on the exit code.
 "$@"
 exit $?


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] macOS

### Description of changes

* Updating our workflows to use macOS 14 runners, which are ARM64 devices by default
* Using these new runners, verify visionOS as part of the CI pipeline

### Binary change

n/a -- only pipeline changes

### Verification

Hopefully CI passes :)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1966)