### PR TITLE
[ListItem] set default line limit to nil so it is not restricted for accessibility

### DIFF
--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -234,13 +234,13 @@ public struct ListItem<LeadingContent: View,
     var onAccessoryTapped: (() -> Void)?
 
     /// The maximum amount of lines shown for the `title`.
-    var titleLineLimit: Int = 1
+    var titleLineLimit: Int?
 
     /// The maximum amount of lines shown for the `subtitle`.
-    var subtitleLineLimit: Int = 1
+    var subtitleLineLimit: Int?
 
     /// The maximum amount of lines shown for the `footer`.
-    var footerLineLimit: Int = 1
+    var footerLineLimit: Int?
 
     /// The truncation mode of the `title`.
     var titleTruncationMode: Text.TruncationMode = .tail


### PR DESCRIPTION
### Platforms Impacted
- iOS
- visionOS

### Description of changes

For accessibility, we should not set the line limit for the title, subtitle, and footer of the ListItem. This will allow it to grow to as needed without specifying a line limit. 

I also set the values as optional, as that is the default case for them to be nil and the expectation from the SwiftUI API.

### Verification

Validated in the test app, when line limits are not specified, we get multiple lines for a long title, subtitle, and footer.
![image](https://github.com/microsoft/fluentui-apple/assets/21343215/f425b040-3945-4730-89e4-475674812a07)



 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1975)