### PR TITLE
Set header font to match headerPrimary on visionOS

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterViewTokenSet.swift
@@ -58,7 +58,9 @@ public class TableViewHeaderFooterViewTokenSet: ControlTokenSet<TableViewHeaderF
                     switch style() {
                     case .headerPrimary:
                         return theme.typography(.body1Strong)
-                    case .header, .footer:
+                    case .header:
+                        return theme.typography(Compatibility.isDeviceIdiomVision() ? .body1Strong : .caption1)
+                    case .footer:
                         return theme.typography(.caption1)
                     }
                 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

On visionOS, we only want one style of headers (the larger `.headerPrimary`). Update it so that any headers set to `.header` receive the same font as `.headerPrimary` (`.body1Strong`).
- This change was made in the token set so any calculations for height/width are already accounted for.
- `foreground1` and `foreground2` are both white on visionOS so `.textColor` can remain unchanged.

### Binary change

Total increase: 1,640 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,927,872 bytes | 30,929,512 bytes | ⚠️ 1,640 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterViewTokenSet.o | 81,880 bytes | 83,224 bytes | ⚠️ 1,344 bytes |
| __.SYMDEF | 4,771,216 bytes | 4,771,512 bytes | ⚠️ 296 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="160" alt="before" src="https://github.com/microsoft/fluentui-apple/assets/55368679/66738b29-2417-4c70-880c-34ab265b8c5f"> | <img width="159" alt="after" src="https://github.com/microsoft/fluentui-apple/assets/55368679/53b4839b-4ec6-4064-b894-666df312fcd7"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)