### PR TITLE
Fix `Notification` animation tearing in SwiftUI

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -17,7 +17,7 @@ class NotificationViewDemoControllerSwiftUI: UIHostingController<NotificationDem
 
     init() {
         super.init(rootView: NotificationDemoView())
-        self.title = "Notification View Vnext (SwiftUI)"
+        self.title = "NotificationView (SwiftUI)"
     }
 
     override func willMove(toParent parent: UIViewController?) {

--- a/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
+++ b/ios/FluentUI/Core/UIKit+SwiftUI_interoperability.swift
@@ -31,34 +31,3 @@ struct UIViewAdapter: UIViewRepresentable {
         stackview.addArrangedSubview(makeView())
     }
 }
-
-/// UILabel wrapper that allows SwiftUI to support NSAttributedString
-struct AttributedText: UIViewRepresentable {
-
-    let attributedString: NSAttributedString
-    let preferredMaxWidth: CGFloat
-
-    init(_ attributedString: NSAttributedString, _ preferredMaxWidth: CGFloat) {
-        self.attributedString = attributedString
-        self.preferredMaxWidth = preferredMaxWidth
-    }
-
-    func makeUIView(context: Context) -> UILabel {
-        let label = UILabel()
-
-        // Setting this ensures the UIViewRepresentable respects the parent view's width
-        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
-        label.adjustsFontForContentSizeCategory = true
-        return label
-    }
-
-    func updateUIView(_ label: UILabel, context: Context) {
-        // Update the UILabel's attributes if it changes.
-        DispatchQueue.main.async {
-            label.attributedText = attributedString
-            label.preferredMaxLayoutWidth = preferredMaxWidth
-        }
-    }
-}

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -352,7 +352,7 @@ public struct FluentNotification: View, TokenizedControlView {
     }
 
     private func presentAnimated() {
-        withAnimation(.spring(response: state.style.animationDurationForShow,
+        withAnimation(.spring(response: state.style.animationDurationForShow / 2.0,
                               dampingFraction: state.style.animationDampingRatio,
                               blendDuration: 0)) {
             bottomOffset = 0
@@ -361,7 +361,7 @@ public struct FluentNotification: View, TokenizedControlView {
     }
 
     private func dismissAnimated() {
-        withAnimation(.linear(duration: state.style.animationDurationForHide)) {
+        withAnimation(.linear(duration: state.style.animationDurationForHide / 2.0)) {
             bottomOffset = bottomOffsetForDismissedState
             opacity = 0
         }

--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -137,7 +137,7 @@ public struct FluentNotification: View, TokenizedControlView {
                         .frame(width: imageSize.width,
                                height: imageSize.height,
                                alignment: .center)
-                        .foregroundColor(Color(tokenSet[.imageColor].uiColor))
+                        .foregroundColor(tokenSet[.imageColor].color)
                 }
             }
         }
@@ -146,16 +146,11 @@ public struct FluentNotification: View, TokenizedControlView {
         var titleLabel: some View {
             if state.style.isToast && hasSecondTextRow {
                 if let attributedTitle = state.attributedTitle {
-                    AttributedText(attributedTitle, attributedTitleSize.width)
-                        .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
-                        .onSizeChange { newSize in
-                            attributedTitleSize = newSize
-                        }
-                        .accessibilityLabel(attributedTitle.string)
+                    Text(AttributedString(attributedTitle))
+                        .frame(idealWidth: attributedTitleSize.width)
                 } else if let title = state.title {
                     Text(title)
                         .font(.init(tokenSet[.boldTextFont].uiFont))
-                        .foregroundColor(Color(tokenSet[.foregroundColor].uiColor))
                 }
             }
         }
@@ -163,16 +158,11 @@ public struct FluentNotification: View, TokenizedControlView {
         @ViewBuilder
         var messageLabel: some View {
             if let attributedMessage = state.attributedMessage {
-                AttributedText(attributedMessage, attributedMessageSize.width)
-                    .fixedSize(horizontal: isFlexibleWidthToast, vertical: true)
-                    .onSizeChange { newSize in
-                        attributedMessageSize = newSize
-                    }
-                    .accessibilityLabel(attributedMessage.string)
+                Text(AttributedString(attributedMessage))
+                    .frame(idealWidth: attributedMessageSize.width)
             } else if let message = state.message {
                 Text(message)
                     .font(.init(tokenSet[.regularTextFont].uiFont))
-                    .foregroundColor(Color(tokenSet[.foregroundColor].uiColor))
             }
         }
 
@@ -191,14 +181,12 @@ public struct FluentNotification: View, TokenizedControlView {
         var button: some View {
             let shouldHaveDefaultAction = state.showDefaultDismissActionButton && shouldSelfPresent
             if let buttonAction = state.actionButtonAction ?? (shouldHaveDefaultAction ? dismissAnimated : nil) {
-                let foregroundColor = tokenSet[.foregroundColor].uiColor
                 if let actionTitle = state.actionButtonTitle, !actionTitle.isEmpty {
                     SwiftUI.Button(actionTitle) {
                         isPresented = false
                         buttonAction()
                     }
                     .lineLimit(1)
-                    .foregroundColor(Color(foregroundColor))
                     .font(.init(tokenSet[.boldTextFont].uiFont))
                     .hoverEffect()
                 } else {
@@ -214,7 +202,6 @@ public struct FluentNotification: View, TokenizedControlView {
                                 .accessibilityLabel("Accessibility.Dismiss.Label".localized)
                         }
                     })
-                    .foregroundColor(Color(foregroundColor))
                     .hoverEffect()
                 }
             }
@@ -271,7 +258,7 @@ public struct FluentNotification: View, TokenizedControlView {
                         .scaleEffect(x: 1.0, y: g.size.height / g.size.width, anchor: .top)
                 }
             } else {
-                Color(tokenSet[.backgroundColor].uiColor)
+                tokenSet[.backgroundColor].color
             }
         }
 
@@ -279,11 +266,12 @@ public struct FluentNotification: View, TokenizedControlView {
         var notification: some View {
             let shadowInfo = tokenSet[.shadow].shadowInfo
             innerContents
+                .foregroundStyle(tokenSet[.foregroundColor].color)
                 .background(
                     RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float)
                         .border(width: tokenSet[.outlineWidth].float,
                                 edges: state.showFromBottom ? [.top] : [.bottom],
-                                color: Color(tokenSet[.outlineColor].uiColor)).foregroundColor(.clear)
+                                color: tokenSet[.outlineColor].color).foregroundColor(.clear)
                         .background(
                             backgroundFill
                                 .clipShape(RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -108,7 +108,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
         super.init { [style] token, theme in
             switch token {
             case .backgroundColor:
-                return .uiColor {
+                return .color {
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
@@ -127,7 +127,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .foregroundColor:
-                return .uiColor {
+                return .color {
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
@@ -145,7 +145,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 }
 
             case .imageColor:
-                return .uiColor {
+                return .color {
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
@@ -192,7 +192,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                 return .float { 52.0 }
 
             case .outlineColor:
-                return .uiColor {
+                return .color {
                     switch style() {
                     case .primaryToast, .neutralToast, .primaryBar, .neutralBar, .dangerToast, .warningToast:
                         return .clear


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Move FluentNotification to use `Color` instead of `UIColor`, which resolves the issue with animation tearing in iOS 17.

While developing this fix, I noticed that the animation curve is twice as slow in SwiftUI as in UIKit, so fixed that too.

### Binary change

Total increase: 1,608 bytes
Total decrease: -78,792 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,069,608 bytes | 30,992,424 bytes | 🎉 -77,184 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| IndeterminateProgressBar.o | 230,320 bytes | 231,928 bytes | ⚠️ 1,608 bytes |
| NotificationTokenSet.o | 94,216 bytes | 94,016 bytes | 🎉 -200 bytes |
| FluentNotification.o | 684,792 bytes | 663,744 bytes | 🎉 -21,048 bytes |
| __.SYMDEF | 4,861,000 bytes | 4,837,816 bytes | 🎉 -23,184 bytes |
| UIKit+SwiftUI_interoperability.o | 46,664 bytes | 12,304 bytes | 🎉 -34,360 bytes |
</details>

### Verification

Texted all varieties of notification, in both dark and light mode.

<details>
<summary>Visual Verification</summary>

Before:

https://github.com/microsoft/fluentui-apple/assets/4934719/82c327ba-23af-4867-8dea-0df0f34462dd

After:

https://github.com/microsoft/fluentui-apple/assets/4934719/4d3e37dc-9891-4187-8d7f-3ddd8cae3623

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2018)