### PR TITLE
New `FluentButtonToggleStyle`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -110,7 +110,7 @@ struct ButtonDemoView: View {
         .controlSize(controlSize)
         .disabled(isDisabled)
         .fixedSize()
-        .padding(8.0)
+        .padding(GlobalTokens.spacing(.size80))
         .alert(isPresented: $showAlert, content: {
             Alert(title: Text("Button tapped"))
         })
@@ -125,7 +125,7 @@ struct ButtonDemoView: View {
         .controlSize(controlSize)
         .disabled(isDisabled)
         .fixedSize()
-        .padding(8.0)
+        .padding(GlobalTokens.spacing(.size80))
     }
 
     @ViewBuilder

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -65,7 +65,11 @@ extension ButtonDemoControllerSwiftUI: UIPopoverPresentationControllerDelegate {
 struct ButtonDemoView: View {
     public var body: some View {
         VStack {
-            demoButton(style, size, isDisabled: isDisabled)
+            if showToggle {
+                demoToggle(size, isDisabled: isDisabled)
+            } else {
+                demoButton(style, size, isDisabled: isDisabled)
+            }
             demoOptions
         }
     }
@@ -77,22 +81,30 @@ struct ButtonDemoView: View {
     @State var showAlert: Bool = false
     @State var size: ControlSize = .large
     @State var style: FluentUI.ButtonStyle = .accent
+    @State var showToggle: Bool = false
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
+
+    @State var isToggleOn: Bool = false
+
+    @ViewBuilder
+    private var buttonLabel: some View {
+        HStack {
+            if showImage {
+                Image("Placeholder_24")
+            }
+            if showLabel && text.count > 0 {
+                Text(text)
+            }
+        }
+    }
 
     @ViewBuilder
     private func demoButton(_ buttonStyle: FluentUI.ButtonStyle, _ controlSize: ControlSize, isDisabled: Bool) -> some View {
         Button(action: {
             showAlert = true
         }, label: {
-            HStack {
-                if showImage {
-                    Image("Placeholder_24")
-                }
-                if showLabel && text.count > 0 {
-                    Text(text)
-                }
-            }
+            buttonLabel
         })
         .buttonStyle(FluentButtonStyle(style: buttonStyle))
         .controlSize(controlSize)
@@ -102,6 +114,18 @@ struct ButtonDemoView: View {
         .alert(isPresented: $showAlert, content: {
             Alert(title: Text("Button tapped"))
         })
+    }
+
+    @ViewBuilder
+    private func demoToggle(_ controlSize: ControlSize, isDisabled: Bool) -> some View {
+        Toggle(isOn: $isToggleOn, label: {
+            buttonLabel
+        })
+        .toggleStyle(FluentButtonToggleStyle())
+        .controlSize(controlSize)
+        .disabled(isDisabled)
+        .fixedSize()
+        .padding(8.0)
     }
 
     @ViewBuilder
@@ -124,9 +148,12 @@ struct ButtonDemoView: View {
             }
 
             Section("Style and Size") {
-                Picker("Style", selection: $style) {
-                    ForEach(Array(FluentUI.ButtonStyle.allCases.enumerated()), id: \.element) { _, buttonStyle in
-                        Text("\(buttonStyle.description)").tag(buttonStyle.rawValue)
+                FluentUIDemoToggle(titleKey: "Present as toggle", isOn: $showToggle)
+                if !showToggle {
+                    Picker("Style", selection: $style) {
+                        ForEach(Array(FluentUI.ButtonStyle.allCases.enumerated()), id: \.element) { _, buttonStyle in
+                            Text("\(buttonStyle.description)").tag(buttonStyle.rawValue)
+                        }
                     }
                 }
 

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		9298798B2669A875002B1EB4 /* PersonaButtonTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927E34C62668350800998031 /* PersonaButtonTokenSet.swift */; };
 		929DD257266ED3AC00E8175E /* PersonaButtonCarouselTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD255266ED3AC00E8175E /* PersonaButtonCarouselTokenSet.swift */; };
 		929DD25A266ED3B600E8175E /* PersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */; };
+		929F2ACF2BB77ED100683EA8 /* FluentButtonToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929F2ACE2BB77ED100683EA8 /* FluentButtonToggleStyle.swift */; };
 		92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A1E4F326A791590007ED60 /* MSFCardNudge.swift */; };
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D49054278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */; };
@@ -367,6 +368,7 @@
 		929215B82B6C75E500D4EA9F /* AvatarTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AvatarTests.swift; sourceTree = "<group>"; };
 		929DD255266ED3AC00E8175E /* PersonaButtonCarouselTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselTokenSet.swift; sourceTree = "<group>"; };
 		929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarousel.swift; sourceTree = "<group>"; };
+		929F2ACE2BB77ED100683EA8 /* FluentButtonToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentButtonToggleStyle.swift; sourceTree = "<group>"; };
 		92A1E4F326A791590007ED60 /* MSFCardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFCardNudge.swift; sourceTree = "<group>"; };
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselModifiers.swift; sourceTree = "<group>"; };
@@ -668,6 +670,7 @@
 				A5CEC23020E451D00016922A /* Button.swift */,
 				EC65F78F292EDCEF002A1A23 /* ButtonTokenSet.swift */,
 				92279B322B97C7DC00994D88 /* FluentButtonStyle.swift */,
+				929F2ACE2BB77ED100683EA8 /* FluentButtonToggleStyle.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -1733,6 +1736,7 @@
 				925728F7276D6AF800EE1019 /* ShadowInfo.swift in Sources */,
 				66963D0A29CA7F89006F5FA9 /* TwoLineTitleViewTokenSet.swift in Sources */,
 				5328D97326FBA3D700F3723B /* IndeterminateProgressBarModifiers.swift in Sources */,
+				929F2ACF2BB77ED100683EA8 /* FluentButtonToggleStyle.swift in Sources */,
 				923DB9D7274CB66D00D8E58A /* ControlHostingView.swift in Sources */,
 				5314E03B25F00E3D0099271A /* BadgeStringExtractor.swift in Sources */,
 				EC1C31732923022E00CF052C /* SegmentedControlTokenSet.swift in Sources */,

--- a/ios/FluentUI/Button/ButtonTokenSet.swift
+++ b/ios/FluentUI/Button/ButtonTokenSet.swift
@@ -233,7 +233,7 @@ public class ButtonTokenSet: ControlTokenSet<ButtonToken> {
                 }
             case .cornerRadius:
                 return .float {
-                    if Compatibility.isDeviceIdiomVision() {
+                    if style().isFloating || Compatibility.isDeviceIdiomVision() {
                         return ButtonTokenSet.minContainerHeight(style: style(), size: size()) / 2
                     }
                     switch size() {

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -6,7 +6,7 @@
 import SwiftUI
 import UIKit
 
-/// ButtonStyle which configures the Button View according to its state and design tokens.
+/// `ButtonStyle` which configures the `Button` according to its state and design tokens.
 public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     public init(style: ButtonStyle) {
         self.style = style
@@ -20,6 +20,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
         let size = size
 
         let tokenSet = ButtonTokenSet(style: { style }, size: { size })
+        tokenSet.replaceAllOverrides(with: tokenOverrides)
         tokenSet.update(fluentTheme)
 
         let cornerRadius = tokenSet[.cornerRadius].float
@@ -44,10 +45,12 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
         }
 
         @ViewBuilder var backgroundView: some View {
-            if isFloatingStyle {
-                backgroundColor.clipShape(Capsule())
-            } else {
-                backgroundColor.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            if backgroundColor != Color(.clear) {
+                if isFloatingStyle {
+                    backgroundColor.clipShape(Capsule())
+                } else {
+                    backgroundColor.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+                }
             }
         }
 
@@ -107,5 +110,14 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
             bottom: .zero,
             trailing: style.isFloating ? fabAlternativePadding : horizontalPadding
         )
+    }
+
+    private var tokenOverrides: [ButtonToken: ControlTokenValue]?
+}
+
+public extension FluentButtonStyle {
+    /// Provide override values for various `ButtokToken` values.
+    mutating func overrideTokens(_ overrides: [ButtonToken: ControlTokenValue]) {
+        tokenOverrides = overrides
     }
 }

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -16,7 +16,6 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
         let isPressed = configuration.isPressed
         let isDisabled = !isEnabled
         let isFocused = isFocused
-        let isFloatingStyle = style.isFloating
         let size = size
 
         let tokenSet = ButtonTokenSet(style: { style }, size: { size })
@@ -46,26 +45,20 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
 
         @ViewBuilder var backgroundView: some View {
             if backgroundColor != Color(.clear) {
-                if isFloatingStyle {
-                    backgroundColor.clipShape(Capsule())
-                } else {
-                    backgroundColor.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
-                }
+                backgroundColor.clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             }
         }
 
         @ViewBuilder var overlayView: some View {
             if borderColor != Color(.clear) {
-                if isFloatingStyle {
-                    Capsule()
-                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
-                        .foregroundStyle(borderColor)
-                } else {
-                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
-                        .foregroundStyle(borderColor)
-                }
+                contentShape
+                    .stroke(style: .init(lineWidth: tokenSet[.borderWidth].float))
+                    .foregroundStyle(borderColor)
             }
+        }
+
+        @ViewBuilder var contentShape: some Shape {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
         }
 
         return configuration.label
@@ -76,6 +69,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
             .background(backgroundView)
             .overlay { overlayView }
             .applyFluentShadow(shadowInfo: shadowInfo)
+            .contentShape(contentShape)
             .pointerInteraction(isEnabled)
     }
 

--- a/ios/FluentUI/Button/FluentButtonStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonStyle.swift
@@ -110,7 +110,7 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
 }
 
 public extension FluentButtonStyle {
-    /// Provide override values for various `ButtokToken` values.
+    /// Provide override values for various `ButtonToken` values.
     mutating func overrideTokens(_ overrides: [ButtonToken: ControlTokenValue]) {
         tokenOverrides = overrides
     }

--- a/ios/FluentUI/Button/FluentButtonToggleStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonToggleStyle.swift
@@ -17,7 +17,7 @@ public struct FluentButtonToggleStyle: ToggleStyle {
         }, label: {
             configuration.label
         })
-        .buttonStyle(configuration.isOn ? buttonStylePressed : buttonStyle)
+        .buttonStyle(configuration.isOn ? buttonStyleOn : buttonStyle)
     }
 
     private var buttonStyle: FluentButtonStyle {
@@ -26,9 +26,9 @@ public struct FluentButtonToggleStyle: ToggleStyle {
         return style
     }
 
-    private var buttonStylePressed: FluentButtonStyle {
+    private var buttonStyleOn: FluentButtonStyle {
         var style = FluentButtonStyle(style: .subtle)
-        style.overrideTokens(pressedButtonTokens)
+        style.overrideTokens(buttonOnTokens)
         return style
     }
 
@@ -38,7 +38,7 @@ public struct FluentButtonToggleStyle: ToggleStyle {
         ]
     }
 
-    private var pressedButtonTokens: [ButtonToken: ControlTokenValue] {
+    private var buttonOnTokens: [ButtonToken: ControlTokenValue] {
         let backgroundColor = fluentTheme.color(.brandBackgroundTint)
         return buttonTokens.merging([
             .backgroundColor: .uiColor { backgroundColor },

--- a/ios/FluentUI/Button/FluentButtonToggleStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonToggleStyle.swift
@@ -1,0 +1,49 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// `ToggleStyle` which configures the `Toggle` according to its state and design tokens.
+public struct FluentButtonToggleStyle: ToggleStyle {
+    public init() {}
+
+    @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+
+    public func makeBody(configuration: Configuration) -> some View {
+        SwiftUI.Button(action: {
+            configuration.isOn.toggle()
+        }, label: {
+            configuration.label
+        })
+        .buttonStyle(configuration.isOn ? buttonStylePressed : buttonStyle)
+    }
+
+    private var buttonStyle: FluentButtonStyle {
+        var style = FluentButtonStyle(style: .transparentNeutral)
+        style.overrideTokens(buttonTokens)
+        return style
+    }
+
+    private var buttonStylePressed: FluentButtonStyle {
+        var style = FluentButtonStyle(style: .subtle)
+        style.overrideTokens(pressedButtonTokens)
+        return style
+    }
+
+    private var buttonTokens: [ButtonToken: ControlTokenValue] {
+        [
+            .cornerRadius: .float { GlobalTokens.corner(.radius40) }
+        ]
+    }
+
+    private var pressedButtonTokens: [ButtonToken: ControlTokenValue] {
+        let backgroundColor = fluentTheme.color(.brandBackgroundTint)
+        return buttonTokens.merging([
+            .backgroundColor: .uiColor { backgroundColor },
+            .backgroundPressedColor: .uiColor { backgroundColor },
+            .backgroundFocusedColor: .uiColor { backgroundColor }
+        ]) { (_, new) in new }
+    }
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Adding a new `FluentButtonToggleStyle` based on `FluentButtonStyle`.

Also simplifying some logic in `FluentButtonStyle` for determining border shape.

### Binary change

Total increase: 97,088 bytes
Total decrease: -12,296 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,217,864 bytes | 31,302,656 bytes | 🛑 84,792 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentButtonToggleStyle.o | 0 bytes | 67,432 bytes | 🛑 67,432 bytes |
| HUD.o | 252,200 bytes | 267,248 bytes | ⚠️ 15,048 bytes |
| __.SYMDEF | 4,856,184 bytes | 4,868,400 bytes | ⚠️ 12,216 bytes |
| ButtonTokenSet.o | 124,912 bytes | 125,920 bytes | ⚠️ 1,008 bytes |
| FocusRingView.o | 822,832 bytes | 823,448 bytes | ⚠️ 616 bytes |
| BadgeView.o | 624,760 bytes | 625,200 bytes | ⚠️ 440 bytes |
| FluentTheme.o | 201,752 bytes | 202,080 bytes | ⚠️ 328 bytes |
| SwiftUI+ViewModifiers.o | 126,904 bytes | 126,896 bytes | 🎉 -8 bytes |
| FluentButtonStyle.o | 168,640 bytes | 156,352 bytes | 🎉 -12,288 bytes |
</details>

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

![Simulator Screen Recording - iPad mini (6th generation) - 2024-04-03 at 10 39 17](https://github.com/microsoft/fluentui-apple/assets/4934719/477076e6-078a-4390-bd20-04d2ebbe913e)

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1993)