### PR TITLE
Move visionOS token overrides to separate function and file

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		925728F9276D6B5800EE1019 /* FontInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925728F8276D6B5800EE1019 /* FontInfo.swift */; };
 		925D461D26FD133600179583 /* GlobalTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D461B26FD133600179583 /* GlobalTokens.swift */; };
 		925D462026FD18B200179583 /* AliasTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 925D461E26FD18B200179583 /* AliasTokens.swift */; };
+		926B4C9A2B8E94F6001EBA16 /* FluentTheme+visionOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926B4C992B8E94F6001EBA16 /* FluentTheme+visionOS.swift */; };
 		926FEEAA2B45A8B4002C61D0 /* Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 926FEEA92B45A8B4002C61D0 /* Compatibility.swift */; };
 		9275105626815A7100F12730 /* MSFPersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */; };
 		927EB2BD278627440069753D /* PersonaButtonModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927EB2BC278627440069753D /* PersonaButtonModifiers.swift */; };
@@ -356,6 +357,7 @@
 		925728F8276D6B5800EE1019 /* FontInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontInfo.swift; sourceTree = "<group>"; };
 		925D461B26FD133600179583 /* GlobalTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalTokens.swift; sourceTree = "<group>"; };
 		925D461E26FD18B200179583 /* AliasTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasTokens.swift; sourceTree = "<group>"; };
+		926B4C992B8E94F6001EBA16 /* FluentTheme+visionOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FluentTheme+visionOS.swift"; sourceTree = "<group>"; };
 		926FEEA92B45A8B4002C61D0 /* Compatibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Compatibility.swift; sourceTree = "<group>"; };
 		9275105426815A7100F12730 /* MSFPersonaButtonCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButtonCarousel.swift; sourceTree = "<group>"; };
 		927E34C62668350800998031 /* PersonaButtonTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonTokenSet.swift; sourceTree = "<group>"; };
@@ -819,6 +821,7 @@
 				925D461A26FD126800179583 /* Tokens */,
 				923DB9D3274CB65700D8E58A /* FluentTheme.swift */,
 				9231F10229BB99090079CD94 /* FluentTheme+Tokens.swift */,
+				926B4C992B8E94F6001EBA16 /* FluentTheme+visionOS.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -1735,6 +1738,7 @@
 				5314E07D25F00F1A0099271A /* DateTimePickerViewComponentTableView.swift in Sources */,
 				0AE3041D29F721B2003CDDD9 /* TableViewHeaderFooterViewTokenSet.swift in Sources */,
 				926FEEAA2B45A8B4002C61D0 /* Compatibility.swift in Sources */,
+				926B4C9A2B8E94F6001EBA16 /* FluentTheme+visionOS.swift in Sources */,
 				5314E03125F00DDD0099271A /* CardView.swift in Sources */,
 				5314E08925F00F2D0099271A /* CommandBarButtonGroupView.swift in Sources */,
 				5314E08C25F00F2D0099271A /* CommandBarButton.swift in Sources */,

--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -200,26 +200,26 @@ public extension FluentTheme {
 }
 
 extension FluentTheme {
-    static func defaultColors(_ token: FluentTheme.ColorToken) -> UIColor {
+    static func defaultColor(_ token: FluentTheme.ColorToken) -> UIColor {
         switch token {
         case .foreground1:
             return UIColor(light: GlobalTokens.neutralColor(.grey14),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white : GlobalTokens.neutralColor(.white))
+                           dark: GlobalTokens.neutralColor(.white))
         case .foreground2:
             return UIColor(light: GlobalTokens.neutralColor(.grey38),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white : GlobalTokens.neutralColor(.grey84))
+                           dark: GlobalTokens.neutralColor(.grey84))
         case .foreground3:
             return UIColor(light: GlobalTokens.neutralColor(.grey50),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white : GlobalTokens.neutralColor(.grey68))
+                           dark: GlobalTokens.neutralColor(.grey68))
         case .foregroundDisabled1:
             return UIColor(light: GlobalTokens.neutralColor(.grey74),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.8) : GlobalTokens.neutralColor(.grey36))
+                           dark: GlobalTokens.neutralColor(.grey36))
         case .foregroundDisabled2:
             return UIColor(light: GlobalTokens.neutralColor(.white),
                            dark: GlobalTokens.neutralColor(.grey18))
         case .foregroundOnColor:
             return UIColor(light: GlobalTokens.neutralColor(.white),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white : GlobalTokens.neutralColor(.black))
+                           dark: GlobalTokens.neutralColor(.black))
         case .brandForegroundTint:
             return UIColor(light: GlobalTokens.brandColor(.comm60),
                            dark: GlobalTokens.brandColor(.comm130))
@@ -254,32 +254,32 @@ extension FluentTheme {
                            dark: GlobalTokens.neutralColor(.white))
         case .background1:
             return UIColor(light: GlobalTokens.neutralColor(.white),
-                           dark: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.black),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey4))
+                           dark: GlobalTokens.neutralColor(.black),
+                           darkElevated: GlobalTokens.neutralColor(.grey4))
         case .background1Pressed:
             return UIColor(light: GlobalTokens.neutralColor(.grey88),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey18),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey18))
+                           dark: GlobalTokens.neutralColor(.grey18),
+                           darkElevated: GlobalTokens.neutralColor(.grey18))
         case .background1Selected:
             return UIColor(light: GlobalTokens.neutralColor(.grey92),
                            dark: GlobalTokens.neutralColor(.grey14),
                            darkElevated: GlobalTokens.neutralColor(.grey14))
         case .background2:
             return UIColor(light: GlobalTokens.neutralColor(.white),
-                           dark: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey12),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey16))
+                           dark: GlobalTokens.neutralColor(.grey12),
+                           darkElevated: GlobalTokens.neutralColor(.grey16))
         case .background2Pressed:
             return UIColor(light: GlobalTokens.neutralColor(.grey88),
-                           dark: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey30),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey30))
+                           dark: GlobalTokens.neutralColor(.grey30),
+                           darkElevated: GlobalTokens.neutralColor(.grey30))
         case .background2Selected:
             return UIColor(light: GlobalTokens.neutralColor(.grey92),
                            dark: GlobalTokens.neutralColor(.grey26),
                            darkElevated: GlobalTokens.neutralColor(.grey26))
         case .background3:
             return UIColor(light: GlobalTokens.neutralColor(.white),
-                           dark: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey16),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey20))
+                           dark: GlobalTokens.neutralColor(.grey16),
+                           darkElevated: GlobalTokens.neutralColor(.grey20))
         case .background3Pressed:
             return UIColor(light: GlobalTokens.neutralColor(.grey88),
                            dark: GlobalTokens.neutralColor(.grey34),
@@ -290,8 +290,8 @@ extension FluentTheme {
                            darkElevated: GlobalTokens.neutralColor(.grey30))
         case .background4:
             return UIColor(light: GlobalTokens.neutralColor(.grey98),
-                           dark: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey20),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey24))
+                           dark: GlobalTokens.neutralColor(.grey20),
+                           darkElevated: GlobalTokens.neutralColor(.grey24))
         case .background4Pressed:
             return UIColor(light: GlobalTokens.neutralColor(.grey86),
                            dark: GlobalTokens.neutralColor(.grey38),
@@ -302,12 +302,12 @@ extension FluentTheme {
                            darkElevated: GlobalTokens.neutralColor(.grey34))
         case .background5:
             return UIColor(light: GlobalTokens.neutralColor(.grey94),
-                           dark: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.2) : GlobalTokens.neutralColor(.grey24),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.2) : GlobalTokens.neutralColor(.grey28))
+                           dark: GlobalTokens.neutralColor(.grey24),
+                           darkElevated: GlobalTokens.neutralColor(.grey28))
         case .background5Pressed:
             return UIColor(light: GlobalTokens.neutralColor(.grey82),
-                           dark: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey42),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .black.withAlphaComponent(0.1) : GlobalTokens.neutralColor(.grey42))
+                           dark: GlobalTokens.neutralColor(.grey42),
+                           darkElevated: GlobalTokens.neutralColor(.grey42))
         case .background5Selected:
             return UIColor(light: GlobalTokens.neutralColor(.grey86),
                            dark: GlobalTokens.neutralColor(.grey38),
@@ -352,8 +352,8 @@ extension FluentTheme {
                            dark: GlobalTokens.neutralColor(.grey20))
         case .backgroundCanvas:
             return UIColor(light: GlobalTokens.neutralColor(.grey96),
-                           dark: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey8),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .clear : GlobalTokens.neutralColor(.grey14))
+                           dark: GlobalTokens.neutralColor(.grey8),
+                           darkElevated: GlobalTokens.neutralColor(.grey14))
         case .backgroundDarkStatic:
             return UIColor(light: GlobalTokens.neutralColor(.grey14),
                            dark: GlobalTokens.neutralColor(.grey24),
@@ -372,15 +372,15 @@ extension FluentTheme {
                            darkElevated: GlobalTokens.neutralColor(.grey42))
         case .stroke1:
             return UIColor(light: GlobalTokens.neutralColor(.grey82),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.4) : GlobalTokens.neutralColor(.grey30),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.4) : GlobalTokens.neutralColor(.grey36))
+                           dark: GlobalTokens.neutralColor(.grey30),
+                           darkElevated: GlobalTokens.neutralColor(.grey36))
         case .stroke1Pressed:
             return UIColor(light: GlobalTokens.neutralColor(.grey70),
                            dark: GlobalTokens.neutralColor(.grey48))
         case .stroke2:
             return UIColor(light: GlobalTokens.neutralColor(.grey88),
-                           dark: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.5) : GlobalTokens.neutralColor(.grey24),
-                           darkElevated: Compatibility.isDeviceIdiomVision() ? .white.withAlphaComponent(0.5) : GlobalTokens.neutralColor(.grey30))
+                           dark: GlobalTokens.neutralColor(.grey24),
+                           darkElevated: GlobalTokens.neutralColor(.grey30))
         case .strokeAccessible:
             return UIColor(light: GlobalTokens.neutralColor(.grey38),
                            dark: GlobalTokens.neutralColor(.grey62),
@@ -415,7 +415,7 @@ extension FluentTheme {
                            dark: GlobalTokens.sharedColor(.red, .tint30))
         case .dangerForeground2:
             return UIColor(light: GlobalTokens.sharedColor(.red, .primary),
-                           dark: Compatibility.isDeviceIdiomVision() ? GlobalTokens.sharedColor(.red, .primary) : GlobalTokens.sharedColor(.red, .tint30))
+                           dark: GlobalTokens.sharedColor(.red, .tint30))
         case .dangerStroke1:
             return UIColor(light: GlobalTokens.sharedColor(.red, .tint20),
                            dark: GlobalTokens.sharedColor(.red, .tint20))
@@ -481,7 +481,7 @@ extension FluentTheme {
         }
     }
 
-    static func defaultShadows(_ token: ShadowToken) -> ShadowInfo {
+    static func defaultShadow(_ token: ShadowToken) -> ShadowInfo {
         switch token {
         case .clear:
             return ShadowInfo(keyColor: .clear,
@@ -603,7 +603,7 @@ extension FluentTheme {
     }
 
     /// Derives its default values from the theme's `colorTokenSet` values
-    static func defaultGradientColors(_ token: GradientToken, colorTokenSet: TokenSet<ColorToken, UIColor>) -> [UIColor] {
+    static func defaultGradientColor(_ token: GradientToken, colorTokenSet: TokenSet<ColorToken, UIColor>) -> [UIColor] {
         switch token {
         case .flair:
             return [colorTokenSet[.brandGradient1],

--- a/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+#if os(visionOS)
+extension FluentTheme {
+    static func defaultColor_visionOS(_ token: FluentTheme.ColorToken) -> UIColor {
+        // Apply overrides as needed. Note that visionOS only supports one mode, so there's no
+        // need to provide multiple values (e.g. light + dark, elevated, etc).
+        switch token {
+        case .foreground1:
+            return .white
+        case .foreground2:
+            return .white
+        case .foreground3:
+            return .white
+        case .foregroundDisabled1:
+            return .white.withAlphaComponent(0.8)
+        case .foregroundOnColor:
+            return .white
+        case .background1:
+            return .clear
+        case .background1Pressed:
+            return .white.withAlphaComponent(0.1)
+        case .background2:
+            return .black.withAlphaComponent(0.1)
+        case .background2Pressed:
+            return .clear
+        case .background3:
+            return .black.withAlphaComponent(0.1)
+        case .background4:
+            return .clear
+        case .background5:
+            return .black.withAlphaComponent(0.2)
+        case .background5Pressed:
+            return .black.withAlphaComponent(0.1)
+        case .backgroundCanvas:
+            return .clear
+        case .stroke1:
+            return .white.withAlphaComponent(0.4)
+        case .stroke2:
+            return .white.withAlphaComponent(0.5)
+        case .dangerForeground2:
+            return GlobalTokens.sharedColor(.red, .primary)
+
+        default:
+            // Return the standard iOS color by default.
+            return defaultColor(token)
+        }
+    }
+}
+#endif

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -42,12 +42,19 @@ public class FluentTheme: NSObject, ObservableObject {
             return FontInfo(name: font.fontName, size: font.pointSize)
         })
 
-        let colorTokenSet = TokenSet<ColorToken, UIColor>(FluentTheme.defaultColors(_:), colorOverrides)
-        let shadowTokenSet = TokenSet<ShadowToken, ShadowInfo>(FluentTheme.defaultShadows(_:), shadowOverrides)
+#if os(visionOS)
+        // We have custom overrides for `defaultColors` in visionOS.
+        let defaultColorFunction = FluentTheme.defaultColor_visionOS(_:)
+#else
+        let defaultColorFunction = FluentTheme.defaultColor(_:)
+#endif
+
+        let colorTokenSet = TokenSet<ColorToken, UIColor>(defaultColorFunction, colorOverrides)
+        let shadowTokenSet = TokenSet<ShadowToken, ShadowInfo>(FluentTheme.defaultShadow(_:), shadowOverrides)
         let typographyTokenSet = TokenSet<TypographyToken, FontInfo>(FluentTheme.defaultTypography(_:), mappedTypographyOverrides)
         let gradientTokenSet = TokenSet<GradientToken, [UIColor]>({ [colorTokenSet] token in
             // Reference the colorTokenSet as part of the gradient lookup
-            return FluentTheme.defaultGradientColors(token, colorTokenSet: colorTokenSet)
+            return FluentTheme.defaultGradientColor(token, colorTokenSet: colorTokenSet)
         })
 
         self.colorTokenSet = colorTokenSet


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Separate out Fluent theme tokens for visionOS into a separate file. This has two obvious advantages:
* Cleaning up the token values for both iOS and visionOS, making them easier to read and update.
* The chance to determine tokens at *build* time rather than *run* time, reducing binary size.

### Binary change

Total increase: 12,944 bytes
Total decrease: -25,976 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,057,904 bytes | 31,044,872 bytes | 🎉 -13,032 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentTheme+visionOS.o | 0 bytes | 11,112 bytes | ⚠️ 11,112 bytes |
| __.SYMDEF | 4,826,352 bytes | 4,827,016 bytes | ⚠️ 664 bytes |
| FluentTheme.o | 201,744 bytes | 202,056 bytes | ⚠️ 312 bytes |
| TableViewCellTokenSet.o | 114,248 bytes | 114,416 bytes | ⚠️ 168 bytes |
| TableViewCell.o | 815,000 bytes | 815,152 bytes | ⚠️ 152 bytes |
| SideTabBarTokenSet.o | 54,864 bytes | 54,968 bytes | ⚠️ 104 bytes |
| SearchBarTokenSet.o | 81,208 bytes | 81,304 bytes | ⚠️ 96 bytes |
| TableViewHeaderFooterViewTokenSet.o | 83,488 bytes | 83,552 bytes | ⚠️ 64 bytes |
| ButtonTokenSet.o | 126,048 bytes | 126,112 bytes | ⚠️ 64 bytes |
| PopupMenuItemCell.o | 176,800 bytes | 176,848 bytes | ⚠️ 48 bytes |
| TabBarView.o | 138,384 bytes | 138,432 bytes | ⚠️ 48 bytes |
| FocusRingView.o | 819,880 bytes | 819,928 bytes | ⚠️ 48 bytes |
| ShyHeaderController.o | 261,800 bytes | 261,840 bytes | ⚠️ 40 bytes |
| DatePickerController.o | 322,952 bytes | 322,960 bytes | ⚠️ 8 bytes |
| FluentUIFramework.o | 76,544 bytes | 76,552 bytes | ⚠️ 8 bytes |
| NavigationBarTokenSet.o | 72,304 bytes | 72,312 bytes | ⚠️ 8 bytes |
| BadgeView.o | 624,864 bytes | 624,760 bytes | 🎉 -104 bytes |
| FluentTheme+Tokens.o | 174,488 bytes | 148,616 bytes | 🎉 -25,872 bytes |
</details>

### Verification

Ensured that the correct tokens are still being loaded for both iOS and visionOS.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/4934719/48045382-0abf-477c-af67-d0c98744eb81) | ![after](https://github.com/microsoft/fluentui-apple/assets/4934719/bbe2d8d5-1c1b-4971-9e9a-d98e7b6f95e4) | 
| ![before](https://github.com/microsoft/fluentui-apple/assets/4934719/0a837cf6-db9c-431a-b7e3-b0e6072d74ec) | ![after](https://github.com/microsoft/fluentui-apple/assets/4934719/b17938e3-2b69-4fe9-864c-8d9c19bb2792) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1980)