### PR TITLE
Allow Bottom Sheets to go Directly from Hidden to Expanded

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -99,10 +99,6 @@ class BottomSheetDemoController: DemoController {
         bottomSheetViewController?.preferredWidth = sender.isOn ? 400 : 0
     }
 
-    @objc private func toggleUnhideToExpandedState(_ sender: BooleanCell) {
-        bottomSheetViewController?.unhideFinishedState = sender.isOn ? .expanded : .collapsed
-    }
-
     @objc private func showTransientSheet() {
         let hostingVC = UIHostingController(rootView: BottomSheetDemoListContentView())
 
@@ -123,7 +119,7 @@ class BottomSheetDemoController: DemoController {
         secondarySheetController.allowsSwipeToHide = true
 
         let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { _ in
-            secondarySheetController.setIsHidden(true, animated: true)
+            secondarySheetController.setHidden(true, animated: true)
         }))
 
         dismissButton.style = .accent
@@ -269,11 +265,7 @@ class BottomSheetDemoController: DemoController {
                 DemoItem(title: "Set preferred width to 400",
                           type: .boolean,
                         action: #selector(togglePreferredWidth),
-                          isOn: bottomSheetViewController?.preferredWidth == 400),
-                DemoItem(title: "Unhide to expanded state",
-                         type: .boolean,
-                        action: #selector(toggleUnhideToExpandedState),
-                         isOn: bottomSheetViewController?.unhideFinishedState == .expanded)
+                          isOn: bottomSheetViewController?.preferredWidth == 400)
             ],
             [
                 DemoItem(title: "Show transient sheet", type: .action, action: #selector(showTransientSheet))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -99,6 +99,10 @@ class BottomSheetDemoController: DemoController {
         bottomSheetViewController?.preferredWidth = sender.isOn ? 400 : 0
     }
 
+    @objc private func toggleUnhideToExpandedState(_ sender: BooleanCell) {
+        bottomSheetViewController?.unhideFinishedState = sender.isOn ? .expanded : .collapsed
+    }
+
     @objc private func showTransientSheet() {
         let hostingVC = UIHostingController(rootView: BottomSheetDemoListContentView())
 
@@ -265,7 +269,11 @@ class BottomSheetDemoController: DemoController {
                 DemoItem(title: "Set preferred width to 400",
                           type: .boolean,
                         action: #selector(togglePreferredWidth),
-                          isOn: bottomSheetViewController?.preferredWidth == 400)
+                          isOn: bottomSheetViewController?.preferredWidth == 400),
+                DemoItem(title: "Unhide to expanded state",
+                         type: .boolean,
+                        action: #selector(toggleUnhideToExpandedState),
+                         isOn: bottomSheetViewController?.unhideFinishedState == .expanded)
             ],
             [
                 DemoItem(title: "Show transient sheet", type: .action, action: #selector(showTransientSheet))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -190,7 +190,7 @@ class TwoLineTitleViewDemoController: DemoController {
         secondarySheetController.allowsSwipeToHide = true
 
         let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { _ in
-            secondarySheetController.setIsHidden(true, animated: true)
+            secondarySheetController.setHidden(true, animated: true)
         }))
 
         dismissButton.style = .accent

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -173,7 +173,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
     ///   - completion: Closure to be called when the state change completes.
     @objc public func setIsHidden(_ isHidden: Bool, animated: Bool = true, completion: ((_ isFinished: Bool) -> Void)? = nil) {
         if isInSheetMode {
-            bottomSheetController?.setIsHidden(isHidden, animated: animated, completion: completion)
+            bottomSheetController?.setHidden(isHidden, animated: animated, completion: completion)
         } else {
             if isViewLoaded {
                 completeBottomBarAnimationsIfNeeded()

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -32,7 +32,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 }
 
 /// Defines the position the sheet is currently in
- @objc public enum BottomSheetExpansionState: Int {
+@objc public enum BottomSheetExpansionState: Int {
     case expanded // Sheet is fully expanded
     case collapsed // Sheet is collapsed
     case hidden // Sheet is hidden (fully off-screen)

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -32,7 +32,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 }
 
 /// Defines the position the sheet is currently in
-@objc public enum BottomSheetExpansionState: Int {
+ @objc public enum BottomSheetExpansionState: Int {
     case expanded // Sheet is fully expanded
     case collapsed // Sheet is collapsed
     case hidden // Sheet is hidden (fully off-screen)
@@ -106,6 +106,19 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
         set {
             setIsHidden(newValue)
+        }
+    }
+
+    /// Indicates where bottom sheet should expand to after setting `setIsHidden` is set to `false`
+    ///
+    /// When set to `.collapsed` the sheet will go to the collapsed state from the hidden state
+    /// When set to `.expanded` the sheet will go directly to the hidden state from the expanded state
+    /// Other states are invalid unhiding targets
+    @objc open var unhideFinishedState: BottomSheetExpansionState = .collapsed {
+        didSet {
+            if unhideFinishedState != .collapsed && unhideFinishedState != .expanded {
+                unhideFinishedState = oldValue
+            }
         }
     }
 
@@ -305,7 +318,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     ///   - animated: Indicates if the change should be animated. The default value is `true`.
     ///   - completion: Closure to be called when the state change completes.
     @objc public func setIsHidden(_ isHidden: Bool, animated: Bool = true, completion: ((_ isFinished: Bool) -> Void)? = nil) {
-        let targetState: BottomSheetExpansionState = isHidden ? .hidden : .collapsed
+        let targetState: BottomSheetExpansionState = isHidden ? .hidden : unhideFinishedState
         if isViewLoaded {
             move(to: targetState, animated: animated, allowUnhiding: true) { finalPosition in
                 completion?(finalPosition == .end)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS

### Description of changes
Bottom sheets currently does not provide users a way to expand the sheet directly from the hidden state. The best consumers currently can do is to setIsExpanded in a completion block when calling `setIsHidden`. However, this produces unstable UI where the animation can be jittery amongst other complications.

Solution:
Add a new parameter `unhiddenTargetState` to `setIsHidden` that allows consumers to specify the targeted state when a sheet goes from hidden to not hidden.
Additionally, we rename `setIsHidden` to `setHidden` and deprecate the old 3 parameter `setIsHidden`. This accomplishes 2 things.
1. We avoid issues with call ambiguity to the old deprecated 3 parameter API.
2. We fix our naming convention to be consistent with Apple's.

### Binary change
Total increase: 31,074,176 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 0 bytes | 31,074,176 bytes | ⛔️ 31,074,176 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 0 bytes | 4,844,784 bytes | ⛔️ 4,844,784 bytes |
| BottomCommandingController.o | 0 bytes | 843,288 bytes | ⛔️ 843,288 bytes |
| FocusRingView.o | 0 bytes | 821,312 bytes | ⛔️ 821,312 bytes |
| TableViewCell.o | 0 bytes | 815,760 bytes | ⛔️ 815,760 bytes |
| FluentNotification.o | 0 bytes | 698,840 bytes | ⛔️ 698,840 bytes |
| BadgeView.o | 0 bytes | 625,000 bytes | ⛔️ 625,000 bytes |
| Avatar.o | 0 bytes | 600,128 bytes | ⛔️ 600,128 bytes |
| BadgeField.o | 0 bytes | 583,536 bytes | ⛔️ 583,536 bytes |
| NavigationBar.o | 0 bytes | 549,336 bytes | ⛔️ 549,336 bytes |
| GlobalTokens.o | 0 bytes | 539,240 bytes | ⛔️ 539,240 bytes |
| BottomSheetController.o | 0 bytes | 521,200 bytes | ⛔️ 521,200 bytes |
| DrawerController.o | 0 bytes | 483,072 bytes | ⛔️ 483,072 bytes |
| CardNudge.o | 0 bytes | 447,288 bytes | ⛔️ 447,288 bytes |
| AvatarGroup.o | 0 bytes | 420,728 bytes | ⛔️ 420,728 bytes |
| SearchBar.o | 0 bytes | 383,560 bytes | ⛔️ 383,560 bytes |
| PopupMenuController.o | 0 bytes | 382,936 bytes | ⛔️ 382,936 bytes |
| SegmentedControl.o | 0 bytes | 333,272 bytes | ⛔️ 333,272 bytes |
| DatePickerController.o | 0 bytes | 323,264 bytes | ⛔️ 323,264 bytes |
| PeoplePicker.o | 0 bytes | 310,584 bytes | ⛔️ 310,584 bytes |
| TableViewHeaderFooterView.o | 0 bytes | 281,984 bytes | ⛔️ 281,984 bytes |
| DateTimePickerViewDataSource.o | 0 bytes | 275,824 bytes | ⛔️ 275,824 bytes |
| ListItem.o | 0 bytes | 272,536 bytes | ⛔️ 272,536 bytes |
| TwoLineTitleView.o | 0 bytes | 262,488 bytes | ⛔️ 262,488 bytes |
| ShyHeaderController.o | 0 bytes | 262,016 bytes | ⛔️ 262,016 bytes |
| HUD.o | 0 bytes | 257,768 bytes | ⛔️ 257,768 bytes |
| HeadsUpDisplay.o | 0 bytes | 249,856 bytes | 🛑 249,856 bytes |
| CardView.o | 0 bytes | 246,728 bytes | 🛑 246,728 bytes |
| PillButtonBar.o | 0 bytes | 246,712 bytes | 🛑 246,712 bytes |
| PersonaButton.o | 0 bytes | 242,896 bytes | 🛑 242,896 bytes |
| IndeterminateProgressBar.o | 0 bytes | 233,616 bytes | 🛑 233,616 bytes |
| DrawerPresentationController.o | 0 bytes | 229,960 bytes | 🛑 229,960 bytes |
| ListActionItem.o | 0 bytes | 225,120 bytes | 🛑 225,120 bytes |
| TabBarItemView.o | 0 bytes | 221,832 bytes | 🛑 221,832 bytes |
| TooltipView.o | 0 bytes | 216,200 bytes | 🛑 216,200 bytes |
| ShimmerView.o | 0 bytes | 214,928 bytes | 🛑 214,928 bytes |
| Button.o | 0 bytes | 211,888 bytes | 🛑 211,888 bytes |
| DateTimePickerView.o | 0 bytes | 207,304 bytes | 🛑 207,304 bytes |
| SideTabBar.o | 0 bytes | 206,520 bytes | 🛑 206,520 bytes |
| FluentTheme.o | 0 bytes | 201,720 bytes | 🛑 201,720 bytes |
| CommandBarCommandGroupsView.o | 0 bytes | 199,616 bytes | 🛑 199,616 bytes |
| CommandBar.o | 0 bytes | 196,064 bytes | 🛑 196,064 bytes |
| FluentTextField.o | 0 bytes | 194,440 bytes | 🛑 194,440 bytes |
| AvatarTitleView.o | 0 bytes | 191,912 bytes | 🛑 191,912 bytes |
| PersonaListView.o | 0 bytes | 186,016 bytes | 🛑 186,016 bytes |
| PopupMenuItemCell.o | 0 bytes | 176,944 bytes | 🛑 176,944 bytes |
| FluentTheme+Tokens.o | 0 bytes | 174,432 bytes | 🛑 174,432 bytes |
| PersonaButtonCarousel.o | 0 bytes | 168,344 bytes | 🛑 168,344 bytes |
| PillButton.o | 0 bytes | 167,368 bytes | 🛑 167,368 bytes |
| DateTimePicker.o | 0 bytes | 165,376 bytes | 🛑 165,376 bytes |
| ActionsCell.o | 0 bytes | 164,048 bytes | 🛑 164,048 bytes |
| ActivityIndicator.o | 0 bytes | 163,992 bytes | 🛑 163,992 bytes |
| NavigationController.o | 0 bytes | 157,648 bytes | 🛑 157,648 bytes |
| PageCardPresenterController.o | 0 bytes | 146,448 bytes | 🛑 146,448 bytes |
| DateTimePickerController.o | 0 bytes | 142,992 bytes | 🛑 142,992 bytes |
| MultilineCommandBar.o | 0 bytes | 140,568 bytes | 🛑 140,568 bytes |
| MSFNotification.o | 0 bytes | 139,520 bytes | 🛑 139,520 bytes |
| TabBarView.o | 0 bytes | 138,416 bytes | 🛑 138,416 bytes |
| DateTimePickerViewComponent.o | 0 bytes | 138,160 bytes | 🛑 138,160 bytes |
| Label.o | 0 bytes | 134,672 bytes | 🛑 134,672 bytes |
| CalendarViewDataSource.o | 0 bytes | 131,496 bytes | 🛑 131,496 bytes |
| CalendarViewDayCell.o | 0 bytes | 130,928 bytes | 🛑 130,928 bytes |
| ButtonTokenSet.o | 0 bytes | 126,080 bytes | 🛑 126,080 bytes |
| PopupMenuItem.o | 0 bytes | 125,632 bytes | 🛑 125,632 bytes |
| Tooltip.o | 0 bytes | 123,680 bytes | 🛑 123,680 bytes |
| SwiftUI+ViewModifiers.o | 0 bytes | 123,480 bytes | 🛑 123,480 bytes |
| ShyHeaderView.o | 0 bytes | 120,056 bytes | 🛑 120,056 bytes |
| AvatarTokenSet.o | 0 bytes | 117,248 bytes | 🛑 117,248 bytes |
| NavigationAnimator.o | 0 bytes | 116,080 bytes | 🛑 116,080 bytes |
| TableViewCellTokenSet.o | 0 bytes | 114,296 bytes | 🛑 114,296 bytes |
| BadgeLabelButton.o | 0 bytes | 109,912 bytes | 🛑 109,912 bytes |
| CommandBarItem.o | 0 bytes | 104,360 bytes | 🛑 104,360 bytes |
| ShimmerLinesView.o | 0 bytes | 103,496 bytes | 🛑 103,496 bytes |
| AliasTokens.o | 0 bytes | 97,064 bytes | 🛑 97,064 bytes |
| CommandBarButton.o | 0 bytes | 95,960 bytes | 🛑 95,960 bytes |
| BadgeViewTokenSet.o | 0 bytes | 94,288 bytes | 🛑 94,288 bytes |
| SegmentPillButton.o | 0 bytes | 91,904 bytes | 🛑 91,904 bytes |
| SegmentedControlTokenSet.o | 0 bytes | 91,784 bytes | 🛑 91,784 bytes |
| CommandingItem.o | 0 bytes | 91,224 bytes | 🛑 91,224 bytes |
| NotificationTokenSet.o | 0 bytes | 90,944 bytes | 🛑 90,944 bytes |
| BooleanCell.o | 0 bytes | 90,152 bytes | 🛑 90,152 bytes |
| PillButtonTokenSet.o | 0 bytes | 87,280 bytes | 🛑 87,280 bytes |
| CenteredLabelCell.o | 0 bytes | 85,640 bytes | 🛑 85,640 bytes |
| TableViewHeaderFooterViewTokenSet.o | 0 bytes | 83,472 bytes | 🛑 83,472 bytes |
| ActivityIndicatorCell.o | 0 bytes | 82,496 bytes | 🛑 82,496 bytes |
| CardNudgeTokenSet.o | 0 bytes | 82,240 bytes | 🛑 82,240 bytes |
| SearchBarTokenSet.o | 0 bytes | 81,200 bytes | 🛑 81,200 bytes |
| DrawerShadowView.o | 0 bytes | 81,032 bytes | 🛑 81,032 bytes |
| UINavigationItem+Navigation.o | 0 bytes | 80,216 bytes | 🛑 80,216 bytes |
| UIColor+Extensions.o | 0 bytes | 78,848 bytes | 🛑 78,848 bytes |
| TextFieldTokenSet.o | 0 bytes | 78,608 bytes | 🛑 78,608 bytes |
| CalendarViewWeekdayHeadingView.o | 0 bytes | 76,520 bytes | 🛑 76,520 bytes |
| FluentUIFramework.o | 0 bytes | 76,512 bytes | 🛑 76,512 bytes |
| Separator.o | 0 bytes | 74,072 bytes | 🛑 74,072 bytes |
| Persona.o | 0 bytes | 73,720 bytes | 🛑 73,720 bytes |
| ResizingHandleView.o | 0 bytes | 73,232 bytes | 🛑 73,232 bytes |
| CalendarViewLayout.o | 0 bytes | 73,176 bytes | 🛑 73,176 bytes |
| NavigationBarTokenSet.o | 0 bytes | 72,288 bytes | 🛑 72,288 bytes |
| NotificationModifiers.o | 0 bytes | 71,960 bytes | 🛑 71,960 bytes |
| DrawerTransitionAnimator.o | 0 bytes | 71,752 bytes | 🛑 71,752 bytes |
| ShimmerTokenSet.o | 0 bytes | 70,680 bytes | 🛑 70,680 bytes |
| FontInfo.o | 0 bytes | 70,568 bytes | 🛑 70,568 bytes |
| ControlTokenSet.o | 0 bytes | 70,528 bytes | 🛑 70,528 bytes |
| CalendarView.o | 0 bytes | 69,832 bytes | 🛑 69,832 bytes |
| DateTimePickerViewComponentTableView.o | 0 bytes | 67,944 bytes | 🛑 67,944 bytes |
| TabBarItem.o | 0 bytes | 67,920 bytes | 🛑 67,920 bytes |
| BottomCommandingTokenSet.o | 0 bytes | 66,824 bytes | 🛑 66,824 bytes |
| HUDModifiers.o | 0 bytes | 65,672 bytes | 🛑 65,672 bytes |
| CardTransitionAnimator.o | 0 bytes | 65,664 bytes | 🛑 65,664 bytes |
| PersonaButtonTokenSet.o | 0 bytes | 65,544 bytes | 🛑 65,544 bytes |
| ControlHostingView.o | 0 bytes | 63,672 bytes | 🛑 63,672 bytes |
| BadgeLabel.o | 0 bytes | 63,608 bytes | 🛑 63,608 bytes |
| CommandBarTokenSet.o | 0 bytes | 63,240 bytes | 🛑 63,240 bytes |
| TabBarItemTokenSet.o | 0 bytes | 63,032 bytes | 🛑 63,032 bytes |
| BadgeStringExtractor.o | 0 bytes | 62,912 bytes | 🛑 62,912 bytes |
| PersonaCell.o | 0 bytes | 62,856 bytes | 🛑 62,856 bytes |
| ActivityIndicatorTokenSet.o | 0 bytes | 61,272 bytes | 🛑 61,272 bytes |
| String+Date.o | 0 bytes | 59,896 bytes | 🛑 59,896 bytes |
| CommandBarButtonGroupView.o | 0 bytes | 59,136 bytes | 🛑 59,136 bytes |
| DayOfMonth.o | 0 bytes | 59,120 bytes | 🛑 59,120 bytes |
| DateTimePickerViewComponentCell.o | 0 bytes | 58,000 bytes | 🛑 58,000 bytes |
| SwiftUI+ViewPresentation.o | 0 bytes | 57,824 bytes | 🛑 57,824 bytes |
| TwoLineTitleViewTokenSet.o | 0 bytes | 57,496 bytes | 🛑 57,496 bytes |
| DatePickerSelectionManager.o | 0 bytes | 57,424 bytes | 🛑 57,424 bytes |
| DateTimePickerViewLayout.o | 0 bytes | 57,312 bytes | 🛑 57,312 bytes |
| LabelTokenSet.o | 0 bytes | 56,632 bytes | 🛑 56,632 bytes |
| TooltipTokenSet.o | 0 bytes | 56,064 bytes | 🛑 56,064 bytes |
| SideTabBarTokenSet.o | 0 bytes | 54,824 bytes | 🛑 54,824 bytes |
| BadgeFieldTokenSet.o | 0 bytes | 54,312 bytes | 🛑 54,312 bytes |
| DrawerTokenSet.o | 0 bytes | 53,608 bytes | 🛑 53,608 bytes |
| HeadsUpDisplayTokenSet.o | 0 bytes | 53,000 bytes | 🛑 53,000 bytes |
| AvatarGroupTokenSet.o | 0 bytes | 52,656 bytes | 🛑 52,656 bytes |
| DimmingView.o | 0 bytes | 51,544 bytes | 🛑 51,544 bytes |
| AvatarTitleViewTokenSet.o | 0 bytes | 51,296 bytes | 🛑 51,296 bytes |
| CalendarConfiguration.o | 0 bytes | 49,272 bytes | ⚠️ 49,272 bytes |
| DynamicColor.o | 0 bytes | 49,264 bytes | ⚠️ 49,264 bytes |
| SwiftUI+ViewAnimation.o | 0 bytes | 48,800 bytes | ⚠️ 48,800 bytes |
| BadgeLabelTokenSet.o | 0 bytes | 48,784 bytes | ⚠️ 48,784 bytes |
| Date+Extensions.o | 0 bytes | 48,632 bytes | ⚠️ 48,632 bytes |
| FluentTextFieldInternal.o | 0 bytes | 48,576 bytes | ⚠️ 48,576 bytes |
| ShadowInfo.o | 0 bytes | 47,872 bytes | ⚠️ 47,872 bytes |
| BottomSheetTokenSet.o | 0 bytes | 47,840 bytes | ⚠️ 47,840 bytes |
| Calendar+Extensions.o | 0 bytes | 47,776 bytes | ⚠️ 47,776 bytes |
| TokenizedControlView.o | 0 bytes | 47,624 bytes | ⚠️ 47,624 bytes |
| CardPresentationController.o | 0 bytes | 46,920 bytes | ⚠️ 46,920 bytes |
| UIKit+SwiftUI_interoperability.o | 0 bytes | 46,376 bytes | ⚠️ 46,376 bytes |
| TooltipViewController.o | 0 bytes | 45,992 bytes | ⚠️ 45,992 bytes |
| TabBarTokenSet.o | 0 bytes | 45,688 bytes | ⚠️ 45,688 bytes |
| ColorProviding.o | 0 bytes | 45,496 bytes | ⚠️ 45,496 bytes |
| CardNudgeModifiers.o | 0 bytes | 45,320 bytes | ⚠️ 45,320 bytes |
| LinearGradientInfo.o | 0 bytes | 45,192 bytes | ⚠️ 45,192 bytes |
| UIView+Extensions.o | 0 bytes | 45,168 bytes | ⚠️ 45,168 bytes |
| ResizingHandleTokenSet.o | 0 bytes | 44,264 bytes | ⚠️ 44,264 bytes |
| AvatarModifiers.o | 0 bytes | 43,944 bytes | ⚠️ 43,944 bytes |
| IndeterminateProgressBarTokenSet.o | 0 bytes | 43,920 bytes | ⚠️ 43,920 bytes |
| MSFAvatarPresence.o | 0 bytes | 43,072 bytes | ⚠️ 43,072 bytes |
| CalendarViewDayMonthCell.o | 0 bytes | 42,832 bytes | ⚠️ 42,832 bytes |
| PersonaButtonCarouselTokenSet.o | 0 bytes | 41,624 bytes | ⚠️ 41,624 bytes |
| CalendarViewDayMonthYearCell.o | 0 bytes | 41,560 bytes | ⚠️ 41,560 bytes |
| SeparatorTokenSet.o | 0 bytes | 39,920 bytes | ⚠️ 39,920 bytes |
| ShapeCutout.o | 0 bytes | 37,928 bytes | ⚠️ 37,928 bytes |
| MSFPersonaButton.o | 0 bytes | 37,656 bytes | ⚠️ 37,656 bytes |
| AccessibilityContainerView.o | 0 bytes | 37,256 bytes | ⚠️ 37,256 bytes |
| PersonaBadgeViewDataSource.o | 0 bytes | 37,072 bytes | ⚠️ 37,072 bytes |
| EmptyTokenSet.o | 0 bytes | 36,936 bytes | ⚠️ 36,936 bytes |
| CalendarViewDayTodayCell.o | 0 bytes | 36,440 bytes | ⚠️ 36,440 bytes |
| MSFCardNudge.o | 0 bytes | 36,296 bytes | ⚠️ 36,296 bytes |
| BlurringView.o | 0 bytes | 34,848 bytes | ⚠️ 34,848 bytes |
| MSFHeadsUpDisplay.o | 0 bytes | 33,872 bytes | ⚠️ 33,872 bytes |
| TouchForwardingView.o | 0 bytes | 33,824 bytes | ⚠️ 33,824 bytes |
| UIScrollView+Extensions.o | 0 bytes | 33,464 bytes | ⚠️ 33,464 bytes |
| SegmentItem.o | 0 bytes | 33,056 bytes | ⚠️ 33,056 bytes |
| FluentUIHostingController.o | 0 bytes | 32,736 bytes | ⚠️ 32,736 bytes |
| MSFPersonaButtonCarousel.o | 0 bytes | 32,496 bytes | ⚠️ 32,496 bytes |
| PopupMenuItemTokenSet.o | 0 bytes | 32,408 bytes | ⚠️ 32,408 bytes |
| DotView.o | 0 bytes | 31,832 bytes | ⚠️ 31,832 bytes |
| UIBarButtonItem+BadgeValue.o | 0 bytes | 31,264 bytes | ⚠️ 31,264 bytes |
| AnimationSynchronizer.o | 0 bytes | 31,184 bytes | ⚠️ 31,184 bytes |
| MSFActivityIndicator.o | 0 bytes | 30,872 bytes | ⚠️ 30,872 bytes |
| BarButtonItems.o | 0 bytes | 29,120 bytes | ⚠️ 29,120 bytes |
| TwoLineTitleView+Navigation.o | 0 bytes | 28,776 bytes | ⚠️ 28,776 bytes |
| PopupMenuSection.o | 0 bytes | 28,744 bytes | ⚠️ 28,744 bytes |
| PopupMenuSectionHeaderView.o | 0 bytes | 28,456 bytes | ⚠️ 28,456 bytes |
| MSFIndeterminateProgressBar.o | 0 bytes | 28,424 bytes | ⚠️ 28,424 bytes |
| CalendarViewMonthBannerView.o | 0 bytes | 27,976 bytes | ⚠️ 27,976 bytes |
| CommandingSection.o | 0 bytes | 27,936 bytes | ⚠️ 27,936 bytes |
| EasyTapButton.o | 0 bytes | 27,792 bytes | ⚠️ 27,792 bytes |
| MSFAvatarGroup.o | 0 bytes | 27,776 bytes | ⚠️ 27,776 bytes |
| CardPresenterNavigationController.o | 0 bytes | 27,504 bytes | ⚠️ 27,504 bytes |
| NSLayoutConstraint+Extensions.o | 0 bytes | 27,400 bytes | ⚠️ 27,400 bytes |
| MSFAvatar.o | 0 bytes | 27,352 bytes | ⚠️ 27,352 bytes |
| PopupMenuProtocols.o | 0 bytes | 27,024 bytes | ⚠️ 27,024 bytes |
| ActivityIndicatorModifiers.o | 0 bytes | 26,264 bytes | ⚠️ 26,264 bytes |
| ListItemModifiers.o | 0 bytes | 25,872 bytes | ⚠️ 25,872 bytes |
| Obscurable.o | 0 bytes | 24,720 bytes | ⚠️ 24,720 bytes |
| String+Extension.o | 0 bytes | 23,112 bytes | ⚠️ 23,112 bytes |
| FluentTextInputError.o | 0 bytes | 23,008 bytes | ⚠️ 23,008 bytes |
| ContentHeightResolutionContext.o | 0 bytes | 22,848 bytes | ⚠️ 22,848 bytes |
| PeoplePickerTokenSet.o | 0 bytes | 22,456 bytes | ⚠️ 22,456 bytes |
| BottomSheetPassthroughView.o | 0 bytes | 21,784 bytes | ⚠️ 21,784 bytes |
| ListActionItemModifiers.o | 0 bytes | 20,888 bytes | ⚠️ 20,888 bytes |
| PopupMenuTokenSet.o | 0 bytes | 20,576 bytes | ⚠️ 20,576 bytes |
| TokenSet.o | 0 bytes | 19,064 bytes | ⚠️ 19,064 bytes |
| IndeterminateProgressBarModifiers.o | 0 bytes | 17,208 bytes | ⚠️ 17,208 bytes |
| ContentScrollViewTraits.o | 0 bytes | 16,032 bytes | ⚠️ 16,032 bytes |
| UIViewController+Navigation.o | 0 bytes | 15,912 bytes | ⚠️ 15,912 bytes |
| AccessibleViewDelegate.o | 0 bytes | 15,768 bytes | ⚠️ 15,768 bytes |
| TokenizedControl.o | 0 bytes | 13,888 bytes | ⚠️ 13,888 bytes |
| GenericDateTimePicker.o | 0 bytes | 13,688 bytes | ⚠️ 13,688 bytes |
| UIApplication+Extensions.o | 0 bytes | 12,056 bytes | ⚠️ 12,056 bytes |
| DateComponents+Extensions.o | 0 bytes | 12,024 bytes | ⚠️ 12,024 bytes |
| UIImage+Extensions.o | 0 bytes | 11,856 bytes | ⚠️ 11,856 bytes |
| CALayer+Extensions.o | 0 bytes | 11,808 bytes | ⚠️ 11,808 bytes |
| Compatibility.o | 0 bytes | 11,720 bytes | ⚠️ 11,720 bytes |
| PersonaButtonCarouselModifiers.o | 0 bytes | 11,096 bytes | ⚠️ 11,096 bytes |
| PersonaButtonModifiers.o | 0 bytes | 11,056 bytes | ⚠️ 11,056 bytes |
| AvatarGroupModifiers.o | 0 bytes | 11,040 bytes | ⚠️ 11,040 bytes |
| FluentUI_vers.o | 0 bytes | 2,744 bytes | ⚠️ 2,744 bytes |
</details>

### Verification
Tested in the demo app that when we set the value of `unhiddenTargetState` to `.expanded` we animate the sheet up to the expanded state. Similarly we get the correct result for the `.collapsed` state.

### Pull request checklist

This PR has considered:
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] Objective-C exposure (provide it only if needed)