### PR TITLE
expose accessibility string for done action in navigation bar

### DIFF
--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -169,6 +169,10 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     /// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
     @objc public static let backButtonAccessibilityLabel: String = "Accessibility.NavigationBar.BackLabel".localized
 
+	/// The accessibility label that should be applied for the done button for when navigation bar is shown in a modal view.
+	/// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
+	@objc public static let doneButtonAccessibilityLabel: String = "Accessibility.Done.Label".localized
+
     /// An element size to describe the behavior of large title's avatar. If `.automatic`, avatar will resize when `expand(animated:)` and `contract(animated:)` are called.
     @objc open var avatarSize: ElementSize = .automatic {
         didSet {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -169,9 +169,9 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     /// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
     @objc public static let backButtonAccessibilityLabel: String = "Accessibility.NavigationBar.BackLabel".localized
 
-	/// The accessibility label that should be applied for the done button for when navigation bar is shown in a modal view.
-	/// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
-	@objc public static let doneButtonAccessibilityLabel: String = "Accessibility.Done.Label".localized
+    /// The accessibility label that should be applied for the done button for when navigation bar is shown in a modal view.
+    /// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
+    @objc public static let doneButtonAccessibilityLabel: String = "Accessibility.Done.Label".localized
 
     /// An element size to describe the behavior of large title's avatar. If `.automatic`, avatar will resize when `expand(animated:)` and `contract(animated:)` are called.
     @objc open var avatarSize: ElementSize = .automatic {

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -165,6 +165,10 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         }
     }
 
+    /// The accessibility label that should be applied for the back button.
+    /// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
+    @objc public static let backButtonAccessibilityLabel: String = "Accessibility.NavigationBar.BackLabel".localized
+
     /// An element size to describe the behavior of large title's avatar. If `.automatic`, avatar will resize when `expand(animated:)` and `contract(animated:)` are called.
     @objc open var avatarSize: ElementSize = .automatic {
         didSet {
@@ -349,7 +353,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
                                              target: nil,
                                              action: #selector(NavigationBarBackButtonDelegate.backButtonWasPressed))
         backButtonItem.accessibilityIdentifier = "Back"
-        backButtonItem.accessibilityLabel = "Accessibility.NavigationBar.BackLabel".localized
+        backButtonItem.accessibilityLabel = backButtonAccessibilityLabel
         return backButtonItem
     }()
 


### PR DESCRIPTION
### Platforms Impacted
- iOS
- visionOS

### Description of changes

Today we do not have a control for a navigation controller in swiftUI. Part of the navigation controller is providing a dismiss action which will need an accessibility identifier. Until we support a NavigationStack for swiftUI, we need the same accessibility identifier. Exposing it so it can be used.
### Binary change

Total increase: 3,101 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,260,080 bytes | 31,263,181 bytes | ⚠️ 3,101 bytes |


### Verification

Ran VoiceOver and the accessibility identifier is still read properly on the navigation bar.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2005)