### PR TITLE
Expose accessibility string on the correct component

### DIFF
--- a/ios/FluentUI/BarButtonItems/BarButtonItems.swift
+++ b/ios/FluentUI/BarButtonItems/BarButtonItems.swift
@@ -6,13 +6,18 @@
 import UIKit
 
 public final class BarButtonItems: NSObject {
+
+    /// The accessibility label that should be applied for the done bar button.
+    /// A temporary change so that consumers who use SwiftUI for a toolbar can avoid duplicated resources until support of a swiftUI control is available.
+    @objc public static let doneButtonAccessibilityLabel: String = "Accessibility.Done.Label".localized
+
     /// When adding this barButtonItem to the view, tint it with appropriate app color UIColor(light: Colors.primary(for: window), dark: Colors.textDominant)
     @objc static func confirm(target: Any?, action: Selector?) -> UIBarButtonItem {
         let image = UIImage.staticImageNamed("checkmark-24x24")
         let landscapeImage = UIImage.staticImageNamed("checkmark-thin-20x20")
 
         let button = UIBarButtonItem(image: image, landscapeImagePhone: landscapeImage, style: .plain, target: target, action: action)
-        button.accessibilityLabel = "Accessibility.Done.Label".localized
+        button.accessibilityLabel = doneButtonAccessibilityLabel
         return button
     }
 

--- a/ios/FluentUI/Navigation/NavigationBar.swift
+++ b/ios/FluentUI/Navigation/NavigationBar.swift
@@ -169,10 +169,6 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     /// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
     @objc public static let backButtonAccessibilityLabel: String = "Accessibility.NavigationBar.BackLabel".localized
 
-    /// The accessibility label that should be applied for the done button for when navigation bar is shown in a modal view.
-    /// A temporary change so that consumers who use SwiftUI for navigation can avoid duplicated resources until support of a swiftUI control is available.
-    @objc public static let doneButtonAccessibilityLabel: String = "Accessibility.Done.Label".localized
-
     /// An element size to describe the behavior of large title's avatar. If `.automatic`, avatar will resize when `expand(animated:)` and `contract(animated:)` are called.
     @objc open var avatarSize: ElementSize = .automatic {
         didSet {


### PR DESCRIPTION
Follow up to #2011, in which it was accidentally closed before the last change to move the accessibility string to be exposed on a different component.
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2013)