### PR TITLE
Publicly expose applyShadow function for SwiftUI

### DIFF
--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -72,7 +72,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
             .frame(minHeight: ButtonTokenSet.minContainerHeight(style: style, size: size))
             .background(backgroundView)
             .overlay { overlayView }
-            .applyShadow(shadowInfo: shadowInfo)
+            .applyFluentShadow(shadowInfo: shadowInfo)
             .pointerInteraction(isEnabled)
     }
 

--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -51,14 +51,6 @@ extension View {
         modifier(LargeContentViewerModifier(text: text, image: image))
     }
 
-    /// Applies multiple shadows on a View
-    /// - Parameters:
-    ///  - shadowInfo: The values of the two shadows to be applied
-    /// - Returns: The modified view.
-    func applyShadow(shadowInfo: ShadowInfo) -> some View {
-        modifier(ShadowModifier(shadowInfo: shadowInfo))
-    }
-
     /// Abstracts away differences in pre-iOS 17 `onChange(of:perform:)` versus post-iOS 17 `onChange(of:_:)`.
     ///
     /// This function will be removed once FluentUI moves to iOS 17 as a minimum target.

--- a/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
+++ b/ios/FluentUI/Core/SwiftUI+ViewModifiers.swift
@@ -51,6 +51,14 @@ extension View {
         modifier(LargeContentViewerModifier(text: text, image: image))
     }
 
+    /// Applies a key and an ambient shadow on a `View`.
+    /// - Parameters:
+    ///   - shadowInfo: The values of the two shadows to be applied.
+    /// - Returns: The modified view.
+    public func applyFluentShadow(shadowInfo: ShadowInfo) -> some View {
+        modifier(ShadowModifier(shadowInfo: shadowInfo))
+    }
+
     /// Abstracts away differences in pre-iOS 17 `onChange(of:perform:)` versus post-iOS 17 `onChange(of:_:)`.
     ///
     /// This function will be removed once FluentUI moves to iOS 17 as a minimum target.

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -5,7 +5,6 @@
 
 import CoreGraphics
 import UIKit
-import SwiftUI
 
 /// Represents a two-part shadow as used by FluentUI.
 @objc(MSFShadowInfo)
@@ -68,7 +67,10 @@ public class ShadowInfo: NSObject {
 }
 
 public extension ShadowInfo {
-
+    /// Applies a key and an ambient shadow on a `UIView`.
+    /// - Parameters:
+    ///   - view: The view on which the shadows will be applied.
+    ///   - parentController: The view controller responsible for the view on which the shadows will be applied.
     func applyShadow(to view: UIView, parentController: UIViewController? = nil) {
         guard var shadowable = (view as? Shadowable) ?? (view.superview as? Shadowable) ?? (parentController as? Shadowable) else {
             assertionFailure("Cannot apply Fluent shadows to a non-Shadowable view")
@@ -88,6 +90,11 @@ public extension ShadowInfo {
         view.layer.insertSublayer(keyShadow, below: ambientShadow)
     }
 
+    /// Initializes a `CALayer` with the relevant `ShadowInfo` values
+    /// - Parameters:
+    ///   - view: The view on which the shadows will be applied.
+    ///   - isAmbientShadow: Determines whether to apply ambient or key shadow values on the layer.
+    /// - Returns: The modified `CALayer`.
     func initializeShadowLayer(view: UIView, isAmbientShadow: Bool = false) -> CALayer {
         let layer = CALayer()
 
@@ -104,16 +111,6 @@ public extension ShadowInfo {
         layer.backgroundColor = view.backgroundColor?.cgColor
 
         return layer
-    }
-}
-
-public extension View {
-    /// Applies multiple shadows on a View
-    /// - Parameters:
-    ///  - shadowInfo: The values of the two shadows to be applied
-    /// - Returns: The modified view.
-    func applyFluentShadow(shadowInfo: ShadowInfo) -> some View {
-        modifier(ShadowModifier(shadowInfo: shadowInfo))
     }
 }
 

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -5,7 +5,7 @@
 
 import CoreGraphics
 import UIKit
-import Foundation
+import SwiftUI
 
 /// Represents a two-part shadow as used by FluentUI.
 @objc(MSFShadowInfo)
@@ -107,9 +107,18 @@ public extension ShadowInfo {
     }
 }
 
+public extension View {
+    /// Applies multiple shadows on a View
+    /// - Parameters:
+    ///  - shadowInfo: The values of the two shadows to be applied
+    /// - Returns: The modified view.
+    func applyFluentShadow(shadowInfo: ShadowInfo) -> some View {
+        modifier(ShadowModifier(shadowInfo: shadowInfo))
+    }
+}
+
 /// Public protocol that, when implemented, allows any UIView or one of its subviews to implement fluent shadows
 public protocol Shadowable {
-
     /// The layer on which the ambient shadow is implemented
     var ambientShadow: CALayer? { get set }
 

--- a/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ShadowInfo.swift
@@ -90,9 +90,9 @@ public extension ShadowInfo {
         view.layer.insertSublayer(keyShadow, below: ambientShadow)
     }
 
-    /// Initializes a `CALayer` with the relevant `ShadowInfo` values
+    /// Initializes a `CALayer` with the relevant `ShadowInfo` values.
     /// - Parameters:
-    ///   - view: The view on which the shadows will be applied.
+    ///   - view: The view on which the shadow layer will be applied.
     ///   - isAmbientShadow: Determines whether to apply ambient or key shadow values on the layer.
     /// - Returns: The modified `CALayer`.
     func initializeShadowLayer(view: UIView, isAmbientShadow: Bool = false) -> CALayer {

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -288,7 +288,7 @@ public struct FluentNotification: View, TokenizedControlView {
                             backgroundFill
                                 .clipShape(RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
                         )
-                        .applyShadow(shadowInfo: shadowInfo)
+                        .applyFluentShadow(shadowInfo: shadowInfo)
                 )
                 .onTapGesture {
                     if let messageAction = messageButtonAction {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

This PR addresses requests to publicly expose the `applyShadow` function for SwitUI. To avoid potential symbols collision with UIKit's `applyShadow`, the SwiftUI function is renamed to `applyFluentShadow`. Also added documentation for UIKit's shadow function.

### Binary change

Total increase: 4,200 bytes
Total decrease: -376 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,433,448 bytes | 31,437,272 bytes | ⚠️ 3,824 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| SwiftUI+ViewModifiers.o | 123,632 bytes | 127,152 bytes | ⚠️ 3,520 bytes |
| __.SYMDEF | 4,960,568 bytes | 4,961,248 bytes | ⚠️ 680 bytes |
| FluentNotification.o | 700,248 bytes | 700,064 bytes | 🎉 -184 bytes |
| FluentButtonStyle.o | 169,264 bytes | 169,072 bytes | 🎉 -192 bytes |
</details>

### Verification

Validated that `applyFluentShadow` was now accessible in `AvatarDemoControllerSwiftUI`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1992)