### PR TITLE
Move iOS projects to always use spaces for indentation

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -474,6 +474,7 @@
 				5340828A26CFF298007716E1 /* Recovered References */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		A5CEC20D20E436F10016922A /* Products */ = {
 			isa = PBXGroup;

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -927,6 +927,7 @@
 				923DF2E62712B6AB00637646 /* Frameworks */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		A5CEC15220D980B20016922A /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

We always want spaces for indentation in our iOS projects--let's enforce that at an Xcode project level. Useful for people (like me!) who move between tabs-only and spaces-only projects.

### Binary change

n/a -- no impact on build

### Verification

Verified that Xcode uses spaces in both the library and demo app projects, even when the global app settings are set to tabs.

<details>
<summary>Visual Verification</summary>

n/a

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1998)