### PR TITLE
Update dangerForeground2 to use light mode variant on visionOS

### DIFF
--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -415,7 +415,7 @@ extension FluentTheme {
                            dark: GlobalTokens.sharedColor(.red, .tint30))
         case .dangerForeground2:
             return UIColor(light: GlobalTokens.sharedColor(.red, .primary),
-                           dark: GlobalTokens.sharedColor(.red, .tint30))
+                           dark: Compatibility.isDeviceIdiomVision() ? GlobalTokens.sharedColor(.red, .primary) : GlobalTokens.sharedColor(.red, .tint30))
         case .dangerStroke1:
             return UIColor(light: GlobalTokens.sharedColor(.red, .tint20),
                            dark: GlobalTokens.sharedColor(.red, .tint20))


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Update `dangerForeground2` to use light mode variant. The dark mode variant is hard to see on glass material.

### Binary change

Total increase: 936 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,929,448 bytes | 30,930,384 bytes | ⚠️ 936 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentTheme+Tokens.o | 173,344 bytes | 174,280 bytes | ⚠️ 936 bytes |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1973)