### PR TITLE
Adding keyboard type to text field

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldDemoController.swift
@@ -11,7 +11,7 @@ class TextFieldDemoController: DemoController {
         super.viewDidLoad()
 
         let textField1 = FluentTextField()
-		textField1.keyboardType = .URL
+        textField1.keyboardType = .URL
         textField1.placeholder = "Validates text on each input character"
         textField1.leadingImage = UIImage(named: "Placeholder_24")
         textField1.onEditingChanged = onEditingChanged

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TextFieldDemoController.swift
@@ -11,6 +11,7 @@ class TextFieldDemoController: DemoController {
         super.viewDidLoad()
 
         let textField1 = FluentTextField()
+		textField1.keyboardType = .URL
         textField1.placeholder = "Validates text on each input character"
         textField1.leadingImage = UIImage(named: "Placeholder_24")
         textField1.onEditingChanged = onEditingChanged

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -55,6 +55,15 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
         }
     }
 
+	@objc public var keyboardType: UIKeyboardType {
+		get {
+			return textfield.keyboardType
+		}
+		set {
+			textfield.keyboardType = newValue
+		}
+	}
+
     /// String representing the placeholder text.
     @objc public var placeholder: String? {
         didSet {

--- a/ios/FluentUI/TextField/FluentTextField.swift
+++ b/ios/FluentUI/TextField/FluentTextField.swift
@@ -55,14 +55,14 @@ public final class FluentTextField: UIView, UITextFieldDelegate, TokenizedContro
         }
     }
 
-	@objc public var keyboardType: UIKeyboardType {
-		get {
-			return textfield.keyboardType
-		}
-		set {
-			textfield.keyboardType = newValue
-		}
-	}
+    @objc public var keyboardType: UIKeyboardType {
+        get {
+            return textfield.keyboardType
+        }
+        set {
+            textfield.keyboardType = newValue
+        }
+    }
 
     /// String representing the placeholder text.
     @objc public var placeholder: String? {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Adding `keyboardType` property to `FluentTextField`.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Added URL type to demo:
<img src="https://github.com/microsoft/fluentui-apple/assets/22566866/1c6a2112-fbce-4f0f-82ca-1832381520dd" width="250">
### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1987)