### PR TITLE
Update accessoryCheckmarkColor on visionOS to be white

### DIFF
--- a/ios/FluentUI/Table View/TableViewCellTokenSet.swift
+++ b/ios/FluentUI/Table View/TableViewCellTokenSet.swift
@@ -162,7 +162,7 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellToken> {
                 return .uiColor { theme.color(.foreground3) }
 
             case .accessoryCheckmarkColor:
-                return .uiColor { theme.color(.brandForeground1) }
+                return .uiColor { Compatibility.isDeviceIdiomVision() ? .white : theme.color(.brandForeground1) }
 
             case .separatorColor:
                 return .uiColor { theme.color(.stroke2) }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

On visionOS, `accessoryCheckmarkColor` is currently `brandForeground1`. It should be white.

### Binary change

Total increase: 1,144 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,358,040 bytes | 31,359,184 bytes | ⚠️ 1,144 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewCellTokenSet.o | 125,040 bytes | 126,032 bytes | ⚠️ 992 bytes |
| __.SYMDEF | 4,830,360 bytes | 4,830,512 bytes | ⚠️ 152 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/5f213ac3-1cec-4d09-86a7-e9c6b53c237e) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/868b7937-573d-4b04-a844-bcbb2e02d30a) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/1999)