### PR TITLE
[SwiftUI] FluentButtonStyle

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		8F0B81122670200300463726 /* AppCenterDistribute in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = 8F0B81112670200300463726 /* AppCenterDistribute */; };
 		8F0B8114267021A700463726 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = 8F0B8113267021A700463726 /* AppCenterAnalytics */; };
 		8F0B8116267021A700463726 /* AppCenterCrashes in Frameworks */ = {isa = PBXBuildFile; platformFilter = ios; productRef = 8F0B8115267021A700463726 /* AppCenterCrashes */; };
+		92279B352B97F5DA00994D88 /* ButtonDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92279B342B97F5D900994D88 /* ButtonDemoController_SwiftUI.swift */; };
 		923DF2DB271158C900637646 /* libFluentUI.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 923DF2DA271158C900637646 /* libFluentUI.a */; };
 		923DF2DF27115B4700637646 /* FluentUIResources-ios.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 923DF2DC271158CD00637646 /* FluentUIResources-ios.bundle */; };
 		9245E1F927BECDBB007616F3 /* GlobalColorTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */; };
@@ -220,6 +221,7 @@
 		807E8B4428F9F8B8002B8F84 /* PillButtonDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PillButtonDemoController.swift; sourceTree = "<group>"; };
 		80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomCommandingDemoController.swift; sourceTree = "<group>"; };
 		80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetDemoController.swift; sourceTree = "<group>"; };
+		92279B342B97F5D900994D88 /* ButtonDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		923DF2DA271158C900637646 /* libFluentUI.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libFluentUI.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		923DF2DC271158CD00637646 /* FluentUIResources-ios.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = "FluentUIResources-ios.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalColorTokensDemoController.swift; sourceTree = "<group>"; };
@@ -520,6 +522,7 @@
 				80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */,
 				80B1F7002628D8BB004DFEE5 /* BottomSheetDemoController.swift */,
 				B4D852DA225C010A004B1B29 /* ButtonDemoController.swift */,
+				92279B342B97F5D900994D88 /* ButtonDemoController_SwiftUI.swift */,
 				92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */,
 				CCC18C2E2501C75F00BE830E /* CardViewDemoController.swift */,
 				9245E1F827BECDBB007616F3 /* GlobalColorTokensDemoController.swift */,
@@ -838,6 +841,7 @@
 				E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */,
 				EC24DBC628B97EB70026EF92 /* PopupMenuObjCDemoController.m in Sources */,
 				53097D3C27028AD000A6E4DC /* HUDDemoController.swift in Sources */,
+				92279B352B97F5DA00994D88 /* ButtonDemoController_SwiftUI.swift in Sources */,
 				3ADA2E1D29C515890020434A /* MultilineCommandBarDemoController.swift in Sources */,
 				92E977B826C7144F008E10A8 /* DemoControllerScrollView.swift in Sources */,
 				92E977B726C7144F008E10A8 /* UIResponder+Extensions.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -13,6 +13,9 @@ class ButtonDemoController: DemoController {
 
         container.alignment = .leading
 
+        addTitle(text: "SwiftUI Demo")
+        container.addArrangedSubview(createButton(title: "Show", action: #selector(showSwiftUIDemo)))
+
         for style in ButtonStyle.allCases {
             for size in ButtonSizeCategory.allCases {
                 if style.isFloating && size == .medium {
@@ -246,5 +249,10 @@ extension ButtonDemoController: DemoAppearanceDelegate {
                                dark: GlobalTokens.sharedColor(.orchid, .shade30))
             }
         ]
+    }
+
+    @objc private func showSwiftUIDemo() {
+        navigationController?.pushViewController(ButtonDemoControllerSwiftUI(),
+                                                 animated: true)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift
@@ -13,7 +13,7 @@ class ButtonDemoController: DemoController {
 
         container.alignment = .leading
 
-        addTitle(text: "SwiftUI Demo")
+        addTitle(text: "SwiftUI Button Demo")
         container.addArrangedSubview(createButton(title: "Show", action: #selector(showSwiftUIDemo)))
 
         for style in ButtonStyle.allCases {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -1,0 +1,123 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import SwiftUI
+import UIKit
+
+class ButtonDemoControllerSwiftUI: UIHostingController<ButtonDemoView> {
+    override init?(coder aDecoder: NSCoder, rootView: ButtonDemoView) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    init() {
+        super.init(rootView: ButtonDemoView())
+        self.title = "Button (SwiftUI)"
+    }
+}
+
+struct ButtonDemoView: View {
+    @State var isDisabled: Bool = false
+    @State var text: String = "Button"
+    @State var showImage: Bool = true
+    @State var showLabel: Bool = true
+    @State var showAlert: Bool = false
+    @State var size: FluentUI.ButtonSizeCategory = .large
+    @State var style: FluentUI.ButtonStyle = .accent
+
+    public var body: some View {
+        VStack {
+            Button(action: {
+                showAlert = true
+                // TODO: add a real theme switcher to the demo controller
+//                DemoColorTheme.currentAppWideTheme = .purple
+            }, label: {
+                HStack {
+                    if showImage {
+                        Image("Placeholder_24")
+                    }
+                    if showLabel {
+                        Text(text)
+                    }
+                }
+            })
+            .buttonStyle(FluentButtonStyle(style: style, size: size))
+            .disabled(isDisabled)
+            .fixedSize()
+            .padding()
+            .alert(isPresented: $showAlert, content: {
+                Alert(title: Text("Button tapped"))
+            })
+
+            ScrollView {
+                Group {
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Content")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        TextField("Text", text: $text)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                        FluentUIDemoToggle(titleKey: "Show image", isOn: $showImage)
+                        FluentUIDemoToggle(titleKey: "Show label", isOn: $showLabel)
+                        FluentUIDemoToggle(titleKey: "Disable", isOn: $isDisabled)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Style")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $style, label: EmptyView()) {
+                            Text("accent").tag(FluentUI.ButtonStyle.accent)
+                            Text("outlineAccent").tag(FluentUI.ButtonStyle.outlineAccent)
+                            Text("outlineNeutral").tag(FluentUI.ButtonStyle.outlineNeutral)
+                            Text("subtle").tag(FluentUI.ButtonStyle.subtle)
+                            Text("transparentNeutral").tag(FluentUI.ButtonStyle.transparentNeutral)
+                            Text("danger").tag(FluentUI.ButtonStyle.danger)
+                            Text("dangerOutline").tag(FluentUI.ButtonStyle.dangerOutline)
+                            Text("dangerSubtle").tag(FluentUI.ButtonStyle.dangerSubtle)
+                            Text("floatingAccent").tag(FluentUI.ButtonStyle.floatingAccent)
+                            Text("floatingSubtle").tag(FluentUI.ButtonStyle.floatingSubtle)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Group {
+                        VStack(spacing: 0) {
+                            Text("Size")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title)
+                            Divider()
+                        }
+
+                        Picker(selection: $size, label: EmptyView()) {
+                            Text(".large").tag(FluentUI.ButtonSizeCategory.large)
+                            Text(".medium").tag(FluentUI.ButtonSizeCategory.medium)
+                            Text(".small").tag(FluentUI.ButtonSizeCategory.small)
+                        }
+                        .labelsHidden()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -63,6 +63,13 @@ extension ButtonDemoControllerSwiftUI: UIPopoverPresentationControllerDelegate {
 }
 
 struct ButtonDemoView: View {
+    public var body: some View {
+        VStack {
+            demoButton(style, size, isDisabled: isDisabled)
+            demoOptions
+        }
+    }
+
     @State var isDisabled: Bool = false
     @State var text: String = "Button"
     @State var showImage: Bool = true
@@ -71,15 +78,10 @@ struct ButtonDemoView: View {
     @State var size: ControlSize = .large
     @State var style: FluentUI.ButtonStyle = .accent
 
-    public var body: some View {
-        VStack {
-            demoButton
-            demoOptions
-        }
-    }
+    @Environment(\.fluentTheme) var fluentTheme: FluentTheme
 
     @ViewBuilder
-    private var demoButton: some View {
+    private func demoButton(_ buttonStyle: FluentUI.ButtonStyle, _ controlSize: ControlSize, isDisabled: Bool) -> some View {
         Button(action: {
             showAlert = true
         }, label: {
@@ -92,11 +94,11 @@ struct ButtonDemoView: View {
                 }
             }
         })
-        .buttonStyle(FluentButtonStyle(style: style))
-        .controlSize(size)
+        .buttonStyle(FluentButtonStyle(style: buttonStyle))
+        .controlSize(controlSize)
         .disabled(isDisabled)
         .fixedSize()
-        .padding()
+        .padding(8.0)
         .alert(isPresented: $showAlert, content: {
             Alert(title: Text("Button tapped"))
         })
@@ -132,6 +134,29 @@ struct ButtonDemoView: View {
                     ForEach(Array(SwiftUI.ControlSize.allCases.enumerated()), id: \.element) { _, buttonSize in
                         Text("\(buttonSize.description)").tag(buttonSize)
                     }
+                }
+            }
+
+            Section("More") {
+                NavigationLink("All Button Styles") {
+                    allButtonStyles
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var allButtonStyles: some View {
+        ScrollView {
+            ForEach(Array(FluentUI.ButtonStyle.allCases.enumerated()), id: \.element) { _, buttonStyle in
+                Text("\(buttonStyle.description)")
+                    .font(Font(fluentTheme.typography(.title2)))
+                ForEach(Array([ControlSize.small, ControlSize.regular, ControlSize.large].enumerated()), id: \.element) { _, controlSize in
+                    HStack {
+                        demoButton(buttonStyle, controlSize, isDisabled: false)
+                        demoButton(buttonStyle, controlSize, isDisabled: true)
+                    }
+                    .frame(maxWidth: .infinity)
                 }
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -68,7 +68,7 @@ struct ButtonDemoView: View {
     @State var showImage: Bool = true
     @State var showLabel: Bool = true
     @State var showAlert: Bool = false
-    @State var size: FluentUI.ButtonSizeCategory = .large
+    @State var size: ControlSize = .large
     @State var style: FluentUI.ButtonStyle = .accent
 
     public var body: some View {
@@ -92,7 +92,8 @@ struct ButtonDemoView: View {
                 }
             }
         })
-        .buttonStyle(FluentButtonStyle(style: style, size: size))
+        .buttonStyle(FluentButtonStyle(style: style))
+        .controlSize(size)
         .disabled(isDisabled)
         .fixedSize()
         .padding()
@@ -120,21 +121,38 @@ struct ButtonDemoView: View {
                 FluentUIDemoToggle(titleKey: "Disabled", isOn: $isDisabled)
             }
 
-            Section("Style") {
+            Section("Style and Size") {
                 Picker("Style", selection: $style) {
                     ForEach(Array(FluentUI.ButtonStyle.allCases.enumerated()), id: \.element) { _, buttonStyle in
                         Text("\(buttonStyle.description)").tag(buttonStyle.rawValue)
                     }
                 }
-            }
 
-            Section("Size") {
-                Picker("Size", selection: $size) {
-                    ForEach(Array(FluentUI.ButtonSizeCategory.allCases.enumerated()), id: \.element) { _, buttonSize in
-                        Text("\(buttonSize.description)").tag(buttonSize.rawValue)
+                Picker("Control Size", selection: $size) {
+                    ForEach(Array(SwiftUI.ControlSize.allCases.enumerated()), id: \.element) { _, buttonSize in
+                        Text("\(buttonSize.description)").tag(buttonSize)
                     }
                 }
             }
+        }
+    }
+}
+
+private extension ControlSize {
+    var description: String {
+        switch self {
+        case .mini:
+            return "mini"
+        case .small:
+            return "small"
+        case .regular:
+            return "regular"
+        case .large:
+            return "large"
+        case .extraLarge:
+            return "extraLarge"
+        @unknown default:
+            return "UNKNOWN"
         }
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -33,90 +33,69 @@ struct ButtonDemoView: View {
 
     public var body: some View {
         VStack {
-            Button(action: {
-                showAlert = true
-                // TODO: add a real theme switcher to the demo controller
-//                DemoColorTheme.currentAppWideTheme = .purple
-            }, label: {
-                HStack {
-                    if showImage {
-                        Image("Placeholder_24")
-                    }
-                    if showLabel {
-                        Text(text)
+            demoButton
+            demoOptions
+        }
+    }
+
+    @ViewBuilder
+    private var demoButton: some View {
+        Button(action: {
+            showAlert = true
+            // TODO: add a real theme switcher to the demo controller
+//            DemoColorTheme.currentAppWideTheme = .purple
+        }, label: {
+            HStack {
+                if showImage {
+                    Image("Placeholder_24")
+                }
+                if showLabel && text.count > 0 {
+                    Text(text)
+                }
+            }
+        })
+        .buttonStyle(FluentButtonStyle(style: style, size: size))
+        .disabled(isDisabled)
+        .fixedSize()
+        .padding()
+        .alert(isPresented: $showAlert, content: {
+            Alert(title: Text("Button tapped"))
+        })
+    }
+
+    @ViewBuilder
+    private var demoOptions: some View {
+        Form {
+            Section("Content") {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Button Text")
+                    Spacer()
+                    TextField("Text", text: $text)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .multilineTextAlignment(.trailing)
+                }
+                .frame(maxWidth: .infinity)
+
+                FluentUIDemoToggle(titleKey: "Show image", isOn: $showImage)
+                FluentUIDemoToggle(titleKey: "Show label", isOn: $showLabel)
+                FluentUIDemoToggle(titleKey: "Disabled", isOn: $isDisabled)
+            }
+
+            Section("Style") {
+                Picker("Style", selection: $style) {
+                    ForEach(Array(FluentUI.ButtonStyle.allCases.enumerated()), id: \.element) { _, buttonStyle in
+                        Text("\(buttonStyle.description)").tag(buttonStyle.rawValue)
                     }
                 }
-            })
-            .buttonStyle(FluentButtonStyle(style: style, size: size))
-            .disabled(isDisabled)
-            .fixedSize()
-            .padding()
-            .alert(isPresented: $showAlert, content: {
-                Alert(title: Text("Button tapped"))
-            })
+            }
 
-            ScrollView {
-                Group {
-                    Group {
-                        VStack(spacing: 0) {
-                            Text("Content")
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .font(.title)
-                            Divider()
-                        }
-
-                        TextField("Text", text: $text)
-                            .autocapitalization(.none)
-                            .disableAutocorrection(true)
-                            .textFieldStyle(RoundedBorderTextFieldStyle())
-
-                        FluentUIDemoToggle(titleKey: "Show image", isOn: $showImage)
-                        FluentUIDemoToggle(titleKey: "Show label", isOn: $showLabel)
-                        FluentUIDemoToggle(titleKey: "Disable", isOn: $isDisabled)
-                    }
-
-                    Group {
-                        VStack(spacing: 0) {
-                            Text("Style")
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .font(.title)
-                            Divider()
-                        }
-
-                        Picker(selection: $style, label: EmptyView()) {
-                            Text("accent").tag(FluentUI.ButtonStyle.accent)
-                            Text("outlineAccent").tag(FluentUI.ButtonStyle.outlineAccent)
-                            Text("outlineNeutral").tag(FluentUI.ButtonStyle.outlineNeutral)
-                            Text("subtle").tag(FluentUI.ButtonStyle.subtle)
-                            Text("transparentNeutral").tag(FluentUI.ButtonStyle.transparentNeutral)
-                            Text("danger").tag(FluentUI.ButtonStyle.danger)
-                            Text("dangerOutline").tag(FluentUI.ButtonStyle.dangerOutline)
-                            Text("dangerSubtle").tag(FluentUI.ButtonStyle.dangerSubtle)
-                            Text("floatingAccent").tag(FluentUI.ButtonStyle.floatingAccent)
-                            Text("floatingSubtle").tag(FluentUI.ButtonStyle.floatingSubtle)
-                        }
-                        .labelsHidden()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-
-                    Group {
-                        VStack(spacing: 0) {
-                            Text("Size")
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .font(.title)
-                            Divider()
-                        }
-
-                        Picker(selection: $size, label: EmptyView()) {
-                            Text(".large").tag(FluentUI.ButtonSizeCategory.large)
-                            Text(".medium").tag(FluentUI.ButtonSizeCategory.medium)
-                            Text(".small").tag(FluentUI.ButtonSizeCategory.small)
-                        }
-                        .labelsHidden()
-                        .frame(maxWidth: .infinity, alignment: .leading)
+            Section("Size") {
+                Picker("Size", selection: $size) {
+                    ForEach(Array(FluentUI.ButtonSizeCategory.allCases.enumerated()), id: \.element) { _, buttonSize in
+                        Text("\(buttonSize.description)").tag(buttonSize.rawValue)
                     }
                 }
-                .padding()
             }
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -7,18 +7,58 @@ import FluentUI
 import SwiftUI
 import UIKit
 
-class ButtonDemoControllerSwiftUI: UIHostingController<ButtonDemoView> {
-    override init?(coder aDecoder: NSCoder, rootView: ButtonDemoView) {
-        preconditionFailure("init(coder:) has not been implemented")
-    }
-
+class ButtonDemoControllerSwiftUI: FluentUIHostingController {
     @objc required dynamic init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
 
     init() {
-        super.init(rootView: ButtonDemoView())
+        super.init(rootView: AnyView(ButtonDemoView()))
         self.title = "Button (SwiftUI)"
+    }
+
+    @MainActor required dynamic init(rootView: AnyView) {
+        super.init(rootView: rootView)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureAppearanceAndReadmePopovers()
+    }
+
+    // MARK: - Demo Appearance Popover
+
+    func configureAppearanceAndReadmePopovers() {
+        let settingsButton = UIBarButtonItem(image: UIImage(named: "ic_fluent_settings_24_regular"),
+                                             style: .plain,
+                                             target: self,
+                                             action: #selector(showAppearancePopover(_:)))
+        navigationItem.rightBarButtonItems = [settingsButton]
+    }
+
+    @objc func showAppearancePopover(_ sender: AnyObject, presenter: UIViewController) {
+        if let barButtonItem = sender as? UIBarButtonItem {
+            appearanceController.popoverPresentationController?.barButtonItem = barButtonItem
+        } else if let sourceView = sender as? UIView {
+            appearanceController.popoverPresentationController?.sourceView = sourceView
+            appearanceController.popoverPresentationController?.sourceRect = sourceView.bounds
+        }
+        appearanceController.popoverPresentationController?.delegate = self
+        presenter.present(appearanceController, animated: true, completion: nil)
+    }
+
+    @objc func showAppearancePopover(_ sender: AnyObject) {
+        showAppearancePopover(sender, presenter: self)
+    }
+
+    private lazy var appearanceController: DemoAppearanceController = .init(delegate: self as? DemoAppearanceDelegate)
+
+}
+
+extension ButtonDemoControllerSwiftUI: UIPopoverPresentationControllerDelegate {
+    /// Overridden to allow for popover-style modal presentation on compact (e.g. iPhone) devices.
+    func adaptivePresentationStyle(for controller: UIPresentationController) -> UIModalPresentationStyle {
+        return .none
     }
 }
 
@@ -42,8 +82,6 @@ struct ButtonDemoView: View {
     private var demoButton: some View {
         Button(action: {
             showAlert = true
-            // TODO: add a real theme switcher to the demo controller
-//            DemoColorTheme.currentAppWideTheme = .purple
         }, label: {
             HStack {
                 if showImage {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -7,7 +7,7 @@ import FluentUI
 import SwiftUI
 import UIKit
 
-class ButtonDemoControllerSwiftUI: FluentUIHostingController {
+class ButtonDemoControllerSwiftUI: FluentThemedHostingController {
     @objc required dynamic init?(coder aDecoder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		92016FF8299DF34A00660DB7 /* EmptyTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92016FF7299DF34A00660DB7 /* EmptyTokenSet.swift */; };
 		92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92088EF72666DB2C003F571A /* PersonaButton.swift */; };
 		920945492703DDA000B38E1A /* CardNudgeTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920945472703DDA000B38E1A /* CardNudgeTokenSet.swift */; };
+		92279B332B97C7DC00994D88 /* FluentButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92279B322B97C7DC00994D88 /* FluentButtonStyle.swift */; };
 		922A34DF27BB87990062721F /* TokenizedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922A34DE27BB87990062721F /* TokenizedControlView.swift */; };
 		9231491128BF026A001B033E /* HeadsUpDisplayTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17F27FB6D9B00B01E0D /* HeadsUpDisplayTokenSet.swift */; };
 		9231491228BF026A001B033E /* HUDModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5336B17027F77EB700B01E0D /* HUDModifiers.swift */; };
@@ -347,6 +348,7 @@
 		92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeModifiers.swift; sourceTree = "<group>"; };
 		92088EF72666DB2C003F571A /* PersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButton.swift; sourceTree = "<group>"; };
 		920945472703DDA000B38E1A /* CardNudgeTokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeTokenSet.swift; sourceTree = "<group>"; };
+		92279B322B97C7DC00994D88 /* FluentButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentButtonStyle.swift; sourceTree = "<group>"; };
 		922A34DE27BB87990062721F /* TokenizedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenizedControlView.swift; sourceTree = "<group>"; };
 		9231F10229BB99090079CD94 /* FluentTheme+Tokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FluentTheme+Tokens.swift"; sourceTree = "<group>"; };
 		923DB9D2274CB65700D8E58A /* TokenizedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokenizedControl.swift; sourceTree = "<group>"; };
@@ -664,6 +666,7 @@
 			isa = PBXGroup;
 			children = (
 				A5CEC23020E451D00016922A /* Button.swift */,
+				92279B322B97C7DC00994D88 /* FluentButtonStyle.swift */,
 				EC65F78F292EDCEF002A1A23 /* ButtonTokenSet.swift */,
 			);
 			path = Button;
@@ -1560,6 +1563,7 @@
 				5314E12B25F016230099271A /* PillButtonBar.swift in Sources */,
 				5314E07E25F00F1A0099271A /* DateTimePickerView.swift in Sources */,
 				5328D97726FBA3D700F3723B /* IndeterminateProgressBar.swift in Sources */,
+				92279B332B97C7DC00994D88 /* FluentButtonStyle.swift in Sources */,
 				5314E07625F00F160099271A /* DateTimePickerController.swift in Sources */,
 				922A34DF27BB87990062721F /* TokenizedControlView.swift in Sources */,
 				92016FF8299DF34A00660DB7 /* EmptyTokenSet.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -666,8 +666,8 @@
 			isa = PBXGroup;
 			children = (
 				A5CEC23020E451D00016922A /* Button.swift */,
-				92279B322B97C7DC00994D88 /* FluentButtonStyle.swift */,
 				EC65F78F292EDCEF002A1A23 /* ButtonTokenSet.swift */,
+				92279B322B97C7DC00994D88 /* FluentButtonStyle.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -136,7 +136,7 @@
 		532FE3D426EA6D74007539C0 /* ActivityIndicatorTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3CE26EA6D73007539C0 /* ActivityIndicatorTokenSet.swift */; };
 		532FE3D626EA6D74007539C0 /* ActivityIndicatorModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3CF26EA6D73007539C0 /* ActivityIndicatorModifiers.swift */; };
 		532FE3D826EA6D74007539C0 /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 532FE3D026EA6D74007539C0 /* ActivityIndicator.swift */; };
-		535559E42711411E0094A871 /* FluentUIHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535559E22711411E0094A871 /* FluentUIHostingController.swift */; };
+		535559E42711411E0094A871 /* FluentThemedHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535559E22711411E0094A871 /* FluentThemedHostingController.swift */; };
 		5373D5652694D65C0032A3B4 /* AvatarTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D5602694D65C0032A3B4 /* AvatarTokenSet.swift */; };
 		5373D5672694D65C0032A3B4 /* Avatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D5612694D65C0032A3B4 /* Avatar.swift */; };
 		5373D56B2694D65C0032A3B4 /* MSFAvatarPresence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5373D5632694D65C0032A3B4 /* MSFAvatarPresence.swift */; };
@@ -301,7 +301,7 @@
 		5336B17327F77EB700B01E0D /* HeadsUpDisplay.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeadsUpDisplay.swift; sourceTree = "<group>"; };
 		5336B17427F77EB700B01E0D /* HUD.resources.xcfilelist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcfilelist; path = HUD.resources.xcfilelist; sourceTree = "<group>"; };
 		5336B17F27FB6D9B00B01E0D /* HeadsUpDisplayTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeadsUpDisplayTokenSet.swift; sourceTree = "<group>"; };
-		535559E22711411E0094A871 /* FluentUIHostingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentUIHostingController.swift; sourceTree = "<group>"; };
+		535559E22711411E0094A871 /* FluentThemedHostingController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentThemedHostingController.swift; sourceTree = "<group>"; };
 		5373D5602694D65C0032A3B4 /* AvatarTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarTokenSet.swift; sourceTree = "<group>"; };
 		5373D5612694D65C0032A3B4 /* Avatar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Avatar.swift; sourceTree = "<group>"; };
 		5373D5632694D65C0032A3B4 /* MSFAvatarPresence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MSFAvatarPresence.swift; sourceTree = "<group>"; };
@@ -1008,8 +1008,8 @@
 				D6296DAD295B7C9F002E8EB6 /* ColorProviding.swift */,
 				926FEEA92B45A8B4002C61D0 /* Compatibility.swift */,
 				923DB9D6274CB66D00D8E58A /* ControlHostingView.swift */,
+				535559E22711411E0094A871 /* FluentThemedHostingController.swift */,
 				A559BB82212B7D870055E107 /* FluentUIFramework.swift */,
-				535559E22711411E0094A871 /* FluentUIHostingController.swift */,
 				EC04E65729C27359005F8BA0 /* FocusRingView.swift */,
 				530D9C5227EE7B2C00BDCBBF /* SwiftUI+ViewAnimation.swift */,
 				5373D56F2694D66F0032A3B4 /* SwiftUI+ViewModifiers.swift */,
@@ -1612,7 +1612,7 @@
 				5314E30225F0260E0099271A /* AccessibilityContainerView.swift in Sources */,
 				8035CAD026377C17007B3FD1 /* CommandingItem.swift in Sources */,
 				5314E0F325F012C80099271A /* ShyHeaderController.swift in Sources */,
-				535559E42711411E0094A871 /* FluentUIHostingController.swift in Sources */,
+				535559E42711411E0094A871 /* FluentThemedHostingController.swift in Sources */,
 				3A9FC0F72A705C090060A6BE /* PeoplePickerTokenSet.swift in Sources */,
 				9231491628BF02B9001B033E /* Button.swift in Sources */,
 				5314E1B125F01A980099271A /* TooltipView.swift in Sources */,

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -128,8 +128,6 @@ public enum ButtonToken: Int, TokenSetKey {
 public class ButtonTokenSet: ControlTokenSet<ButtonToken> {
     init(style: @escaping () -> ButtonStyle,
          size: @escaping () -> ButtonSizeCategory) {
-        self.style = style
-        self.size = size
         super.init { [style, size] token, theme in
             switch token {
             case .backgroundColor:
@@ -298,9 +296,6 @@ public class ButtonTokenSet: ControlTokenSet<ButtonToken> {
             }
         }
     }
-
-    var style: () -> ButtonStyle
-    var size: () -> ButtonSizeCategory
 }
 
 extension ButtonTokenSet {

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -43,7 +43,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
 
         @ViewBuilder var backgroundView: some View {
             if isFloatingStyle {
-                foregroundColor.clipShape(Capsule())
+                backgroundColor.clipShape(Capsule())
             } else {
                 backgroundColor.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             }
@@ -63,7 +63,6 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
             }
         }
 
-        // TODO: why are floating buttons filled with the wrong color?
         return configuration.label
             .font(Font(tokenSet[.titleFont].uiFont))
             .foregroundStyle(foregroundColor)
@@ -72,6 +71,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
             .background(backgroundView)
             .overlay { overlayView }
             .applyShadow(shadowInfo: shadowInfo)
+            .pointerInteraction(isEnabled)
     }
 
     @ObservedObject private var tokenSet: ButtonTokenSet
@@ -95,100 +95,4 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     }
 
     private var isFloatingStyle: Bool { style.isFloating }
-
-//    @Environment(\.isEnabled) var isEnabled: Bool
-//    @Environment(\.isFocused) var isFocused: Bool
-//    @ObservedObject var tokenSet: ButtonTokenSet
-//
-//    var text: String?
-//    var image: Image?
-//    var style: FluentUI.ButtonStyle
-//    var sizeCategory: FluentUI.ButtonSizeCategory
-//
-//    func makeBody(configuration: Self.Configuration) -> some View {
-//        let isPressed = configuration.isPressed
-//        let isDisabled = !isEnabled
-//        let isFocused = isFocused
-//        let isFloatingStyle = style.isFloating
-//        let shouldUsePressedShadow = isDisabled || isPressed
-//        let verticalPadding = tokenSet[.minVerticalPadding].float
-//        let horizontalPadding = ButtonTokenSet.horizontalPadding(style: style, size: sizeCategory)
-//        let foregroundColor: Color
-//        let borderColor: Color
-//        let backgroundColor: Color
-//        if isDisabled {
-//            foregroundColor = Color(tokenSet[.foregroundDisabledColor].uiColor)
-//            borderColor = Color(tokenSet[.borderDisabledColor].uiColor)
-//            backgroundColor = Color(tokenSet[.backgroundDisabledColor].uiColor)
-//        } else if isPressed || isFocused {
-//            foregroundColor = Color(tokenSet[.foregroundPressedColor].uiColor)
-//            borderColor = Color(tokenSet[.borderPressedColor].uiColor)
-//            backgroundColor = Color(tokenSet[.backgroundPressedColor].uiColor)
-//        } else {
-//            foregroundColor = Color(tokenSet[.foregroundColor].uiColor)
-//            borderColor = Color(tokenSet[.borderColor].uiColor)
-//            backgroundColor = Color(tokenSet[.backgroundColor].uiColor)
-//        }
-//
-//        @ViewBuilder
-//        var buttonContent: some View {
-//            HStack(spacing: tokenSet[.interspace].float) {
-//                if let image {
-//                    image
-//                        .resizable()
-//                        .foregroundColor(foregroundColor)
-//                        .frame(width: tokenSet[.iconSize].float, height: tokenSet[.iconSize].float, alignment: .center)
-//                }
-//                if let text {
-//                    Text(text)
-//                        .multilineTextAlignment(.center)
-//                        .font(.init(tokenSet[.textFont].uiFont))
-//                        .frame(minHeight: isFloatingStyle ? tokenSet[.textMinimumHeight].float : nil)
-//                }
-//            }
-//            .padding(EdgeInsets(top: verticalPadding,
-//                                leading: horizontalPadding,
-//                                bottom: verticalPadding,
-//                                trailing: horizontalPadding))
-//            .modifyIf(isFloatingStyle && !(text?.isEmpty ?? true), { view in
-//                view.padding(.horizontal, tokenSet[.textAdditionalHorizontalPadding].float )
-//            })
-//            .frame(maxWidth: .infinity, minHeight: tokenSet[.minHeight].float, maxHeight: .infinity)
-//            .foregroundColor(foregroundColor)
-//        }
-//
-//        @ViewBuilder
-//        var buttonBackground: some View {
-//            if tokenSet[.borderWidth].float > 0 {
-//                buttonContent.background(
-//                    RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
-//                        .strokeBorder(lineWidth: tokenSet[.borderWidth].float, antialiased: false)
-//                        .foregroundColor(borderColor)
-//                        .contentShape(Rectangle()))
-//            } else {
-//                buttonContent.background(
-//                    RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
-//                        .fill(backgroundColor))
-//            }
-//        }
-//
-//        let shadowInfo = (shouldUsePressedShadow ? tokenSet[.shadowPressed] : tokenSet[.shadowRest]).shadowInfo
-//
-//        @ViewBuilder
-//        var button: some View {
-//            if isFloatingStyle {
-//                buttonBackground
-//                    .clipShape(Capsule())
-//                    .applyShadow(shadowInfo: shadowInfo)
-//                    .contentShape(Capsule())
-//            } else {
-//                buttonBackground
-//                    .contentShape(RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
-//            }
-//        }
-//
-//        return button
-//            .pointerInteraction(isEnabled)
-//    }
-//
 }

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -11,11 +11,12 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     public init(style: ButtonStyle, size: ButtonSizeCategory) {
         self.style = style
         self.size = size
-        self.tokenSet = ButtonTokenSet(style: { style }, size: { size })
     }
 
     public func makeBody(configuration: Configuration) -> some View {
+        let tokenSet = ButtonTokenSet(style: { style }, size: { size })
         tokenSet.update(fluentTheme)
+
         let isPressed = configuration.isPressed
         let isDisabled = !isEnabled
         let isFocused = isFocused
@@ -50,7 +51,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
         }
 
         @ViewBuilder var overlayView: some View {
-            if borderColor != .clear {
+            if borderColor != Color(.clear) {
                 if isFloatingStyle {
                     RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                         .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
@@ -73,8 +74,6 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
             .applyShadow(shadowInfo: shadowInfo)
             .pointerInteraction(isEnabled)
     }
-
-    @ObservedObject private var tokenSet: ButtonTokenSet
 
     private let style: ButtonStyle
     private let size: ButtonSizeCategory

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -1,0 +1,194 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+import UIKit
+
+/// ButtonStyle which configures the Button View according to its state and design tokens.
+public struct FluentButtonStyle: SwiftUI.ButtonStyle {
+    public init(style: ButtonStyle, size: ButtonSizeCategory) {
+        self.style = style
+        self.size = size
+        self.tokenSet = ButtonTokenSet(style: { style }, size: { size })
+    }
+
+    public func makeBody(configuration: Configuration) -> some View {
+        tokenSet.update(fluentTheme)
+        let isPressed = configuration.isPressed
+        let isDisabled = !isEnabled
+        let isFocused = isFocused
+
+        let cornerRadius = tokenSet[.cornerRadius].float
+        let shadowToken = (isDisabled || isFocused || isPressed) ? ButtonToken.shadowPressed : ButtonToken.shadowRest
+        let shadowInfo = tokenSet[shadowToken].shadowInfo
+
+        let foregroundColor: Color
+        let borderColor: Color
+        let backgroundColor: Color
+        if isDisabled {
+            foregroundColor = Color(tokenSet[.foregroundDisabledColor].uiColor)
+            borderColor = Color(tokenSet[.borderDisabledColor].uiColor)
+            backgroundColor = Color(tokenSet[.backgroundDisabledColor].uiColor)
+        } else if isPressed || isFocused {
+            foregroundColor = Color(tokenSet[.foregroundPressedColor].uiColor)
+            borderColor = Color(tokenSet[.borderPressedColor].uiColor)
+            backgroundColor = Color(tokenSet[.backgroundPressedColor].uiColor)
+        } else {
+            foregroundColor = Color(tokenSet[.foregroundColor].uiColor)
+            borderColor = Color(tokenSet[.borderColor].uiColor)
+            backgroundColor = Color(tokenSet[.backgroundColor].uiColor)
+        }
+
+        @ViewBuilder var backgroundView: some View {
+            if isFloatingStyle {
+                foregroundColor.clipShape(Capsule())
+            } else {
+                backgroundColor.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            }
+        }
+
+        @ViewBuilder var overlayView: some View {
+            if borderColor != .clear {
+                if isFloatingStyle {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
+                        .foregroundStyle(borderColor)
+                } else {
+                    Capsule()
+                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
+                        .foregroundStyle(borderColor)
+                }
+            }
+        }
+
+        // TODO: why are floating buttons filled with the wrong color?
+        return configuration.label
+            .font(Font(tokenSet[.titleFont].uiFont))
+            .foregroundStyle(foregroundColor)
+            .padding(edgeInsets)
+            .frame(minHeight: ButtonTokenSet.minContainerHeight(style: style, size: size))
+            .background(backgroundView)
+            .overlay { overlayView }
+            .applyShadow(shadowInfo: shadowInfo)
+    }
+
+    @ObservedObject private var tokenSet: ButtonTokenSet
+
+    private let style: ButtonStyle
+    private let size: ButtonSizeCategory
+
+    @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+    @Environment(\.isEnabled) private var isEnabled: Bool
+    @Environment(\.isFocused) private var isFocused: Bool
+
+    private var edgeInsets: EdgeInsets {
+        let horizontalPadding = ButtonTokenSet.horizontalPadding(style: style, size: size)
+        let fabAlternativePadding = ButtonTokenSet.fabAlternativePadding(size)
+        return EdgeInsets(
+            top: .zero,
+            leading: horizontalPadding,
+            bottom: .zero,
+            trailing: style.isFloating ? fabAlternativePadding : horizontalPadding
+        )
+    }
+
+    private var isFloatingStyle: Bool { style.isFloating }
+
+//    @Environment(\.isEnabled) var isEnabled: Bool
+//    @Environment(\.isFocused) var isFocused: Bool
+//    @ObservedObject var tokenSet: ButtonTokenSet
+//
+//    var text: String?
+//    var image: Image?
+//    var style: FluentUI.ButtonStyle
+//    var sizeCategory: FluentUI.ButtonSizeCategory
+//
+//    func makeBody(configuration: Self.Configuration) -> some View {
+//        let isPressed = configuration.isPressed
+//        let isDisabled = !isEnabled
+//        let isFocused = isFocused
+//        let isFloatingStyle = style.isFloating
+//        let shouldUsePressedShadow = isDisabled || isPressed
+//        let verticalPadding = tokenSet[.minVerticalPadding].float
+//        let horizontalPadding = ButtonTokenSet.horizontalPadding(style: style, size: sizeCategory)
+//        let foregroundColor: Color
+//        let borderColor: Color
+//        let backgroundColor: Color
+//        if isDisabled {
+//            foregroundColor = Color(tokenSet[.foregroundDisabledColor].uiColor)
+//            borderColor = Color(tokenSet[.borderDisabledColor].uiColor)
+//            backgroundColor = Color(tokenSet[.backgroundDisabledColor].uiColor)
+//        } else if isPressed || isFocused {
+//            foregroundColor = Color(tokenSet[.foregroundPressedColor].uiColor)
+//            borderColor = Color(tokenSet[.borderPressedColor].uiColor)
+//            backgroundColor = Color(tokenSet[.backgroundPressedColor].uiColor)
+//        } else {
+//            foregroundColor = Color(tokenSet[.foregroundColor].uiColor)
+//            borderColor = Color(tokenSet[.borderColor].uiColor)
+//            backgroundColor = Color(tokenSet[.backgroundColor].uiColor)
+//        }
+//
+//        @ViewBuilder
+//        var buttonContent: some View {
+//            HStack(spacing: tokenSet[.interspace].float) {
+//                if let image {
+//                    image
+//                        .resizable()
+//                        .foregroundColor(foregroundColor)
+//                        .frame(width: tokenSet[.iconSize].float, height: tokenSet[.iconSize].float, alignment: .center)
+//                }
+//                if let text {
+//                    Text(text)
+//                        .multilineTextAlignment(.center)
+//                        .font(.init(tokenSet[.textFont].uiFont))
+//                        .frame(minHeight: isFloatingStyle ? tokenSet[.textMinimumHeight].float : nil)
+//                }
+//            }
+//            .padding(EdgeInsets(top: verticalPadding,
+//                                leading: horizontalPadding,
+//                                bottom: verticalPadding,
+//                                trailing: horizontalPadding))
+//            .modifyIf(isFloatingStyle && !(text?.isEmpty ?? true), { view in
+//                view.padding(.horizontal, tokenSet[.textAdditionalHorizontalPadding].float )
+//            })
+//            .frame(maxWidth: .infinity, minHeight: tokenSet[.minHeight].float, maxHeight: .infinity)
+//            .foregroundColor(foregroundColor)
+//        }
+//
+//        @ViewBuilder
+//        var buttonBackground: some View {
+//            if tokenSet[.borderWidth].float > 0 {
+//                buttonContent.background(
+//                    RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
+//                        .strokeBorder(lineWidth: tokenSet[.borderWidth].float, antialiased: false)
+//                        .foregroundColor(borderColor)
+//                        .contentShape(Rectangle()))
+//            } else {
+//                buttonContent.background(
+//                    RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
+//                        .fill(backgroundColor))
+//            }
+//        }
+//
+//        let shadowInfo = (shouldUsePressedShadow ? tokenSet[.shadowPressed] : tokenSet[.shadowRest]).shadowInfo
+//
+//        @ViewBuilder
+//        var button: some View {
+//            if isFloatingStyle {
+//                buttonBackground
+//                    .clipShape(Capsule())
+//                    .applyShadow(shadowInfo: shadowInfo)
+//                    .contentShape(Capsule())
+//            } else {
+//                buttonBackground
+//                    .contentShape(RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
+//            }
+//        }
+//
+//        return button
+//            .pointerInteraction(isEnabled)
+//    }
+//
+}

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -54,11 +54,11 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
         @ViewBuilder var overlayView: some View {
             if borderColor != Color(.clear) {
                 if isFloatingStyle {
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    Capsule()
                         .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
                         .foregroundStyle(borderColor)
                 } else {
-                    Capsule()
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                         .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
                         .foregroundStyle(borderColor)
                 }

--- a/ios/FluentUI/Core/ColorProviding.swift
+++ b/ios/FluentUI/Core/ColorProviding.swift
@@ -104,7 +104,7 @@ private func brandColorOverrides(provider: ColorProviding) -> [FluentTheme.Color
             let brandColors = brandColorOverrides(provider: provider)
             FluentTheme.shared = FluentTheme(colorOverrides: brandColors)
         } else {
-            FluentTheme.shared = FluentThemeKey.defaultValue
+            FluentTheme.shared = .init()
         }
     }
 }

--- a/ios/FluentUI/Core/ControlHostingView.swift
+++ b/ios/FluentUI/Core/ControlHostingView.swift
@@ -36,7 +36,7 @@ open class ControlHostingView: UIView {
     ///
     /// - Parameter controlView: An `AnyView`-wrapped component to host.
     init(_ controlView: AnyView) {
-        hostingController = FluentUIHostingController.init(rootView: AnyView(controlView))
+        hostingController = FluentThemedHostingController.init(rootView: controlView)
         hostingController.disableSafeAreaInsets()
         super.init(frame: .zero)
 
@@ -66,5 +66,5 @@ open class ControlHostingView: UIView {
         self.addConstraints(requiredConstraints)
     }
 
-    private let hostingController: FluentUIHostingController
+    private let hostingController: FluentThemedHostingController
 }

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -216,5 +216,5 @@ public extension EnvironmentValues {
 }
 
 struct FluentThemeKey: EnvironmentKey {
-    static let defaultValue: FluentTheme = .shared
+    static var defaultValue: FluentTheme { .shared }
 }

--- a/ios/FluentUI/Core/Theme/FluentTheme.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme.swift
@@ -100,7 +100,7 @@ public class FluentTheme: NSObject, ObservableObject {
     /// take precedence over this value. This value provides the fallback theme for cases where those
     /// overrides are not provided.
     @objc(sharedTheme)
-    public static var shared: FluentTheme = FluentThemeKey.defaultValue {
+    public static var shared: FluentTheme = .init() {
         didSet {
             NotificationCenter.default.post(name: .didChangeTheme, object: nil)
         }
@@ -216,5 +216,5 @@ public extension EnvironmentValues {
 }
 
 struct FluentThemeKey: EnvironmentKey {
-    static let defaultValue: FluentTheme = .init()
+    static let defaultValue: FluentTheme = .shared
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

New implementation of SwiftUI `FluentButtonStyle`.

Unlike the old `fluent2_tokens` implementation, this is *not* an entire control. Instead, this provides a custom `ButtonStyle` that can be applied to any existing SwiftUI `Button`:

```swift
var body: some View {
    Button("My Button Title!") {
        // Some action
    }.buttonStyle(FluentButtonStyle(style: .accent, size: .large))
}
```

To facilitate testing this, I have also refactored `ControlHostingView` and `FluentUIHostingController`. The latter, a previously-internal-only subclass of `UIHostingController`, can be used any time a SwiftUI Fluent control needs to dynamically intercept theme information from its parent `UIView` or `UIWindow`.

Finally, this change fixes the default `FluentTheme` accessed in SwiftUI, always getting the current instance of `FluentTheme.shared`. Thus, even if you don't use `FluentUIHostingController`, you can rest assured that your Fluent SwiftUI components will use the current static shared theme.

### Binary change

Total increase: 258,280 bytes
Total decrease: -95,328 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,030,144 bytes | 31,193,096 bytes | 🛑 162,952 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentButtonStyle.o | 0 bytes | 156,016 bytes | 🛑 156,016 bytes |
| FluentThemedHostingController.o | 0 bytes | 62,928 bytes | 🛑 62,928 bytes |
| __.SYMDEF | 4,826,760 bytes | 4,853,176 bytes | ⚠️ 26,416 bytes |
| MSFPersonaButton.o | 37,712 bytes | 39,488 bytes | ⚠️ 1,776 bytes |
| MSFCardNudge.o | 36,360 bytes | 38,136 bytes | ⚠️ 1,776 bytes |
| MSFAvatarGroup.o | 27,840 bytes | 29,608 bytes | ⚠️ 1,768 bytes |
| MSFPersonaButtonCarousel.o | 32,568 bytes | 34,328 bytes | ⚠️ 1,760 bytes |
| MSFAvatar.o | 27,416 bytes | 29,152 bytes | ⚠️ 1,736 bytes |
| MSFNotification.o | 139,528 bytes | 141,208 bytes | ⚠️ 1,680 bytes |
| FocusRingView.o | 819,824 bytes | 821,240 bytes | ⚠️ 1,416 bytes |
| HeadsUpDisplayTokenSet.o | 53,032 bytes | 53,584 bytes | ⚠️ 552 bytes |
| MSFHeadsUpDisplay.o | 33,936 bytes | 34,384 bytes | ⚠️ 448 bytes |
| MSFActivityIndicator.o | 30,944 bytes | 30,952 bytes | ⚠️ 8 bytes |
| MSFIndeterminateProgressBar.o | 28,496 bytes | 28,440 bytes | 🎉 -56 bytes |
| SwiftUI+ViewModifiers.o | 123,512 bytes | 123,408 bytes | 🎉 -104 bytes |
| FluentTheme.o | 202,056 bytes | 201,752 bytes | 🎉 -304 bytes |
| ColorProviding.o | 45,560 bytes | 45,208 bytes | 🎉 -352 bytes |
| Button.o | 211,760 bytes | 211,192 bytes | 🎉 -568 bytes |
| ListItem.o | 272,472 bytes | 271,856 bytes | 🎉 -616 bytes |
| ListActionItem.o | 225,096 bytes | 224,408 bytes | 🎉 -688 bytes |
| ButtonTokenSet.o | 126,112 bytes | 124,912 bytes | 🎉 -1,200 bytes |
| ActivityIndicatorCell.o | 82,520 bytes | 78,008 bytes | 🎉 -4,512 bytes |
| SearchBar.o | 383,400 bytes | 378,488 bytes | 🎉 -4,912 bytes |
| HUD.o | 257,744 bytes | 252,200 bytes | 🎉 -5,544 bytes |
| PeoplePicker.o | 310,376 bytes | 295,464 bytes | 🎉 -14,912 bytes |
| ControlHostingView.o | 63,696 bytes | 34,928 bytes | 🎉 -28,768 bytes |
| FluentUIHostingController.o | 32,792 bytes | 0 bytes | 🎉 -32,792 bytes |
</details>

### Verification

* Validated all style and size combinations of the new `FluentButtonStyle`.
* Spot checked other wrapped SwiftUI components to ensure they were unaffected by the above refactor.

<details>
<summary>Visual Verification</summary>

https://github.com/microsoft/fluentui-apple/assets/4934719/11c1245d-50a1-4ad1-abcf-b61b53fa1bec

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1986)