### PR TITLE
Optimize `FluentTheme` updating

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/BrandedSwitch.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/BrandedSwitch.swift
@@ -10,16 +10,15 @@ class BrandedSwitch: UISwitch {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        NotificationCenter.default.addObserver(forName: .didChangeTheme,
-                                               object: nil,
-                                               queue: nil) { [weak self] notification in
+        notificationObserver = NotificationCenter.default.addObserver(forName: .didChangeTheme,
+                                                                      object: nil,
+                                                                      queue: nil) { [weak self] notification in
             guard let strongSelf = self,
-                  let themeView = notification.object as? UIView,
-                  strongSelf.isDescendant(of: themeView)
+                  FluentTheme.isApplicableThemeChange(notification, for: strongSelf)
             else {
                 return
             }
-            strongSelf.onTintColor = themeView.fluentTheme.color(.brandForeground1)
+            strongSelf.onTintColor = strongSelf.fluentTheme.color(.brandForeground1)
         }
     }
 
@@ -34,4 +33,7 @@ class BrandedSwitch: UISwitch {
         }
         onTintColor = newWindow.fluentTheme.color(.brandForeground1)
     }
+
+    /// Stores the notification handler for .didChangeTheme notifications.
+    private var notificationObserver: NSObjectProtocol?
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/ColoredPillBackgroundView.swift
@@ -29,7 +29,7 @@ class ColoredPillBackgroundView: UIView {
     }
 
     @objc func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: self) else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/DemoListViewController.swift
@@ -30,7 +30,7 @@ class DemoListViewController: DemoTableViewController {
     func updateColorProviderFor(window: UIWindow, theme: DemoColorTheme) {
         self.theme = theme
         if let provider = self.provider {
-            FluentTheme.setSharedThemeColorProvider(provider)
+            window.setColorProvider(provider)
             let fluentTheme = self.view.fluentTheme
             let primaryColor = fluentTheme.color(.brandBackground1)
             FluentUIFramework.initializeAppearance(with: primaryColor, whenContainedInInstancesOf: [type(of: window)])

--- a/ios/FluentUI/Calendar/CalendarView.swift
+++ b/ios/FluentUI/Calendar/CalendarView.swift
@@ -61,7 +61,7 @@ class CalendarView: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: self) else {
             return
         }
         updateCollectionViewBackgroundColor()

--- a/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
+++ b/ios/FluentUI/Calendar/Views/CalendarViewWeekdayHeadingView.swift
@@ -37,7 +37,7 @@ class CalendarViewWeekdayHeadingView: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: self) else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -74,7 +74,7 @@ open class ControlHostingView: UIView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: self) else {
             return
         }
         updateRootView()

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -92,17 +92,31 @@ public class FluentTheme: NSObject, ObservableObject {
     @objc(sharedTheme)
     public internal(set) static var shared: FluentTheme = FluentThemeKey.defaultValue {
         didSet {
-            UIApplication.shared.connectedScenes
-                .compactMap {
-                    $0 as? UIWindowScene
-                }
-                .flatMap {
-                    $0.windows
-                }
-                .forEach { window in
-                    NotificationCenter.default.post(name: .didChangeTheme, object: window)
-                }
+            NotificationCenter.default.post(name: .didChangeTheme, object: nil)
         }
+    }
+
+    /// Determines if a given `Notification` should cause an update for the given `UIView`.
+    ///
+    /// - Parameter notification: A `Notification` object that may be requesting a view update based on a theme change.
+    /// - Parameter view: The `UIView` instance that wants to determine whether to update.
+    ///
+    /// - Returns: `True` if the view should update, `false` otherwise.
+    @objc(isApplicableThemeChangeNotification:forView:)
+    public static func isApplicableThemeChange(_ notification: Notification,
+                                               for view: UIView) -> Bool {
+        // Do not update unless the notification's name is `.didChangeTheme`.
+        guard notification.name == .didChangeTheme else {
+            return false
+        }
+
+        // If there is no object, or it is not a UIView, we must assume that we need to update.
+        guard let themeView = notification.object as? UIView else {
+            return true
+        }
+
+        // If the object is a UIView, we only update if `view` is a descendant thereof.
+        return view.isDescendant(of: themeView)
     }
 
     // Token storage

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -83,14 +83,17 @@ public class FluentTheme: NSObject, ObservableObject {
                     gradientTokenSet: gradientTokenSet)
     }()
 
-    /// A shared, immutable, default `FluentTheme` instance.
+    /// The shared `FluentTheme` instance used by default for controls in the app.
     ///
-    /// This instance of `FluentTheme` is not customizable, and will not return any overridden values that may be
-    /// applied to other instances of `FluentTheme`. For example, any branding colors applied via an instantiation of
-    /// the `ColorProviding` protocol will not be reflected here. As such, this should only be used in cases where the
-    /// caller is certain that they are looking for the _default_ token values associated with Fluent.
+    /// This static `FluentTheme` instance will normally return the default token values associated
+    /// with Fluent. However, it is also available for overriding in cases where a single custom theme
+    /// is desired for the app linking this library.
+    ///
+    /// Note that any custom themes set on a `UIView` hierarchy or via a SwiftUI view modifier will
+    /// take precedence over this value. This value provides the fallback theme for cases where those
+    /// overrides are not provided.
     @objc(sharedTheme)
-    public internal(set) static var shared: FluentTheme = FluentThemeKey.defaultValue {
+    public static var shared: FluentTheme = FluentThemeKey.defaultValue {
         didSet {
             NotificationCenter.default.post(name: .didChangeTheme, object: nil)
         }

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -162,13 +162,12 @@ public class ControlTokenSet<T: TokenSetKey>: ObservableObject {
                                                                       object: nil,
                                                                       queue: nil) { [weak self, weak control] notification in
             guard let strongSelf = self,
-                  let themeView = notification.object as? UIView,
                   let control,
-                  control.isDescendant(of: themeView)
+                  FluentTheme.isApplicableThemeChange(notification, for: control)
             else {
                 return
             }
-            strongSelf.update(themeView.fluentTheme)
+            strongSelf.update(control.fluentTheme)
         }
     }
 

--- a/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Picker/DatePickerController.swift
@@ -149,7 +149,7 @@ class DatePickerController: UIViewController, GenericDateTimePicker {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, view.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: view) else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/DateTimePickerController.swift
@@ -115,7 +115,7 @@ class DateTimePickerController: UIViewController, GenericDateTimePicker {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, view.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: view) else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
+++ b/ios/FluentUI/Date Time Pickers/Date Time Picker/Views/DateTimePickerView.swift
@@ -89,7 +89,7 @@ class DateTimePickerView: UIControl {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: self) else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI/People Picker/PersonaListView.swift
+++ b/ios/FluentUI/People Picker/PersonaListView.swift
@@ -100,7 +100,7 @@ open class PersonaListView: UITableView {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, self.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: self) else {
             return
         }
         updateBackgroundColor()

--- a/ios/FluentUI/Presenters/PageCardPresenterController.swift
+++ b/ios/FluentUI/Presenters/PageCardPresenterController.swift
@@ -76,7 +76,7 @@ open class PageCardPresenterController: UIViewController {
     }
 
     @objc private func themeDidChange(_ notification: Notification) {
-        guard let themeView = notification.object as? UIView, view.isDescendant(of: themeView) else {
+        guard FluentTheme.isApplicableThemeChange(notification, for: view) else {
             return
         }
         updatePageControlColors()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

* Setting the shared `FluentTheme` now passes `nil` as the parent window into its notification, instead of iterating through all windows.
* Creating a new function, `FluentTheme.isApplicableThemeChange(_:for:)`, to capture the logic of determining whether a given `UIView` should update based on a theme notification (including the new `nil` logic used by `FluentTheme.shared`).
* Update all components that were doing manual notification observation to use this new API.
* Fix a bug in the Demo app re: per-window theme updates.

### Binary change

Total increase: 2,552 bytes
Total decrease: -43,408 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,061,536 bytes | 31,020,680 bytes | 🎉 -40,856 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ColorProviding.o | 43,384 bytes | 45,560 bytes | ⚠️ 2,176 bytes |
| FocusRingView.o | 817,752 bytes | 818,128 bytes | ⚠️ 376 bytes |
| MSFNotification.o | 139,656 bytes | 139,528 bytes | 🎉 -128 bytes |
| MSFPersonaButtonCarousel.o | 32,696 bytes | 32,568 bytes | 🎉 -128 bytes |
| MSFPersonaButton.o | 37,840 bytes | 37,712 bytes | 🎉 -128 bytes |
| MSFHeadsUpDisplay.o | 34,072 bytes | 33,936 bytes | 🎉 -136 bytes |
| MSFAvatar.o | 27,552 bytes | 27,416 bytes | 🎉 -136 bytes |
| MSFAvatarGroup.o | 27,976 bytes | 27,840 bytes | 🎉 -136 bytes |
| MSFIndeterminateProgressBar.o | 28,632 bytes | 28,496 bytes | 🎉 -136 bytes |
| MSFActivityIndicator.o | 31,080 bytes | 30,944 bytes | 🎉 -136 bytes |
| MSFCardNudge.o | 36,496 bytes | 36,360 bytes | 🎉 -136 bytes |
| BadgeView.o | 625,216 bytes | 624,816 bytes | 🎉 -400 bytes |
| PageCardPresenterController.o | 146,992 bytes | 146,440 bytes | 🎉 -552 bytes |
| DatePickerController.o | 323,576 bytes | 322,952 bytes | 🎉 -624 bytes |
| MultilineCommandBar.o | 141,232 bytes | 140,552 bytes | 🎉 -680 bytes |
| DateTimePickerView.o | 207,936 bytes | 207,216 bytes | 🎉 -720 bytes |
| DateTimePickerController.o | 143,976 bytes | 142,936 bytes | 🎉 -1,040 bytes |
| PersonaListView.o | 187,120 bytes | 186,008 bytes | 🎉 -1,112 bytes |
| PopupMenuController.o | 383,968 bytes | 382,840 bytes | 🎉 -1,128 bytes |
| CalendarView.o | 71,248 bytes | 69,800 bytes | 🎉 -1,448 bytes |
| HUD.o | 259,640 bytes | 257,744 bytes | 🎉 -1,896 bytes |
| ControlHostingView.o | 65,944 bytes | 63,696 bytes | 🎉 -2,248 bytes |
| __.SYMDEF | 4,822,056 bytes | 4,818,744 bytes | 🎉 -3,312 bytes |
| CalendarViewWeekdayHeadingView.o | 86,040 bytes | 76,544 bytes | 🎉 -9,496 bytes |
| FluentTheme.o | 219,296 bytes | 201,744 bytes | 🎉 -17,552 bytes |
</details>

### Verification

Tested UIKit and SwiftUI controls, across multiple windows, to ensure standard expected behavior is maintained.

<details>
<summary>Visual Verification</summary>

https://github.com/microsoft/fluentui-apple/assets/4934719/54a81596-ad23-4dad-9c1a-29284856c99e

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1976)