### PR TITLE
Fix a crash in visionOS when nesting `.onChange` inside `#available`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/SwiftUI/View+Extensions.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/SwiftUI/View+Extensions.swift
@@ -14,6 +14,13 @@ extension View {
     ///   - action: A closure to run when the value changes.
     /// - Returns: A view that fires an action when the specified value changes.
     func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
+#if os(visionOS)
+        // Known bug when using #available and self.onChange together in visionOS: it'll crash!
+        // So for this OS, just use the new .onChange unconditionally.
+        return self.onChange(of: value) { _, newValue in
+            return action(newValue)
+        }
+#else
         if #available(iOS 17, *) {
             return self.onChange(of: value) { _, newValue in
                 return action(newValue)
@@ -21,5 +28,6 @@ extension View {
         } else {
             return self.onChange(of: value, perform: action)
         }
+#endif
     }
 }

--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -67,6 +67,13 @@ extension View {
     ///   - action: A closure to run when the value changes.
     /// - Returns: A view that fires an action when the specified value changes.
     func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
+#if os(visionOS)
+        // Known bug when using #available and self.onChange together in visionOS: it'll crash!
+        // So for this OS, just use the new .onChange unconditionally.
+        return self.onChange(of: value) { _, newValue in
+            return action(newValue)
+        }
+#else
         if #available(iOS 17, *) {
             return self.onChange(of: value) { _, newValue in
                 return action(newValue)
@@ -74,6 +81,7 @@ extension View {
         } else {
             return self.onChange(of: value, perform: action)
         }
+#endif
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

No change to iOS binary, as the check is build-time rather than run-time.

Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,024,864 bytes | 31,024,864 bytes | 🎉 0 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
</details>


### Verification

No crash when using onChange in visionOS.

https://github.com/microsoft/fluentui-apple/assets/4934719/5b0fc72e-2b22-437f-93ac-45b4b5c92036

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1984)