### PR TITLE
Place notification on glass on visionOS

### DIFF
--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -290,6 +290,9 @@ public struct FluentNotification: View, TokenizedControlView {
                         )
                         .applyFluentShadow(shadowInfo: shadowInfo)
                 )
+#if os(visionOS)
+                .glassBackgroundEffect(in: RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
+#endif // os(visionOS)
                 .onTapGesture {
                     if let messageAction = messageButtonAction {
                         isPresented = false

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -206,7 +206,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
 
             case .shadow:
                 return .shadowInfo {
-                    if style().isToast {
+                    if style().isToast && !Compatibility.isDeviceIdiomVision() {
                         return theme.shadow(.shadow16)
                     } else {
                         return theme.shadow(.clear)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

`FluentNotification` is written in SwiftUI, which means we can use the `glassBackgroundEffect`. This places notification on a glass material. This change is most noticeable with `neutralToast`, which is currently clear. The glass adds a material difference that distinguishes notification from other glass surfaces.

While making this change, I also found a bug with shadows. Since windows on visionOS cast their own shadow, remove our implementation and default all shadows on visionOS to be clear

### Binary change

Total increase: 3,280 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,359,184 bytes | 31,362,464 bytes | ⚠️ 3,280 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| NotificationTokenSet.o | 91,416 bytes | 93,848 bytes | ⚠️ 2,432 bytes |
| __.SYMDEF | 4,830,512 bytes | 4,831,360 bytes | ⚠️ 848 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/a28fdebb-0f00-433b-a1fe-e62d34d02784) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/f627ae64-6e79-4775-a070-31f1013ade38) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2002)