### PR TITLE
Update PopupMenuItemCell to be white when selected on visionOS

### DIFF
--- a/ios/FluentUI/Popup Menu/PopupMenuItem.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItem.swift
@@ -56,11 +56,11 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem, FluentThemeable {
             tokenSet[.imageColor] = .uiColor { newValue }
         }
     }
-    /// `title` color when`isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
+    /// `title` color when `isSelected` is true. If unset, brand color on iOS/white on visionOS will be used
     @objc public var titleSelectedColor: UIColor?
-    /// `subtitle` color when`isSelected` is true.  If unset, PopupMenuItemTokenSet.mainBrandColor will be used
+    /// `subtitle` color when `isSelected` is true. If unset, brand color on iOS/white on visionOS will be used
     @objc public var subtitleSelectedColor: UIColor?
-    /// tint color if `selectedImage` is rendered as template and `isSelected` is true.  If unset, PopupMenuItemTokenSet.mainBrandColor will be used
+    /// tint color if `selectedImage` is rendered as template and `isSelected` is true. If unset, brand color on iOS/white on visionOS will be used
     @objc public var imageSelectedColor: UIColor?
     /// background color of PopupMenuItem corresponding cell
     @objc public var backgroundColor: UIColor {
@@ -71,7 +71,7 @@ open class PopupMenuItem: NSObject, PopupMenuTemplateItem, FluentThemeable {
             tokenSet[.cellBackgroundColor] = .uiColor { newValue }
         }
     }
-    /// checkmark color `isAccessoryCheckmarkVisible` and `isSelected` is true. If unset, PopupMenuItemTokenSet.mainBrandColor will be used
+    /// checkmark color `isAccessoryCheckmarkVisible` and `isSelected` is true. If unset, brand color on iOS/white on visionOS will be used
     @objc public var accessoryCheckmarkColor: UIColor?
 
     @objc public let onSelected: (() -> Void)?

--- a/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
+++ b/ios/FluentUI/Popup Menu/PopupMenuItemCell.swift
@@ -210,15 +210,15 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
             _accessoryType = .none
             return
         }
-        let brandColor = item.tokenSet[.brandTextColor].uiColor
+        let selectedColor = Compatibility.isDeviceIdiomVision() ? .white : item.tokenSet[.brandTextColor].uiColor
         let imageColor: UIColor
         let titleColor: UIColor
         let subtitleColor: UIColor
         var accessoryType: TableViewCellAccessoryType = .none
         if isSelected {
-            imageColor = item.imageSelectedColor ?? brandColor
-            titleColor = item.titleSelectedColor ?? brandColor
-            subtitleColor = item.subtitleSelectedColor ?? brandColor
+            imageColor = item.imageSelectedColor ?? selectedColor
+            titleColor = item.titleSelectedColor ?? selectedColor
+            subtitleColor = item.subtitleSelectedColor ?? selectedColor
             if item.isAccessoryCheckmarkVisible {
                 accessoryType = .checkmark
             }
@@ -234,7 +234,7 @@ class PopupMenuItemCell: TableViewCell, PopupMenuItemTemplateCell {
         backgroundColor = item.backgroundColor
         _accessoryType = accessoryType
         if let accessoryTypeView = accessoryTypeView {
-            accessoryTypeView.customTintColor = item.accessoryCheckmarkColor ?? brandColor
+            accessoryTypeView.customTintColor = item.accessoryCheckmarkColor ?? selectedColor
         }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

On iOS, when a `PopupMenuItemCell` is selected, it uses `brandForeground1`. On visionOS, we want white. 

### Binary change

Total increase: 2,296 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,925,576 bytes | 30,927,872 bytes | ⚠️ 2,296 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| PopupMenuItemCell.o | 174,024 bytes | 176,032 bytes | ⚠️ 2,008 bytes |
| __.SYMDEF | 4,770,928 bytes | 4,771,216 bytes | ⚠️ 288 bytes |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1969)