### PR TITLE
SwiftUI Tooltip

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		92DD1E8D279F496300FDEE0F /* DemoAppearanceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DD1E8C279F496300FDEE0F /* DemoAppearanceView.swift */; };
 		92E977B726C7144F008E10A8 /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E977B526C713F3008E10A8 /* UIResponder+Extensions.swift */; };
 		92E977B826C7144F008E10A8 /* DemoControllerScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E977B426C713F3008E10A8 /* DemoControllerScrollView.swift */; };
+		92EFD3E42BDA28F100DB35F2 /* TooltipDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EFD3E32BDA28F100DB35F2 /* TooltipDemoController_SwiftUI.swift */; };
 		A589F856211BA71000471C23 /* LabelDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A589F855211BA71000471C23 /* LabelDemoController.swift */; };
 		A591A3F420F429EB001ED23B /* Demos.swift in Sources */ = {isa = PBXBuildFile; fileRef = A591A3F320F429EB001ED23B /* Demos.swift */; };
 		A5CEC21020E436F10016922A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CEC20F20E436F10016922A /* AppDelegate.swift */; };
@@ -236,6 +237,7 @@
 		92E4784B2661AED800BAA058 /* PersonaButtonCarouselDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselDemoController.swift; sourceTree = "<group>"; };
 		92E977B426C713F3008E10A8 /* DemoControllerScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoControllerScrollView.swift; sourceTree = "<group>"; };
 		92E977B526C713F3008E10A8 /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
+		92EFD3E32BDA28F100DB35F2 /* TooltipDemoController_SwiftUI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TooltipDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		A589F855211BA71000471C23 /* LabelDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelDemoController.swift; sourceTree = "<group>"; };
 		A591A3F320F429EB001ED23B /* Demos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Demos.swift; sourceTree = "<group>"; };
 		A5961FA8218A61BB00E2A506 /* PopupMenuDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopupMenuDemoController.swift; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 				EC98E2B72992FE6900B9DF91 /* TextFieldObjCDemoController.h */,
 				EC98E2B52992FE5000B9DF91 /* TextFieldObjCDemoController.m */,
 				FD7DF06121FB941400857267 /* TooltipDemoController.swift */,
+				92EFD3E32BDA28F100DB35F2 /* TooltipDemoController_SwiftUI.swift */,
 				66963D0B29CB792E006F5FA9 /* TwoLineTitleViewDemoController.swift */,
 				92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */,
 				6FEED93A28A6E5520099D178 /* AliasColorTokensDemoController.swift */,
@@ -841,6 +844,7 @@
 				497DC2DE24185896008D86F8 /* PillButtonBarDemoController.swift in Sources */,
 				B4EF53C5215C45C400573E8F /* PersonaListViewDemoController.swift in Sources */,
 				A5DCA75E211E3A92005F4CB7 /* DrawerDemoController.swift in Sources */,
+				92EFD3E42BDA28F100DB35F2 /* TooltipDemoController_SwiftUI.swift in Sources */,
 				B4414792228F6F740040E88E /* TableViewCellSampleData.swift in Sources */,
 				92B45E4E279A1A0B00E72517 /* DemoAppearanceController.swift in Sources */,
 				E6842974247B672000A29C40 /* SceneDelegate.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos.swift
@@ -54,7 +54,7 @@ struct Demos {
         DemoDescriptor("TableViewCell", TableViewCellDemoController.self, supportsVisionOS: true),
         DemoDescriptor("TableViewHeaderFooterView", TableViewHeaderFooterViewDemoController.self, supportsVisionOS: true),
         DemoDescriptor("Text Field", TextFieldDemoController.self, supportsVisionOS: false),
-        DemoDescriptor("Tooltip", TooltipDemoController.self, supportsVisionOS: false),
+        DemoDescriptor("Tooltip", TooltipDemoController.self, supportsVisionOS: true),
         DemoDescriptor("TwoLineTitleView", TwoLineTitleViewDemoController.self, supportsVisionOS: false)
     ]
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -28,8 +28,6 @@ struct ButtonDemoView: View {
                 demoToggle(size, isDisabled: isDisabled)
             } else {
                 demoButton(style, size, isDisabled: isDisabled)
-                    .fluentTooltip(message: "This is a tooltip!",
-                                   preferredArrowDirection: .left)
             }
             demoOptions
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController_SwiftUI.swift
@@ -28,6 +28,8 @@ struct ButtonDemoView: View {
                 demoToggle(size, isDisabled: isDisabled)
             } else {
                 demoButton(style, size, isDisabled: isDisabled)
+                    .fluentTooltip(message: "This is a tooltip!",
+                                   preferredArrowDirection: .left)
             }
             demoOptions
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift
@@ -19,6 +19,7 @@ class TooltipDemoController: DemoController {
         navigationItem.titleView = titleView
         navigationItem.rightBarButtonItems?.append(UIBarButtonItem(title: "Show on title", style: .plain, target: self, action: #selector(showTitleTooltip)))
 
+        container.addArrangedSubview(createButton(title: "Show SwiftUI Demo", action: #selector(showSwiftUIDemo)))
         container.addArrangedSubview(createButton(title: "Show single-line tooltip below", action: #selector(showSingleTooltipBelow)))
         container.addArrangedSubview(createButton(title: "Show double-line tooltip above", action: #selector(showDoubleTooltipAbove)))
         container.addArrangedSubview(createButton(title: "Show tooltip with title above", action: #selector(showTooltipWithTitle)))
@@ -90,6 +91,11 @@ class TooltipDemoController: DemoController {
         container.addArrangedSubview(middleLabel)
         container.addArrangedSubview(bottomContainer)
         return container
+    }
+
+    @objc func showSwiftUIDemo() {
+        navigationController?.pushViewController(TooltipDemoControllerSwiftUI(),
+                                                 animated: true)
     }
 
     @objc func showTitleTooltip(sender: UIBarButtonItem) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController_SwiftUI.swift
@@ -1,0 +1,133 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import SwiftUI
+import UIKit
+
+class TooltipDemoControllerSwiftUI: DemoHostingController {
+    init() {
+        super.init(rootView: AnyView(TooltipDemoView()), title: "Tooltip (SwiftUI)")
+    }
+
+    @objc required dynamic init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    @MainActor required dynamic init(rootView: AnyView) {
+        preconditionFailure("init(rootView:) has not been implemented")
+    }
+}
+
+struct TooltipDemoView: View {
+    public var body: some View {
+        VStack {
+            tooltipAnchor
+            demoOptions
+        }
+    }
+
+    @ViewBuilder
+    private var tooltipAnchor: some View {
+        Button(action: {
+            showTooltip = true
+        }, label: {
+            Text("Tap for Tooltip")
+        })
+        .buttonStyle(FluentButtonStyle(style: .accent))
+        .controlSize(.large)
+        .fixedSize()
+        .fluentTooltip(message: tooltipMessage,
+                       title: (tooltipTitle != "") ? tooltipTitle : nil,
+                       preferredArrowDirection: arrowDirection,
+                       offset: offset,
+                       dismissMode: dismissMode,
+                       isPresented: $showTooltip)
+        .padding(GlobalTokens.spacing(.size560))
+    }
+
+    @ViewBuilder
+    private var demoOptions: some View {
+        Form {
+            Section("Content") {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Title")
+                    Spacer()
+                    TextField("Title", text: $tooltipTitle)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .multilineTextAlignment(.trailing)
+                }
+                .frame(maxWidth: .infinity)
+
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Message")
+                    Spacer()
+                    TextField("Message", text: $tooltipMessage)
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                        .multilineTextAlignment(.trailing)
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            Section("Layout") {
+                Picker("Dismiss Mode", selection: $dismissMode) {
+                    ForEach(Array(Tooltip.DismissMode.allCases.enumerated()), id: \.element) { _, dismissMode in
+                        Text("\(dismissMode.description)").tag(dismissMode)
+                    }
+                }
+
+                Picker("Arrow Direction", selection: $arrowDirection) {
+                    ForEach(Array(Tooltip.ArrowDirection.allCases.enumerated()), id: \.element) { _, direction in
+                        Text("\(direction.description)").tag(direction)
+                    }
+                }
+
+                FluentUIDemoToggle(titleKey: "Use offset for origin", isOn: $useOffset)
+            }
+        }
+    }
+
+    private var offset: CGPoint {
+        useOffset ? .init(x: 20, y: 20) : .zero
+    }
+
+    @State private var showTooltip: Bool = true
+
+    @State private var tooltipTitle: String = ""
+    @State private var tooltipMessage: String = "Tooltip message"
+    @State private var arrowDirection: Tooltip.ArrowDirection = .down
+    @State private var dismissMode: Tooltip.DismissMode = .tapAnywhere
+    @State private var useOffset: Bool = false
+}
+
+private extension Tooltip.ArrowDirection {
+    var description: String {
+        switch self {
+        case .up:
+            return "Up"
+        case .down:
+            return "Down"
+        case .left:
+            return "Left"
+        case .right:
+            return "Right"
+        }
+    }
+}
+
+private extension Tooltip.DismissMode {
+    var description: String {
+        switch self {
+        case .tapAnywhere:
+            return "Tap anywhere"
+        case .tapOnTooltip:
+            return "Tap on Tooltip"
+        case .tapOnTooltipOrAnchor:
+            return "Tap on Tooltip or Anchor"
+        }
+    }
+}

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController_SwiftUI.swift
@@ -22,7 +22,7 @@ class TooltipDemoControllerSwiftUI: DemoHostingController {
 }
 
 struct TooltipDemoView: View {
-    public var body: some View {
+     var body: some View {
         VStack {
             tooltipAnchor
             demoOptions

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		929DD25A266ED3B600E8175E /* PersonaButtonCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */; };
 		929F2ACF2BB77ED100683EA8 /* FluentButtonToggleStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 929F2ACE2BB77ED100683EA8 /* FluentButtonToggleStyle.swift */; };
 		92A1E4F526A791590007ED60 /* MSFCardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A1E4F326A791590007ED60 /* MSFCardNudge.swift */; };
+		92B2E2352BD71F27005D42C4 /* TooltipModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B2E2342BD71F27005D42C4 /* TooltipModifiers.swift */; };
 		92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */; };
 		92D49054278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */; };
 		92D5598226A0FD2800328FD3 /* CardNudge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598026A0FD2800328FD3 /* CardNudge.swift */; };
@@ -370,6 +371,7 @@
 		929DD258266ED3B600E8175E /* PersonaButtonCarousel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarousel.swift; sourceTree = "<group>"; };
 		929F2ACE2BB77ED100683EA8 /* FluentButtonToggleStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentButtonToggleStyle.swift; sourceTree = "<group>"; };
 		92A1E4F326A791590007ED60 /* MSFCardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFCardNudge.swift; sourceTree = "<group>"; };
+		92B2E2342BD71F27005D42C4 /* TooltipModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipModifiers.swift; sourceTree = "<group>"; };
 		92B7E6A12684262900EFC15E /* MSFPersonaButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MSFPersonaButton.swift; sourceTree = "<group>"; };
 		92D49053278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonaButtonCarouselModifiers.swift; sourceTree = "<group>"; };
 		92D5598026A0FD2800328FD3 /* CardNudge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudge.swift; sourceTree = "<group>"; };
@@ -1309,6 +1311,7 @@
 			isa = PBXGroup;
 			children = (
 				FD7DF05B21FA7F5000857267 /* Tooltip.swift */,
+				92B2E2342BD71F27005D42C4 /* TooltipModifiers.swift */,
 				4B8245D7293FC7A200CF0C77 /* TooltipTokenSet.swift */,
 				FD7DF05D21FA7FC100857267 /* TooltipView.swift */,
 				FD7DF05F21FA83C900857267 /* TooltipViewController.swift */,
@@ -1720,6 +1723,7 @@
 				80AECC22263339E5005AF2F3 /* BottomSheetPassthroughView.swift in Sources */,
 				925728F9276D6B5800EE1019 /* FontInfo.swift in Sources */,
 				5314E1CD25F01B730099271A /* AnimationSynchronizer.swift in Sources */,
+				92B2E2352BD71F27005D42C4 /* TooltipModifiers.swift in Sources */,
 				92088EF92666DB2C003F571A /* PersonaButton.swift in Sources */,
 				9231491428BF026A001B033E /* MSFHeadsUpDisplay.swift in Sources */,
 				5314E13425F016370099271A /* PopupMenuItem.swift in Sources */,

--- a/ios/FluentUI/Tooltip/Tooltip.swift
+++ b/ios/FluentUI/Tooltip/Tooltip.swift
@@ -229,7 +229,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
     }
 
     @objc(MSFTooltipArrowDirection)
-    public enum ArrowDirection: Int {
+    public enum ArrowDirection: Int, CaseIterable {
         case up, down, left, right
 
         var isVertical: Bool {
@@ -256,7 +256,7 @@ open class Tooltip: NSObject, TokenizedControlInternal {
     }
 
     @objc(MSFTooltipDismissMode)
-    public enum DismissMode: Int {
+    public enum DismissMode: Int, CaseIterable {
         case tapAnywhere
         case tapOnTooltip
         case tapOnTooltipOrAnchor

--- a/ios/FluentUI/Tooltip/TooltipModifiers.swift
+++ b/ios/FluentUI/Tooltip/TooltipModifiers.swift
@@ -6,37 +6,88 @@
 import SwiftUI
 
 public extension View {
-    func fluentTooltip() -> some View {
-        self.modifier(TooltipModifier())
+    func fluentTooltip(message: String,
+                       title: String? = nil,
+                       hostViewController: UIViewController? = nil,
+                       preferredArrowDirection: Tooltip.ArrowDirection = .down,
+                       offset: CGPoint = CGPoint(x: 0, y: 0),
+                       dismissMode: Tooltip.DismissMode = .tapAnywhere,
+                       onTap: (() -> Void)? = nil) -> some View {
+        // Package up all the values to pass through.
+        self.modifier(
+            TooltipModifier(
+                values: ToolbarAnchorViewValues(
+                    message: message,
+                    title: title,
+                    hostViewController: hostViewController,
+                    preferredArrowDirection: preferredArrowDirection,
+                    offset: offset,
+                    dismissMode: dismissMode,
+                    onTap: onTap)
+            )
+        )
     }
 }
 
+// MARK: - Private support for public modifiers
+
+private struct ToolbarAnchorViewValues {
+    let message: String
+    let title: String?
+    let hostViewController: UIViewController?
+    let preferredArrowDirection: Tooltip.ArrowDirection
+    let offset: CGPoint
+    let dismissMode: Tooltip.DismissMode
+    let onTap: (() -> Void)?
+}
+
 private struct TooltipModifier: ViewModifier {
+    let values: ToolbarAnchorViewValues
     func body(content: Content) -> some View {
         content
             .background {
-                ToolbarAnchorViewRepresentable()
+                ToolbarAnchorViewRepresentable(values: values)
             }
     }
 }
 
 private class ToolbarAnchorView: UIView {
+    init(values: ToolbarAnchorViewValues) {
+        self.values = values
+        super.init(frame: .zero)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func didMoveToWindow() {
         super.didMoveToWindow()
         if window != nil {
-            Tooltip.shared.show(with: "This is a title-based tooltip.", for: self, preferredArrowDirection: .up)
+            Tooltip.shared.show(with: values.message,
+                                title: values.title,
+                                for: self,
+                                in: values.hostViewController,
+                                preferredArrowDirection: values.preferredArrowDirection,
+                                offset: values.offset,
+                                dismissOn: values.dismissMode,
+                                onTap: values.onTap)
         }
     }
+
+    private let values: ToolbarAnchorViewValues
 }
 
 private struct ToolbarAnchorViewRepresentable: UIViewRepresentable {
     func makeUIView(context: Self.Context) -> ToolbarAnchorView {
-        let view = ToolbarAnchorView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        let view = ToolbarAnchorView(values: values)
         view.backgroundColor = .red
         return view
     }
 
     func updateUIView(_ uiView: ToolbarAnchorView, context: Context) {
+        // no-op
     }
 
+    let values: ToolbarAnchorViewValues
 }

--- a/ios/FluentUI/Tooltip/TooltipModifiers.swift
+++ b/ios/FluentUI/Tooltip/TooltipModifiers.swift
@@ -96,10 +96,6 @@ private class TooltipAnchorView: UIView {
         showTooltipIfPossible()
     }
 
-    func hideTooltip() {
-        Tooltip.shared.hide()
-    }
-
     func showTooltipIfPossible() {
         if isPresented.wrappedValue && window != nil {
             Tooltip.shared.show(with: values.message,
@@ -133,7 +129,7 @@ private struct TooltipAnchorViewRepresentable: UIViewRepresentable {
         if isPresented {
             uiView.showTooltipIfPossible()
         } else {
-            uiView.hideTooltip()
+            Tooltip.shared.hide()
         }
     }
 }

--- a/ios/FluentUI/Tooltip/TooltipModifiers.swift
+++ b/ios/FluentUI/Tooltip/TooltipModifiers.swift
@@ -80,8 +80,6 @@ private class TooltipAnchorView: UIView {
         self.values = values
         self.isPresented = isPresented
         super.init(frame: .zero)
-
-        self.backgroundColor = .clear
     }
 
     required init?(coder: NSCoder) {

--- a/ios/FluentUI/Tooltip/TooltipModifiers.swift
+++ b/ios/FluentUI/Tooltip/TooltipModifiers.swift
@@ -1,0 +1,42 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public extension View {
+    func fluentTooltip() -> some View {
+        self.modifier(TooltipModifier())
+    }
+}
+
+private struct TooltipModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background {
+                ToolbarAnchorViewRepresentable()
+            }
+    }
+}
+
+private class ToolbarAnchorView: UIView {
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        if window != nil {
+            Tooltip.shared.show(with: "This is a title-based tooltip.", for: self, preferredArrowDirection: .up)
+        }
+    }
+}
+
+private struct ToolbarAnchorViewRepresentable: UIViewRepresentable {
+    func makeUIView(context: Self.Context) -> ToolbarAnchorView {
+        let view = ToolbarAnchorView(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        view.backgroundColor = .red
+        return view
+    }
+
+    func updateUIView(_ uiView: ToolbarAnchorView, context: Context) {
+    }
+
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Creates a new view modifier, `fluentTooltip`, for the Fluent `Tooltip` control to be used in SwiftUI.

```swift
@State private var showTooltip: Bool = true

var body: some View {
    SomeButton()
        .fluentTooltip(message: tooltipMessage,
                       title: tooltipTitle,
                       preferredArrowDirection: .up,
                       offset: CGPoint(x: 0, y: 20),
                       dismissMode: .tapAnywhere,
                       isPresented: $showTooltip)
}
```

This is a pure wrapper around the existing UIKit `Tooltip` class, so behaviors and functionality are the same.

To accomplish this, we create an invisible `UIView` (`TooltipAnchorView`) via a `UIViewRepresentable` (`TooltipAnchorViewRepresentable`), and attach it to the background of the SwiftUI `View` being modified.

Still to come: making it possible to host multiple tooltips in a single host view, with independent toggleable state (though only one will be visible at a time still).

### Binary change

Total increase: 132,464 bytes
Total decrease: -776 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,503,480 bytes | 31,635,168 bytes | 🛑 131,688 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TooltipModifiers.o | 0 bytes | 99,880 bytes | 🛑 99,880 bytes |
| __.SYMDEF | 4,884,448 bytes | 4,908,312 bytes | ⚠️ 23,864 bytes |
| Tooltip.o | 125,240 bytes | 132,816 bytes | ⚠️ 7,576 bytes |
| FocusRingView.o | 842,640 bytes | 843,264 bytes | ⚠️ 624 bytes |
| BadgeView.o | 633,312 bytes | 633,832 bytes | ⚠️ 520 bytes |
| SwiftUI+ViewAnimation.o | 49,176 bytes | 48,400 bytes | 🎉 -776 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| iOS                                       | visionOS                                      |
|----------------------------------------------|--------------------------------------------|
| ![tooltip](https://github.com/microsoft/fluentui-apple/assets/4934719/84647e7e-add6-4435-8203-98d564aeafa1) | Screenshot or description before this change | ![Simulator Screenshot - Apple Vision Pro - 2024-04-25 at 17 52 12](https://github.com/microsoft/fluentui-apple/assets/4934719/aebf3135-38f0-4c84-8f15-84be098bbfb6) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2010)