### PR TITLE
[ListItem] make modifier inputs optional

### DIFF
--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -26,7 +26,7 @@ public extension ListItem {
     /// The line limit for `title`.
     /// - Parameter titleLineLimit: The  number of lines to display for the `title`.
     /// - Returns: The modified `ListItem` with the property set.
-    func titleLineLimit(_ titleLineLimit: Int) -> ListItem {
+    func titleLineLimit(_ titleLineLimit: Int?) -> ListItem {
         var listItem = self
         listItem.titleLineLimit = titleLineLimit
         return listItem
@@ -35,7 +35,7 @@ public extension ListItem {
     /// The line limit for `subtitle`.
     /// - Parameter subtitleLineLimit: The  number of lines to display for the `subtitle`.
     /// - Returns: The modified `ListItem` with the property set.
-    func subtitleLineLimit(_ subtitleLineLimit: Int) -> ListItem {
+    func subtitleLineLimit(_ subtitleLineLimit: Int?) -> ListItem {
         var listItem = self
         listItem.subtitleLineLimit = subtitleLineLimit
         return listItem
@@ -44,7 +44,7 @@ public extension ListItem {
     /// The line limit for `footer`.
     /// - Parameter footerLineLimit: The  number of lines to display for the `footer`.
     /// - Returns: The modified `ListItem` with the property set.
-    func footerLineLimit(_ footerLineLimit: Int) -> ListItem {
+    func footerLineLimit(_ footerLineLimit: Int?) -> ListItem {
         var listItem = self
         listItem.footerLineLimit = footerLineLimit
         return listItem


### PR DESCRIPTION
### Platforms Impacted
- iOS

### Description of changes

When using the ListItem modifiers for line limit, it is extending the modifier provided by swiftui which sets the value defaulted to nil. By having the value be nil, the ListItem will grow in number of lines to show all the content provided for title/subtitle/footer.


When using these modifiers though, we have to optionally add them potentially. To support a ListItem providing a line limit for title / subtitle / footer optionally, we have to be allowed to pass in an optional value.

### Binary change

N/A

### Verification
It builds with the input values allowed to be optional. In the Demo app also set the values explicitly to nil and to a value. Saw the UI respected the values. 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1994)