### PR TITLE
[cherry-pick] Extend FluentButtonToggleStyle to support overrideTokens(_:) (#1996)

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -82,6 +82,7 @@ struct ButtonDemoView: View {
     @State var size: ControlSize = .large
     @State var style: FluentUI.ButtonStyle = .accent
     @State var showToggle: Bool = false
+    @State var showThemeOverrides: Bool = false
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
 
@@ -106,7 +107,7 @@ struct ButtonDemoView: View {
         }, label: {
             buttonLabel
         })
-        .buttonStyle(FluentButtonStyle(style: buttonStyle))
+        .buttonStyle(fluentButtonStyle(style: buttonStyle))
         .controlSize(controlSize)
         .disabled(isDisabled)
         .fixedSize()
@@ -121,7 +122,7 @@ struct ButtonDemoView: View {
         Toggle(isOn: $isToggleOn, label: {
             buttonLabel
         })
-        .toggleStyle(FluentButtonToggleStyle())
+        .toggleStyle(fluentButtonToggleStyle())
         .controlSize(controlSize)
         .disabled(isDisabled)
         .fixedSize()
@@ -162,6 +163,8 @@ struct ButtonDemoView: View {
                         Text("\(buttonSize.description)").tag(buttonSize)
                     }
                 }
+
+                FluentUIDemoToggle(titleKey: "Show theme overrides", isOn: $showThemeOverrides)
             }
 
             Section("More") {
@@ -188,6 +191,26 @@ struct ButtonDemoView: View {
             }
         }
     }
+
+    private func fluentButtonStyle(style: FluentUI.ButtonStyle) -> FluentButtonStyle {
+        var buttonStyle = FluentButtonStyle(style: style)
+        if showThemeOverrides {
+            buttonStyle.overrideTokens(tokenOverrides)
+        }
+        return buttonStyle
+    }
+
+    private func fluentButtonToggleStyle() -> FluentButtonToggleStyle {
+        var buttonToggleStyle = FluentButtonToggleStyle()
+        if showThemeOverrides {
+            buttonToggleStyle.overrideTokens(tokenOverrides)
+        }
+        return buttonToggleStyle
+    }
+
+    private var tokenOverrides: [ButtonToken: ControlTokenValue] = [
+        .backgroundPressedColor: .uiColor { .red }
+    ]
 }
 
 private extension ControlSize {

--- a/ios/FluentUI/Button/FluentButtonToggleStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonToggleStyle.swift
@@ -33,17 +33,38 @@ public struct FluentButtonToggleStyle: ToggleStyle {
     }
 
     private var buttonTokens: [ButtonToken: ControlTokenValue] {
-        [
+        var tokens: [ButtonToken: ControlTokenValue] = [
             .cornerRadius: .float { GlobalTokens.corner(.radius40) }
         ]
+
+        if let tokenOverrides = tokenOverrides {
+            tokens = tokens.merging(tokenOverrides) { (_, new) in new }
+        }
+
+        return tokens
     }
 
     private var buttonOnTokens: [ButtonToken: ControlTokenValue] {
         let backgroundColor = fluentTheme.color(.brandBackgroundTint)
-        return buttonTokens.merging([
+        var tokens: [ButtonToken: ControlTokenValue] = buttonTokens.merging([
             .backgroundColor: .uiColor { backgroundColor },
             .backgroundPressedColor: .uiColor { backgroundColor },
             .backgroundFocusedColor: .uiColor { backgroundColor }
         ]) { (_, new) in new }
+
+        if let tokenOverrides = tokenOverrides {
+            tokens = tokens.merging(tokenOverrides) { (_, new) in new }
+        }
+
+        return tokens
+    }
+
+    private var tokenOverrides: [ButtonToken: ControlTokenValue]?
+}
+
+public extension FluentButtonToggleStyle {
+    /// Provide override values for various `ButtonToken` values.
+    mutating func overrideTokens(_ overrides: [ButtonToken: ControlTokenValue]) {
+        tokenOverrides = overrides
     }
 }


### PR DESCRIPTION
Cherry-pick into main_0.27:
- #1996 

### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

There is a use case internally where we need to use slightly different colors for the `FluentButtonToggleStyle` than what is provided through the default button styles. To support this, we should extend `FluentButtonToggleStyle` to support `overrideTokens(_:)`.

### Binary change

Total increase: 5,864 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,977,488 bytes | 30,983,352 bytes | ⚠️ 5,864 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentButtonToggleStyle.o | 66,648 bytes | 70,904 bytes | ⚠️ 4,256 bytes |
| __.SYMDEF | 4,754,208 bytes | 4,755,448 bytes | ⚠️ 1,240 bytes |
| FocusRingView.o | 813,256 bytes | 813,624 bytes | ⚠️ 368 bytes |
</details>

### Verification

I validated the change internally by verifying the colors I provided via `overrideTokens(_:)` are applied to the `Toggle`.

<details>
<summary>Visual Verification</summary>

Recording of changes made to demo to show functionality of using the exposed `overrideTokens(_:)`:

https://github.com/microsoft/fluentui-apple/assets/10938746/498337b8-1c45-41d3-9b41-187bb41e7db4

</details>

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2003)