### PR TITLE
Update TableViewCell backgroundConfiguration to reflect style

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1971,7 +1971,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
     private func setupBackgroundColors() {
         if backgroundStyleType != .custom {
             automaticallyUpdatesBackgroundConfiguration = false
-            var backgroundConfiguration = UIBackgroundConfiguration.clear()
+            var backgroundConfiguration: UIBackgroundConfiguration
+            if backgroundStyleType == .plain {
+                backgroundConfiguration = .listPlainCell()
+            } else if backgroundStyleType == .grouped {
+                backgroundConfiguration = .listGroupedCell()
+            } else {
+                backgroundConfiguration = .clear()
+            }
             backgroundConfiguration.backgroundColor = backgroundStyleType.defaultColor(tokenSet: tokenSet)
             self.backgroundConfiguration = backgroundConfiguration
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

`TableViewCell` currently uses `UIBackgroundConfiguration.clear()` regardless of what style the cell is. This is fine on iOS. On visionOS, this means that plain cells have rectangular corners when they should have rounded ones. Update `backgroundConfiguration` to reflect the cell style.

### Binary change

(This feels wrong to me but I double checked it)

Total increase: 104 bytes
Total decrease: -21,464 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,908,368 bytes | 30,887,008 bytes | 🎉 -21,360 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| PersonaCell.o | 62,744 bytes | 62,848 bytes | ⚠️ 104 bytes |
| FocusRingView.o | 815,288 bytes | 815,176 bytes | 🎉 -112 bytes |
| __.SYMDEF | 4,774,672 bytes | 4,772,600 bytes | 🎉 -2,072 bytes |
| TableViewCell.o | 812,456 bytes | 809,560 bytes | 🎉 -2,896 bytes |
| BooleanCell.o | 89,864 bytes | 86,400 bytes | 🎉 -3,464 bytes |
| BottomCommandingController.o | 846,336 bytes | 842,832 bytes | 🎉 -3,504 bytes |
| PersonaListView.o | 185,616 bytes | 182,072 bytes | 🎉 -3,544 bytes |
| PopupMenuItemCell.o | 176,080 bytes | 170,208 bytes | 🎉 -5,872 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/1c6adf83-b603-4832-8c18-047042ce7ec2) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/fbc9591b-d354-408d-a57c-27ebb134c037) |
| ![plain light before](https://github.com/microsoft/fluentui-apple/assets/55368679/7899e1dd-7d94-48a9-847c-d78d2af5010d) | ![plain light after](https://github.com/microsoft/fluentui-apple/assets/55368679/b8f0d69d-1922-40bf-a398-be13278a5298) |
| ![plain dark before](https://github.com/microsoft/fluentui-apple/assets/55368679/f93cfacf-de48-48c5-b3a9-43e70fc80b1f) | ![plain dark after](https://github.com/microsoft/fluentui-apple/assets/55368679/4f1b17dd-7dcb-4d39-bedc-5767208664b1) |
| ![grouped light before](https://github.com/microsoft/fluentui-apple/assets/55368679/fd85b971-f3e6-4538-a941-aa5b5f9a6fcb) | ![grouped light after](https://github.com/microsoft/fluentui-apple/assets/55368679/8a12f682-56d4-4b1a-a5ce-4aa714f188f8) |
| ![grouped dark before](https://github.com/microsoft/fluentui-apple/assets/55368679/b1d2978c-d1bf-4ea0-977f-da3f00066d7d) | ![grouped dark after](https://github.com/microsoft/fluentui-apple/assets/55368679/3c2f082f-2312-4d0b-a7c1-6f267c4063f1) |
| ![override before](https://github.com/microsoft/fluentui-apple/assets/55368679/e9ddfa8f-a3d8-4055-b4a6-3fd5c9acb267) | ![override after](https://github.com/microsoft/fluentui-apple/assets/55368679/cefd2cf0-5a17-47bd-b6ac-ab9ad0ebb5af) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1981)