### PR TITLE
Add support for ListItem on visionOS

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -36,7 +36,7 @@ struct Demos {
         DemoDescriptor("IndeterminateProgressBar", IndeterminateProgressBarDemoController.self, supportsVisionOS: false),
         DemoDescriptor("Label", LabelDemoController.self, supportsVisionOS: true),
         DemoDescriptor("ListActionItem", ListActionItemDemoController.self, supportsVisionOS: false),
-        DemoDescriptor("ListItem", ListItemDemoController.self, supportsVisionOS: false),
+        DemoDescriptor("ListItem", ListItemDemoController.self, supportsVisionOS: true),
         DemoDescriptor("MultilineCommandBar", MultilineCommandBarDemoController.self, supportsVisionOS: false),
         DemoDescriptor("NavigationController", NavigationControllerDemoController.self, supportsVisionOS: true),
         DemoDescriptor("NotificationView", NotificationViewDemoController.self, supportsVisionOS: true),

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -21,7 +21,8 @@ class ListItemDemoControllerSwiftUI: UIHostingController<ListItemDemoView> {
 }
 
 struct ListItemDemoView: View {
-    @State var showingAlert: Bool = false
+    @State var showingPrimaryAlert: Bool = false
+    @State var showingSecondaryAlert: Bool = false
     @ObservedObject var fluentTheme: FluentTheme = .shared
     let accessoryTypes: [ListItemAccessoryType] = [.none, .checkmark, .detailButton, .disclosureIndicator]
 
@@ -32,6 +33,7 @@ struct ListItemDemoView: View {
     @State var showFooter: Bool = false
     @State var showLeadingContent: Bool = true
     @State var showTrailingContent: Bool = true
+    @State var isTappable: Bool = true
     @State var isDisabled: Bool = false
     @State var accessoryType: ListItemAccessoryType = .none
     @State var leadingContentSize: ListItemLeadingContentSize = .default
@@ -41,6 +43,7 @@ struct ListItemDemoView: View {
     @State var footerLineLimit: Int = 1
     @State var trailingContentFocusableElementCount: Int = 0
     @State var trailingContentToggleEnabled: Bool = true
+    @State var renderStandalone: Bool = false
 
     public var body: some View {
 
@@ -73,7 +76,9 @@ struct ListItemDemoView: View {
                 .accessibilityIdentifier("leadingContentSwitch")
             FluentUIDemoToggle(titleKey: "Show trailing content", isOn: $showTrailingContent)
                 .accessibilityIdentifier("trailingContentSwitch")
+            FluentUIDemoToggle(titleKey: "Tappable", isOn: $isTappable)
             FluentUIDemoToggle(titleKey: "Disabled", isOn: $isDisabled)
+            FluentUIDemoToggle(titleKey: "Render standalone", isOn: $renderStandalone)
         }
 
         @ViewBuilder
@@ -136,57 +141,74 @@ struct ListItemDemoView: View {
         }
 
         @ViewBuilder
+        var listItem: some View {
+            ListItem(title: title,
+                     subtitle: showSubtitle ? subtitle : "",
+                     footer: showFooter ? footer : "",
+                     leadingContent: {
+                         if showLeadingContent {
+                             leadingContent
+                         }
+                     },
+                     trailingContent: {
+                        if showTrailingContent {
+                             switch trailingContentFocusableElementCount {
+                             case 0:
+                                 Text("Spreadsheet")
+                             case 1:
+                                 Toggle("", isOn: $trailingContentToggleEnabled)
+                             default:
+                                 HStack {
+                                     Button {
+                                         showingSecondaryAlert = true
+                                     } label: {
+                                         Text("Button 1")
+                                     }
+                                     Button {
+                                         showingSecondaryAlert = true
+                                     } label: {
+                                         Text("Button 2")
+                                     }
+                                 }
+                             }
+                         }
+                     },
+                     action: !isTappable ? nil : {
+                         showingPrimaryAlert = true
+                     }
+            )
+            .backgroundStyleType(backgroundStyle)
+            .accessoryType(accessoryType)
+            .leadingContentSize(leadingContentSize)
+            .titleLineLimit(titleLineLimit)
+            .subtitleLineLimit(subtitleLineLimit)
+            .footerLineLimit(footerLineLimit)
+            .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
+            .onAccessoryTapped {
+                showingSecondaryAlert = true
+            }
+            .disabled(isDisabled)
+            .alert("List Item tapped", isPresented: $showingPrimaryAlert) {
+                Button("OK", role: .cancel) { }
+            }
+            .alert("Detail button tapped", isPresented: $showingSecondaryAlert) {
+                Button("OK", role: .cancel) { }
+            }
+        }
+
+        @ViewBuilder
         var content: some View {
             VStack {
+                if renderStandalone {
+                    listItem
+                }
                 List {
-                    Section {
-                        ListItem(title: title,
-                                 subtitle: showSubtitle ? subtitle : "",
-                                 footer: showFooter ? footer : "",
-                                 leadingContent: {
-                            if showLeadingContent {
-                                leadingContent
-                            }
-                        },
-                                 trailingContent: {
-                            if showTrailingContent {
-                                switch trailingContentFocusableElementCount {
-                                case 0:
-                                    Text("Spreadsheet")
-                                case 1:
-                                    Toggle("", isOn: $trailingContentToggleEnabled)
-                                default:
-                                    HStack {
-                                        Button {
-                                            showingAlert = true
-                                        } label: {
-                                            Text("Button 1")
-                                        }
-                                        Button {
-                                            showingAlert = true
-                                        } label: {
-                                            Text("Button 2")
-                                        }
-                                    }
-                                }
-                            }
-                        })
-                        .backgroundStyleType(backgroundStyle)
-                        .accessoryType(accessoryType)
-                        .leadingContentSize(leadingContentSize)
-                        .titleLineLimit(titleLineLimit)
-                        .subtitleLineLimit(subtitleLineLimit)
-                        .footerLineLimit(footerLineLimit)
-                        .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-                        .onAccessoryTapped {
-                            showingAlert = true
+                    if !renderStandalone {
+                        Section {
+                            listItem
+                        } header: {
+                            Text("ListItem")
                         }
-                        .disabled(isDisabled)
-                        .alert("Detail button tapped", isPresented: $showingAlert) {
-                            Button("OK", role: .cancel) { }
-                        }
-                    } header: {
-                        Text("ListItem")
                     }
                     controls
                 }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -95,27 +95,30 @@ public struct ListItem<LeadingContent: View,
                 let image = Image(uiImage: icon)
                     .foregroundColor(Color(uiColor: iconColor))
                     .accessibilityIdentifier(AccessibilityIdentifiers.accessoryImage)
-                if accessoryType == .detailButton {
-                    SwiftUI.Button {
-                        if let onAccessoryTapped = onAccessoryTapped {
-                            onAccessoryTapped()
+                Group {
+                    if accessoryType == .detailButton {
+                        SwiftUI.Button {
+                            if let onAccessoryTapped = onAccessoryTapped {
+                                onAccessoryTapped()
+                            }
+                        } label: {
+                            image
                         }
-                    } label: {
-                        image
-                    }
 #if os(visionOS)
-                    .buttonStyle(.bordered)
-                    .clipShape(Circle())
+                        .buttonStyle(.bordered)
+                        .clipShape(Circle())
 #else
-                    .buttonStyle(.plain)
+                        .buttonStyle(.plain)
 #endif
-                    .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
-                    .accessibility(label: Text("Accessibility.TableViewCell.MoreActions.Label".localized))
-                    .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
-                } else {
-                    image
-                        .accessibilityHidden(true)
+                        .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
+                        .accessibility(label: Text("Accessibility.TableViewCell.MoreActions.Label".localized))
+                        .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
+                    } else {
+                        image
+                            .accessibilityHidden(true)
+                    }
                 }
+                .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
         }
 
@@ -144,6 +147,7 @@ public struct ListItem<LeadingContent: View,
             if let trailingContent {
                 trailingContent()
                     .tint(Color(fluentTheme.color(.brandForeground1)))
+                    .padding(.leading, ListItemTokenSet.horizontalSpacing)
                     .accessibilityIdentifier(AccessibilityIdentifiers.trailingContent)
             }
         }
@@ -157,18 +161,15 @@ public struct ListItem<LeadingContent: View,
                     Spacer(minLength: 0)
                     if combineTrailingContentAccessibilityElement {
                         trailingContentView
-                            .padding(.leading, ListItemTokenSet.horizontalSpacing)
                     }
                 }
                 .accessibilityElement(children: .combine)
                 .accessibilitySortPriority(2)
                 if !combineTrailingContentAccessibilityElement {
                     trailingContentView
-                        .padding(.leading, ListItemTokenSet.horizontalSpacing)
                         .accessibilitySortPriority(1)
                 }
                 accessoryView
-                    .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
             .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
                                 leading: ListItemTokenSet.paddingLeading,
@@ -181,18 +182,20 @@ public struct ListItem<LeadingContent: View,
 
         @ViewBuilder
         var contentView: some View {
-            if let action = action {
-                SwiftUI.Button(action: action, label: {
+            Group {
+                if let action = action {
+                    SwiftUI.Button(action: action, label: {
+                        innerContent
+                    })
+                    .buttonStyle(ListItemButtonStyle(backgroundStyleTyle: backgroundStyleType, tokenSet: tokenSet))
+                } else {
                     innerContent
-                })
-                .buttonStyle(ListItemButtonStyle(backgroundStyleTyle: backgroundStyleType, tokenSet: tokenSet))
-            } else {
-                innerContent
+                }
             }
+            .listRowInsets(EdgeInsets())
         }
 
         return contentView
-                .listRowInsets(EdgeInsets())
     }
 
     private static func layoutType(subtitle: Subtitle, footer: Footer) -> LayoutType {

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -17,25 +17,28 @@ public struct ListItem<LeadingContent: View,
                        Subtitle: StringProtocol,
                        Footer: StringProtocol>: View {
 
-	// MARK: Initializer
+    // MARK: Initializer
 
-	/// Creates a ListItem view
-	/// - Parameters:
-	///   - title: Text that appears as the first line of text
-	///   - subtitle: Text that appears as the second line of text
-	///   - footer: Text that appears as the third line of text
-	///   - leadingContent: The content that appears on the leading edge of the view
-	///   - trailingContent: The content that appears on the trailing edge of the view, next to the accessory type if provided
+    /// Creates a `ListItem`
+    /// - Parameters:
+    ///   - title: Text that appears as the first line of text
+    ///   - subtitle: Text that appears as the second line of text
+    ///   - footer: Text that appears as the third line of text
+    ///   - leadingContent: The content that appears on the leading edge of the view
+    ///   - trailingContent: The content that appears on the trailing edge of the view, next to the accessory type if provided
+    ///   - action: The action to be dispatched by tapping on the `ListItem`
     public init(title: Title,
                 subtitle: Subtitle = String(),
                 footer: Footer = String(),
                 @ViewBuilder leadingContent: @escaping () -> LeadingContent,
-                @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
+                @ViewBuilder trailingContent: @escaping () -> TrailingContent,
+                action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.leadingContent = leadingContent
         self.trailingContent = trailingContent
+        self.action = action
         let layoutType = ListItem.layoutType(subtitle: subtitle, footer: footer)
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
     }
@@ -92,12 +95,6 @@ public struct ListItem<LeadingContent: View,
                 let image = Image(uiImage: icon)
                     .foregroundColor(Color(uiColor: iconColor))
                     .accessibilityIdentifier(AccessibilityIdentifiers.accessoryImage)
-                    .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
-                                        leading: ListItemTokenSet.horizontalSpacing,
-                                        bottom: ListItemTokenSet.paddingVertical,
-                                        trailing: ListItemTokenSet.paddingTrailing))
-                    // A non clear background must be applied for VoiceOver focus ring to be around the padded view
-                    .background(backgroundView)
                 if accessoryType == .detailButton {
                     SwiftUI.Button {
                         if let onAccessoryTapped = onAccessoryTapped {
@@ -106,6 +103,12 @@ public struct ListItem<LeadingContent: View,
                     } label: {
                         image
                     }
+#if os(visionOS)
+                    .buttonStyle(.bordered)
+                    .clipShape(Circle())
+#else
+                    .buttonStyle(.plain)
+#endif
                     .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
                     .accessibility(label: Text("Accessibility.TableViewCell.MoreActions.Label".localized))
                     .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
@@ -146,7 +149,7 @@ public struct ListItem<LeadingContent: View,
         }
 
         @ViewBuilder
-        var contentView: some View {
+        var innerContent: some View {
             HStack(alignment: .center) {
                 HStack(spacing: 0) {
                     leadingContentView
@@ -172,14 +175,30 @@ public struct ListItem<LeadingContent: View,
                         .accessibilitySortPriority(1)
                 }
                 accessoryView
+                    .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
+                                        leading: ListItemTokenSet.horizontalSpacing,
+                                        bottom: ListItemTokenSet.paddingVertical,
+                                        trailing: ListItemTokenSet.paddingTrailing))
             }
             .frame(minHeight: layoutType.minHeight)
             .opacity(isEnabled ? ListItemTokenSet.enabledAlpha : ListItemTokenSet.disabledAlpha)
             .background(backgroundView)
-            .listRowInsets(EdgeInsets())
+        }
+
+        @ViewBuilder
+        var contentView: some View {
+            if let action = action {
+                SwiftUI.Button(action: action, label: {
+                    innerContent
+                })
+                .buttonStyle(ListItemButtonStyle(backgroundStyle: backgroundStyleType))
+            } else {
+                innerContent
+            }
         }
 
         return contentView
+                .listRowInsets(EdgeInsets())
     }
 
     private static func layoutType(subtitle: Subtitle, footer: Footer) -> LayoutType {
@@ -224,7 +243,7 @@ public struct ListItem<LeadingContent: View,
 
     // MARK: Internal variables
 
-    /// The `ListItemAccessoryType` that the view should display.
+    /// The `ListItemAccessoryType` that the `ListItem` should display.
     var accessoryType: ListItemAccessoryType = .none
 
     /// The background styling of the `ListItem` to match the type of `List` it is displayed in.
@@ -264,10 +283,34 @@ public struct ListItem<LeadingContent: View,
 
     private var leadingContent: (() -> LeadingContent)?
     private var trailingContent: (() -> TrailingContent)?
+    private var action: (() -> Void)?
 
     private let footer: Footer
     private let subtitle: Subtitle
     private let title: Title
+}
+
+// MARK: Internal structs
+
+private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
+    init(backgroundStyle: ListItemBackgroundStyleType) {
+        self.backgroundStyle = backgroundStyle
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        let backgroundColor = configuration.isPressed ? ListItemTokenSet(customViewSize: { ListItemLeadingContentSize.zero })[.cellBackgroundSelectedColor].uiColor : .clear
+        let cornerRadius = backgroundStyle == .plain && Compatibility.isDeviceIdiomVision() ? 16.0 : 0
+
+        return configuration.label
+            .background(Color(backgroundColor))
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .contentShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .pointerInteraction(isEnabled)
+    }
+
+    let backgroundStyle: ListItemBackgroundStyleType
+
+    @Environment(\.isEnabled) private var isEnabled: Bool
 }
 
 // MARK: Constants
@@ -287,10 +330,12 @@ private struct AccessibilityIdentifiers {
 public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
-         footer: Footer = String()) {
+         footer: Footer = String(),
+         action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.action = action
         let layoutType = ListItem.layoutType(subtitle: subtitle, footer: footer)
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
     }
@@ -300,11 +345,13 @@ public extension ListItem where TrailingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
-         @ViewBuilder leadingContent: @escaping () -> LeadingContent) {
+         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
+         action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.leadingContent = leadingContent
+        self.action = action
         let layoutType = ListItem.layoutType(subtitle: subtitle, footer: footer)
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
     }
@@ -314,11 +361,13 @@ public extension ListItem where LeadingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
-         @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
+         @ViewBuilder trailingContent: @escaping () -> TrailingContent,
+         action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.trailingContent = trailingContent
+        self.action = action
         let layoutType = ListItem.layoutType(subtitle: subtitle, footer: footer)
         self.tokenSet = ListItemTokenSet(customViewSize: { layoutType.leadingContentSize })
     }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -160,26 +160,20 @@ public struct ListItem<LeadingContent: View,
                             .padding(.leading, ListItemTokenSet.horizontalSpacing)
                     }
                 }
-                .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
-                                    leading: ListItemTokenSet.paddingLeading,
-                                    bottom: ListItemTokenSet.paddingVertical,
-                                    trailing: accessoryType == .none ? ListItemTokenSet.paddingTrailing : 0))
                 .accessibilityElement(children: .combine)
                 .accessibilitySortPriority(2)
                 if !combineTrailingContentAccessibilityElement {
                     trailingContentView
-                        .modifyIf(accessoryType == .none, { content in
-                            content
-                                .padding(.trailing, ListItemTokenSet.paddingTrailing)
-                        })
+                        .padding(.leading, ListItemTokenSet.horizontalSpacing)
                         .accessibilitySortPriority(1)
                 }
                 accessoryView
-                    .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
-                                        leading: ListItemTokenSet.horizontalSpacing,
-                                        bottom: ListItemTokenSet.paddingVertical,
-                                        trailing: ListItemTokenSet.paddingTrailing))
+                    .padding(.leading, ListItemTokenSet.horizontalSpacing)
             }
+            .padding(EdgeInsets(top: ListItemTokenSet.paddingVertical,
+                                leading: ListItemTokenSet.paddingLeading,
+                                bottom: ListItemTokenSet.paddingVertical,
+                                trailing: ListItemTokenSet.paddingTrailing))
             .frame(minHeight: layoutType.minHeight)
             .opacity(isEnabled ? ListItemTokenSet.enabledAlpha : ListItemTokenSet.disabledAlpha)
             .background(backgroundView)

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -191,7 +191,7 @@ public struct ListItem<LeadingContent: View,
                 SwiftUI.Button(action: action, label: {
                     innerContent
                 })
-                .buttonStyle(ListItemButtonStyle(backgroundStyle: backgroundStyleType))
+                .buttonStyle(ListItemButtonStyle(backgroundStyleTyle: backgroundStyleType, tokenSet: tokenSet))
             } else {
                 innerContent
             }
@@ -293,13 +293,14 @@ public struct ListItem<LeadingContent: View,
 // MARK: Internal structs
 
 private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
-    init(backgroundStyle: ListItemBackgroundStyleType) {
-        self.backgroundStyle = backgroundStyle
+    init(backgroundStyleTyle: ListItemBackgroundStyleType, tokenSet: ListItemTokenSet) {
+        self.backgroundStyleTyle = backgroundStyleTyle
+        self.tokenSet = tokenSet
     }
 
     func makeBody(configuration: Configuration) -> some View {
-        let backgroundColor = configuration.isPressed ? ListItemTokenSet(customViewSize: { ListItemLeadingContentSize.zero })[.cellBackgroundSelectedColor].uiColor : .clear
-        let cornerRadius = backgroundStyle == .plain && Compatibility.isDeviceIdiomVision() ? 16.0 : 0
+        let backgroundColor = configuration.isPressed ? tokenSet[.cellBackgroundSelectedColor].uiColor : .clear
+        let cornerRadius = backgroundStyleTyle == .plain && Compatibility.isDeviceIdiomVision() ? 16.0 : 0
 
         return configuration.label
             .background(Color(backgroundColor))
@@ -308,7 +309,8 @@ private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
             .pointerInteraction(isEnabled)
     }
 
-    let backgroundStyle: ListItemBackgroundStyleType
+    let backgroundStyleTyle: ListItemBackgroundStyleType
+    let tokenSet: ListItemTokenSet
 
     @Environment(\.isEnabled) private var isEnabled: Bool
 }

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -190,6 +190,12 @@ public struct ListItem<LeadingContent: View,
                     .buttonStyle(ListItemButtonStyle(backgroundStyleType: backgroundStyleType, tokenSet: tokenSet))
                 } else {
                     innerContent
+                        // This is necessary so that the VoiceOver focus ring includes the `innerContent` padding.
+                        // When accessoryType == .detailButton, the detail button should be its own accessiblity element.
+                        .modifyIf(accessoryType != .detailButton, { content in
+                            content
+                                .accessibilityElement(children: .combine)
+                        })
                 }
             }
             .listRowInsets(EdgeInsets())

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -187,7 +187,7 @@ public struct ListItem<LeadingContent: View,
                     SwiftUI.Button(action: action, label: {
                         innerContent
                     })
-                    .buttonStyle(ListItemButtonStyle(backgroundStyleTyle: backgroundStyleType, tokenSet: tokenSet))
+                    .buttonStyle(ListItemButtonStyle(backgroundStyleType: backgroundStyleType, tokenSet: tokenSet))
                 } else {
                     innerContent
                 }
@@ -290,14 +290,14 @@ public struct ListItem<LeadingContent: View,
 // MARK: Internal structs
 
 private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
-    init(backgroundStyleTyle: ListItemBackgroundStyleType, tokenSet: ListItemTokenSet) {
-        self.backgroundStyleTyle = backgroundStyleTyle
+    init(backgroundStyleType: ListItemBackgroundStyleType, tokenSet: ListItemTokenSet) {
+        self.backgroundStyleType = backgroundStyleType
         self.tokenSet = tokenSet
     }
 
     func makeBody(configuration: Configuration) -> some View {
         let backgroundColor = configuration.isPressed ? tokenSet[.cellBackgroundSelectedColor].uiColor : .clear
-        let cornerRadius = backgroundStyleTyle == .plain && Compatibility.isDeviceIdiomVision() ? 16.0 : 0
+        let cornerRadius = backgroundStyleType == .plain && Compatibility.isDeviceIdiomVision() ? 16.0 : 0
 
         return configuration.label
             .background(Color(backgroundColor))
@@ -306,7 +306,7 @@ private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
             .pointerInteraction(isEnabled)
     }
 
-    let backgroundStyleTyle: ListItemBackgroundStyleType
+    let backgroundStyleType: ListItemBackgroundStyleType
     let tokenSet: ListItemTokenSet
 
     @Environment(\.isEnabled) private var isEnabled: Bool


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Adding support for `ListItem` on visionOS.

Currently, `ListItem` internally is a `View`, which means on visionOS, there is no hover/gaze effect. When there are no tap gestures added to the view, this is ok. However, when the `ListItem` is tappable, this presents a usability issue (users can't tell where they are and may not be aware the view is tappable). To fix this, update `ListItem` to be a `Button` when necessary.

List of changes
- New parameter: `action` is an optional closure that executes when the `ListItem` is tapped.
- `ListItemButtonStyle`: a custom SwiftUI button style that is applied when `ListItem` is a `Button`
  - The default cornerRadius makes the button a capsule, update it to match `TableViewCell`
  - Use `cellBackgroundSelectedColor` as the background color when selected
  - The resting color is already set on the `ListItem` itself
- Setting a `buttonStyle` on the `ListItem` will trickle down to the detail button. Explicitly set the detail button's style. On iOS, it should be `.plain` and on visionOS it should be `.bordered`
  - When `ListItem` was first implemented, it was done so to mimic `TableViewCell` as closely as possible. This meant a larger padded detail button. To achieve this, the accessory view's padding was applied to the image and an extra background was added to address VoiceOver. Both of these changes do not work on visionOS (bloated button and darker background).
    - To fix the padding, apply it to the accessory view/`innerContent` instead. Changes made:
      - Move the padding values around so `paddingLeading/paddingTrailing/paddingVertical` are always be on `innerContent`. No matter what's inside the list item, these padding values always apply (this allows us to remove all the conditional code depending on if there's a `trailingContentView`/accessory view.
      - `horizontalSpacing` should then apply to the leading edge of the `trailingContentView` and accessory view. Since it's on the leading edge, we don't run into the issue of double padding.
    - Remove the VoiceOver change, this is actually a bug in `TableViewCell`, not `ListItem` (see screenshot of `UITableViewCell`)
- To preserve existing behavior, when `action` is nil, `ListItem` should still be a `View`
- Update `ListItemDemoController_SwiftUI` with an option to add/remove an `action`
- Add option to display `ListItem` outside `List`

### Binary change

Total increase: 56,264 bytes
Total decrease: -1,568 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,359,184 bytes | 31,413,880 bytes | 🛑 54,696 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| ListItem.o | 268,680 bytes | 315,992 bytes | ⚠️ 47,312 bytes |
| __.SYMDEF | 4,830,512 bytes | 4,839,192 bytes | ⚠️ 8,680 bytes |
| FocusRingView.o | 837,952 bytes | 838,224 bytes | ⚠️ 272 bytes |
| SwiftUI+ViewModifiers.o | 128,464 bytes | 126,896 bytes | 🎉 -1,568 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After iOS                                     | After visionOS                                     |
|----------------------------------------------|--------------------------------------------|--------------------------------------------|
| ![none before](https://github.com/microsoft/fluentui-apple/assets/55368679/e3463baf-50a4-4096-84ce-e8b0730e36be) | ![none after](https://github.com/microsoft/fluentui-apple/assets/55368679/c49f49b9-241a-462c-90e6-2e4659d02224) | ![none](https://github.com/microsoft/fluentui-apple/assets/55368679/64fab2dd-1849-4195-add3-e0338078d51c) |
| ![detail before](https://github.com/microsoft/fluentui-apple/assets/55368679/55ec1e6e-9ead-449e-87a9-2935caca51f9) | ![detail after](https://github.com/microsoft/fluentui-apple/assets/55368679/77c1de08-8c51-4095-bc09-3811bf952d7d) | ![detail](https://github.com/microsoft/fluentui-apple/assets/55368679/2ffa2b53-cd13-425d-8da5-4c7179445a62) |

Standalone `ListItem`
| iOS                                       | visionOS                                      |
|----------------------------------------------|--------------------------------------------|
| ![standalone ipad](https://github.com/microsoft/fluentui-apple/assets/55368679/28202de5-732a-4e4d-a42f-d84745a5b028) | ![standalone vision](https://github.com/microsoft/fluentui-apple/assets/55368679/496992fe-4d85-4fc4-95fc-631c7c0212db) |

VoiceOver change
| UITableViewCell                                       | Before                                      | After                                      |
|----------------------------------------------|--------------------------------------------|--------------------------------------------|
| <img width="672" alt="vo" src="https://github.com/microsoft/fluentui-apple/assets/55368679/2ca21a46-d19b-4e51-8419-29eaaf1dd018"> | <img width="664" alt="ios before" src="https://github.com/microsoft/fluentui-apple/assets/55368679/0c823bce-20a9-44d8-9f9e-3384c73e41b8"> | <img width="658" alt="ios after" src="https://github.com/microsoft/fluentui-apple/assets/55368679/c9850490-c926-41f5-bffd-d8bd87c1f48e"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2000)