### PR TITLE
DrawerController escape accessibility

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -588,6 +588,16 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         }
     }
 
+	@objc func handleEscapeKey() {
+		dismissPresentingViewController(animated: true)
+	}
+
+	open override var keyCommands: [UIKeyCommand]? {
+		return [
+			UIKeyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [], action: #selector(self.handleEscapeKey))
+		]
+	}
+
     open override func accessibilityPerformEscape() -> Bool {
         return dismissPresentingViewController(animated: true)
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Users navigating with the Full Keyboard Access accessibility feature can get stranded in a DrawerController with no way to escape. We should not assume that every implementation of the DrawerController will include an explicit dismiss button but support the Escape key for dismissal, similar to other Apple controls.

### Binary change

N/A

### Verification

Validated using full keyboard access

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Escape key does not work | Here I am pressing the escape key and you can see we dismiss

![EscapeKeyDismiss](https://github.com/microsoft/fluentui-apple/assets/70173161/a2f78661-201d-4db3-b9c2-2d37e4ea88d0) |

</details>

### Pull request checklist

This PR has considered:
- N/A Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- N/A Internationalization and Right to Left layouts
- N/A Different resolutions (1x, 2x, 3x)
- N/A Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- N/A iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- N/A [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- N/A Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1985)