### PR TITLE
Reintroduce light mode iOS tokens on visionOS

### DIFF
--- a/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
@@ -8,48 +8,52 @@ import UIKit
 #if os(visionOS)
 extension FluentTheme {
     static func defaultColor_visionOS(_ token: FluentTheme.ColorToken) -> UIColor {
+        let visionColor: UIColor
+
         // Apply overrides as needed. Note that visionOS only supports one mode, so there's no
         // need to provide multiple values (e.g. light + dark, elevated, etc).
         switch token {
         case .foreground1:
-            return .white
+            visionColor = .white
         case .foreground2:
-            return .white
+            visionColor = .white
         case .foreground3:
-            return .white
+            visionColor = .white
         case .foregroundDisabled1:
-            return .white.withAlphaComponent(0.8)
+            visionColor = .white.withAlphaComponent(0.8)
         case .foregroundOnColor:
-            return .white
+            visionColor = .white
         case .background1:
-            return .clear
+            visionColor = .clear
         case .background1Pressed:
-            return .white.withAlphaComponent(0.1)
+            visionColor = .white.withAlphaComponent(0.1)
         case .background2:
-            return .black.withAlphaComponent(0.1)
+            visionColor = .black.withAlphaComponent(0.1)
         case .background2Pressed:
-            return .clear
+            visionColor = .clear
         case .background3:
-            return .black.withAlphaComponent(0.1)
+            visionColor = .black.withAlphaComponent(0.1)
         case .background4:
-            return .clear
+            visionColor = .clear
         case .background5:
-            return .black.withAlphaComponent(0.2)
+            visionColor = .black.withAlphaComponent(0.2)
         case .background5Pressed:
-            return .black.withAlphaComponent(0.1)
+            visionColor = .black.withAlphaComponent(0.1)
         case .backgroundCanvas:
-            return .clear
+            visionColor = .clear
         case .stroke1:
-            return .white.withAlphaComponent(0.4)
+            visionColor = .white.withAlphaComponent(0.4)
         case .stroke2:
-            return .white.withAlphaComponent(0.5)
+            visionColor = .white.withAlphaComponent(0.5)
         case .dangerForeground2:
-            return GlobalTokens.sharedColor(.red, .primary)
+            visionColor = GlobalTokens.sharedColor(.red, .primary)
 
         default:
             // Return the standard iOS color by default.
-            return defaultColor(token)
+            visionColor = defaultColor(token)
         }
+
+        return UIColor(light: defaultColor(token).light, dark: visionColor.dark)
     }
 }
 #endif


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

#1980 separated out visionOS tokens from iOS ones. For 99% of cases, this works perfectly fine. However, in the 1% of cases where we want to override the user interface style and were relying on iOS light mode colors, this change meant that we no longer had access to them. Reintroduce these missing tokens.

### Binary change

Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,362,464 bytes | 31,362,464 bytes | 🎉 0 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
</details>

### Verification

iOS light mode
![ipad](https://github.com/microsoft/fluentui-apple/assets/55368679/794c430d-7838-4192-a801-06d38d046246)

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/0d336032-a998-4efd-b07e-7c05b8390def) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/bf588a7a-6024-4447-9162-3ca38191d2f4) |


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2007)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2008)