### PR TITLE
Adding `minimumScaleFactor` to HUD rendering

### DIFF
--- a/ios/FluentUI/HUD/HeadsUpDisplay.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplay.swift
@@ -79,6 +79,7 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
                     Spacer()
                         .frame(height: verticalPadding)
                     Text(label)
+                        .minimumScaleFactor(0.6)
                         .foregroundColor(Color(tokenSet[.labelColor].uiColor))
                         .lineLimit(2)
                         .multilineTextAlignment(.center)

--- a/ios/FluentUI/HUD/HeadsUpDisplay.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplay.swift
@@ -79,7 +79,7 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
                     Spacer()
                         .frame(height: verticalPadding)
                     Text(label)
-                        .minimumScaleFactor(0.6)
+                        .minimumScaleFactor(HeadsUpDisplayTokenSet.labelMinimumScaleFactor)
                         .foregroundColor(Color(tokenSet[.labelColor].uiColor))
                         .lineLimit(2)
                         .multilineTextAlignment(.center)

--- a/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
+++ b/ios/FluentUI/HUD/HeadsUpDisplayTokenSet.swift
@@ -76,4 +76,6 @@ extension HeadsUpDisplayTokenSet {
     /// The maximum value for the side of the squared background of the Heads-up display.
     static let maxSize: CGFloat = 192
 
+    /// The minimum scale factor to use for the label when its text does not fit.
+    static let labelMinimumScaleFactor: CGFloat = 0.6
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Introducing a `minimumScaleFactor` to the text of a HUD. Using 0.6 as it strikes a good balance between adding a little extra space, and maintaining a reasonable level of readability.

### Binary change

Total increase: 8,096 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,486,872 bytes | 31,494,968 bytes | ⚠️ 8,096 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| HeadsUpDisplay.o | 252,584 bytes | 258,952 bytes | ⚠️ 6,368 bytes |
| __.SYMDEF | 4,881,264 bytes | 4,882,992 bytes | ⚠️ 1,728 bytes |
</details>

### Verification

Ensured text begins to overflow as expected, with a small amount of extra text available. Also verified a11y text sizes--no behavioral impact compared to the existing feature.

<details>
<summary>Visual Verification</summary>

| Standard                                     | Scaled                                    |
|----------------------------------------------|--------------------------------------------|
| <img width="177" alt="HUD_standard" src="https://github.com/microsoft/fluentui-apple/assets/4934719/684080e7-9360-4a0b-b43e-8e6bea5d1ca9"> | <img width="177" alt="HUD_squished" src="https://github.com/microsoft/fluentui-apple/assets/4934719/e1951217-3ed6-4f87-9130-85a2c445fabd"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)