### PR TITLE
Initial Implementation of FluentList and FluentListSection

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
@@ -84,8 +84,8 @@ struct ListActionItemDemoView: View {
 
         @ViewBuilder
         var content: some View {
-            List {
-                Section {
+            FluentList {
+                FluentListSection {
                     if showSecondaryAction {
                         ListActionItem(primaryActionTitle: primaryActionTitle,
                                        onPrimaryActionTapped: {
@@ -110,7 +110,6 @@ struct ListActionItemDemoView: View {
                         .bottomSeparatorType(bottomSeparatorType)
                         .backgroundStyleType(backgroundStyleType)
                     }
-
                 } header: {
                     Text("ListActionItem")
                 }
@@ -119,7 +118,7 @@ struct ListActionItemDemoView: View {
                         .accessibilityIdentifier("DismissAlertButton")
                 }
 
-                Section {
+                FluentListSection {
                     FluentUIDemoToggle(titleKey: "Show secondary action", isOn: $showSecondaryAction)
                         .accessibilityIdentifier("showSecondaryActionSwitch")
                     textFields
@@ -129,7 +128,6 @@ struct ListActionItemDemoView: View {
                 }
             }
             .fluentTheme(fluentTheme)
-            .listStyle(.insetGrouped)
         }
 
         return content

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
@@ -138,27 +138,11 @@ struct ListActionItemDemoView: View {
             }
         }
 
-        @ViewBuilder
-        var list: some View {
-            if listStyle == .grouped {
-                FluentList(listStyle: .grouped) {
-                    content
-                }
-            } else if listStyle == .inset {
-                FluentList(listStyle: .inset) {
-                    content
-                }
-            } else if listStyle == .insetGrouped {
-                FluentList(listStyle: .insetGrouped) {
-                    content
-                }
-            } else {
-                FluentList {
-                    content
-                }
-            }
+        return FluentList {
+            content
         }
-
-        return list.fluentTheme(fluentTheme)
+        .fluentListStyle(listStyle)
+        .background(ListItem.listBackgroundColor(for: .grouped))
+        .fluentTheme(fluentTheme)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
@@ -83,7 +83,6 @@ struct ListActionItemDemoView: View {
 
             let listStylePickerOptions = Group {
                 Text(".plain").tag(FluentListStyle.plain)
-                Text(".grouped").tag(FluentListStyle.grouped)
                 Text(".insetGrouped").tag(FluentListStyle.insetGrouped)
                 Text(".inset").tag(FluentListStyle.inset)
             }
@@ -138,11 +137,15 @@ struct ListActionItemDemoView: View {
             }
         }
 
-        return FluentList {
-            content
+        @ViewBuilder
+        var list: some View {
+            FluentList {
+                content
+            }
+            .fluentListStyle(listStyle)
+            .fluentTheme(fluentTheme)
         }
-        .fluentListStyle(listStyle)
-        .background(ListItem.listBackgroundColor(for: .grouped))
-        .fluentTheme(fluentTheme)
+
+        return list
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
@@ -31,9 +31,9 @@ struct ListActionItemDemoView: View {
     @State var topSeparatorType: ListActionItemSeparatorType = .none
     @State var bottomSeparatorType: ListActionItemSeparatorType = .inset
     @State var backgroundStyleType: ListItemBackgroundStyleType = .grouped
+    @State var listStyle: FluentListStyle = .plain
 
     public var body: some View {
-
         @ViewBuilder
         var textFields: some View {
             TextField("Primary Action Title", text: $primaryActionTitle)
@@ -80,56 +80,85 @@ struct ListActionItemDemoView: View {
             Picker("Bottom Separator Type", selection: $bottomSeparatorType) {
                 separatorTypePickerOptions
             }
+
+            let listStylePickerOptions = Group {
+                Text(".plain").tag(FluentListStyle.plain)
+                Text(".grouped").tag(FluentListStyle.grouped)
+                Text(".insetGrouped").tag(FluentListStyle.insetGrouped)
+                Text(".inset").tag(FluentListStyle.inset)
+            }
+
+            Picker("List Style Type", selection: $listStyle) {
+                listStylePickerOptions
+            }
         }
 
         @ViewBuilder
         var content: some View {
-            FluentList {
-                FluentListSection {
-                    if showSecondaryAction {
-                        ListActionItem(primaryActionTitle: primaryActionTitle,
-                                       onPrimaryActionTapped: {
-                            showingAlert.toggle()
-                        },
-                                       primaryActionType: primaryActionType,
-                                       secondaryActionTitle: secondaryActionTitle,
-                                       onSecondaryActionTapped: {
-                            showingAlert.toggle()
-                        },
-                                       secondaryActionType: secondaryActionType)
-                        .topSeparatorType(topSeparatorType)
-                        .bottomSeparatorType(bottomSeparatorType)
-                        .backgroundStyleType(backgroundStyleType)
-                    } else {
-                        ListActionItem(title: primaryActionTitle,
-                                       onTapped: {
-                            showingAlert.toggle()
-                        },
-                                       actionType: primaryActionType)
-                        .topSeparatorType(topSeparatorType)
-                        .bottomSeparatorType(bottomSeparatorType)
-                        .backgroundStyleType(backgroundStyleType)
-                    }
-                } header: {
-                    Text("ListActionItem")
+            FluentListSection {
+                if showSecondaryAction {
+                    ListActionItem(primaryActionTitle: primaryActionTitle,
+                                   onPrimaryActionTapped: {
+                        showingAlert.toggle()
+                    },
+                                   primaryActionType: primaryActionType,
+                                   secondaryActionTitle: secondaryActionTitle,
+                                   onSecondaryActionTapped: {
+                        showingAlert.toggle()
+                    },
+                                   secondaryActionType: secondaryActionType)
+                    .topSeparatorType(topSeparatorType)
+                    .bottomSeparatorType(bottomSeparatorType)
+                    .backgroundStyleType(backgroundStyleType)
+                } else {
+                    ListActionItem(title: primaryActionTitle,
+                                   onTapped: {
+                        showingAlert.toggle()
+                    },
+                                   actionType: primaryActionType)
+                    .topSeparatorType(topSeparatorType)
+                    .bottomSeparatorType(bottomSeparatorType)
+                    .backgroundStyleType(backgroundStyleType)
                 }
-                .alert("Action tapped", isPresented: $showingAlert) {
-                    Button("OK", role: .cancel) { }
-                        .accessibilityIdentifier("DismissAlertButton")
-                }
-
-                FluentListSection {
-                    FluentUIDemoToggle(titleKey: "Show secondary action", isOn: $showSecondaryAction)
-                        .accessibilityIdentifier("showSecondaryActionSwitch")
-                    textFields
-                    pickers
-                } header: {
-                    Text("Settings")
-                }
+            } header: {
+                Text("ListActionItem")
             }
-            .fluentTheme(fluentTheme)
+            .alert("Action tapped", isPresented: $showingAlert) {
+                Button("OK", role: .cancel) { }
+                    .accessibilityIdentifier("DismissAlertButton")
+            }
+
+            FluentListSection {
+                FluentUIDemoToggle(titleKey: "Show secondary action", isOn: $showSecondaryAction)
+                    .accessibilityIdentifier("showSecondaryActionSwitch")
+                textFields
+                pickers
+            } header: {
+                Text("Settings")
+            }
         }
 
-        return content
+        @ViewBuilder
+        var list: some View {
+            if listStyle == .grouped {
+                FluentList(listStyle: .grouped) {
+                    content
+                }
+            } else if listStyle == .inset {
+                FluentList(listStyle: .inset) {
+                    content
+                }
+            } else if listStyle == .insetGrouped {
+                FluentList(listStyle: .insetGrouped) {
+                    content
+                }
+            } else {
+                FluentList {
+                    content
+                }
+            }
+        }
+
+        return list.fluentTheme(fluentTheme)
     }
 }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -204,15 +204,6 @@ struct ListItemDemoView: View {
                 }
                 FluentList {
                     if !renderStandalone {
-                        Section {
-                            Text("Test")
-                        }
-                        Section {
-                            Text("Test")
-                        }
-                        FluentListSection {
-                            Text("Test")
-                        }
                         FluentListSection {
                             listItem
                         } header: {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -6,6 +6,13 @@
 import FluentUI
 import SwiftUI
 
+enum FluentListStyle {
+    case plain
+    case grouped
+    case insetGrouped
+    case inset
+}
+
 class ListItemDemoControllerSwiftUI: UIHostingController<ListItemDemoView> {
     override init?(coder aDecoder: NSCoder, rootView: ListItemDemoView) {
         preconditionFailure("init(coder:) has not been implemented")
@@ -44,6 +51,7 @@ struct ListItemDemoView: View {
     @State var trailingContentFocusableElementCount: Int = 0
     @State var trailingContentToggleEnabled: Bool = true
     @State var renderStandalone: Bool = false
+    @State var listStyle: FluentListStyle = .plain
 
     public var body: some View {
 
@@ -102,6 +110,12 @@ struct ListItemDemoView: View {
                 Text(".grouped").tag(ListItemBackgroundStyleType.grouped)
                 Text(".clear").tag(ListItemBackgroundStyleType.clear)
                 Text(".custom").tag(ListItemBackgroundStyleType.custom)
+            }
+            Picker("List Style Type", selection: $listStyle) {
+                Text(".plain").tag(FluentListStyle.plain)
+                Text(".grouped").tag(FluentListStyle.grouped)
+                Text(".insetGrouped").tag(FluentListStyle.insetGrouped)
+                Text(".inset").tag(FluentListStyle.inset)
             }
         }
 
@@ -197,21 +211,47 @@ struct ListItemDemoView: View {
         }
 
         @ViewBuilder
+        var listContent: some View {
+            if !renderStandalone {
+                FluentListSection {
+                    listItem
+                } header: {
+                    Text("ListItem")
+                } footer: {
+                    Text("Footer for demo purposes")
+                }
+            }
+            controls
+        }
+
+        @ViewBuilder
+        var list: some View {
+            if listStyle == .grouped {
+                FluentList(listStyle: .grouped) {
+                    listContent
+                }
+            } else if listStyle == .inset {
+                FluentList(listStyle: .inset) {
+                    listContent
+                }
+            } else if listStyle == .insetGrouped {
+                FluentList(listStyle: .insetGrouped) {
+                    listContent
+                }
+            } else {
+                FluentList {
+                    listContent
+                }
+            }
+        }
+
+        @ViewBuilder
         var content: some View {
             VStack {
                 if renderStandalone {
                     listItem
                 }
-                FluentList {
-                    if !renderStandalone {
-                        FluentListSection {
-                            listItem
-                        } header: {
-                            Text("ListItem")
-                        }
-                    }
-                    controls
-                }
+                list
                 .background(ListItem.listBackgroundColor(for: .grouped))
                 .fluentTheme(fluentTheme)
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -217,8 +217,6 @@ struct ListItemDemoView: View {
                     listItem
                 } header: {
                     Text("ListItem")
-                } footer: {
-                    Text("Footer for demo purposes")
                 }
             }
             controls

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -6,13 +6,6 @@
 import FluentUI
 import SwiftUI
 
-enum FluentListStyle {
-    case plain
-    case grouped
-    case insetGrouped
-    case inset
-}
-
 class ListItemDemoControllerSwiftUI: UIHostingController<ListItemDemoView> {
     override init?(coder aDecoder: NSCoder, rootView: ListItemDemoView) {
         preconditionFailure("init(coder:) has not been implemented")
@@ -211,51 +204,27 @@ struct ListItemDemoView: View {
         }
 
         @ViewBuilder
-        var listContent: some View {
-            if !renderStandalone {
-                FluentListSection {
-                    listItem
-                } header: {
-                    Text("ListItem")
-                }
-            }
-            controls
-        }
-
-        @ViewBuilder
-        var list: some View {
-            if listStyle == .grouped {
-                FluentList(listStyle: .grouped) {
-                    listContent
-                }
-            } else if listStyle == .inset {
-                FluentList(listStyle: .inset) {
-                    listContent
-                }
-            } else if listStyle == .insetGrouped {
-                FluentList(listStyle: .insetGrouped) {
-                    listContent
-                }
-            } else {
-                FluentList {
-                    listContent
-                }
-            }
-        }
-
-        @ViewBuilder
         var content: some View {
             VStack {
                 if renderStandalone {
                     listItem
                 }
-                list
-                .background(ListItem.listBackgroundColor(for: .grouped))
+                FluentList {
+                    if !renderStandalone {
+                        FluentListSection {
+                            listItem
+                        } header: {
+                            Text("ListItem")
+                        }
+                    }
+                    controls
+                }
+                .fluentListStyle(listStyle)
                 .fluentTheme(fluentTheme)
             }
         }
 
-        return content
+        return content.background(ListItem.listBackgroundColor(for: .grouped))
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -202,9 +202,9 @@ struct ListItemDemoView: View {
                 if renderStandalone {
                     listItem
                 }
-                List {
+                FluentList {
                     if !renderStandalone {
-                        Section {
+                        FluentListSection {
                             listItem
                         } header: {
                             Text("ListItem")
@@ -214,7 +214,6 @@ struct ListItemDemoView: View {
                 }
                 .background(ListItem.listBackgroundColor(for: .grouped))
                 .fluentTheme(fluentTheme)
-                .listStyle(.insetGrouped)
             }
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -106,7 +106,6 @@ struct ListItemDemoView: View {
             }
             Picker("List Style Type", selection: $listStyle) {
                 Text(".plain").tag(FluentListStyle.plain)
-                Text(".grouped").tag(FluentListStyle.grouped)
                 Text(".insetGrouped").tag(FluentListStyle.insetGrouped)
                 Text(".inset").tag(FluentListStyle.inset)
             }
@@ -220,11 +219,12 @@ struct ListItemDemoView: View {
                     controls
                 }
                 .fluentListStyle(listStyle)
+                .background(ListItem.listBackgroundColor(for: .grouped))
                 .fluentTheme(fluentTheme)
             }
         }
 
-        return content.background(ListItem.listBackgroundColor(for: .grouped))
+        return content
     }
 }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -204,6 +204,15 @@ struct ListItemDemoView: View {
                 }
                 FluentList {
                     if !renderStandalone {
+                        Section {
+                            Text("Test")
+                        }
+                        Section {
+                            Text("Test")
+                        }
+                        FluentListSection {
+                            Text("Test")
+                        }
                         FluentListSection {
                             listItem
                         } header: {

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
 		94679F2C2BF55059004A1560 /* FluentListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94679F2A2BF55059004A1560 /* FluentListSection.swift */; };
 		94679F2D2BF55059004A1560 /* FluentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94679F2B2BF55059004A1560 /* FluentList.swift */; };
+		94679F2F2BF57F86004A1560 /* FluentListModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94679F2E2BF57F86004A1560 /* FluentListModifiers.swift */; };
 		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
@@ -387,6 +388,7 @@
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
 		94679F2A2BF55059004A1560 /* FluentListSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentListSection.swift; sourceTree = "<group>"; };
 		94679F2B2BF55059004A1560 /* FluentList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentList.swift; sourceTree = "<group>"; };
+		94679F2E2BF57F86004A1560 /* FluentListModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentListModifiers.swift; sourceTree = "<group>"; };
 		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -1195,6 +1197,7 @@
 			isa = PBXGroup;
 			children = (
 				94679F2B2BF55059004A1560 /* FluentList.swift */,
+				94679F2E2BF57F86004A1560 /* FluentListModifiers.swift */,
 				94679F2A2BF55059004A1560 /* FluentListSection.swift */,
 				F3A87D5F2BF57421000D6A64 /* FluentListSectionFooter.swift */,
 				F3A87D5D2BF5606E000D6A64 /* FluentListSectionHeader.swift */,
@@ -1613,6 +1616,7 @@
 				5314E14325F016860099271A /* CardTransitionAnimator.swift in Sources */,
 				5314E0F825F012CB0099271A /* AvatarTitleView.swift in Sources */,
 				8035CAB62633A4DB007B3FD1 /* BottomCommandingController.swift in Sources */,
+				94679F2F2BF57F86004A1560 /* FluentListModifiers.swift in Sources */,
 				5314E13725F016370099271A /* PopupMenuProtocols.swift in Sources */,
 				5314E19725F019650099271A /* TabBarItem.swift in Sources */,
 				EC98E2B4298D989100B9DF91 /* FluentTextInputError.swift in Sources */,

--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		92ECB2DF2BE06BCB00404D79 /* FluentTheme+UIKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92ECB2DE2BE06BCB00404D79 /* FluentTheme+UIKit.swift */; };
 		92EE82AE27025A94009D52B5 /* TokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92EE82AC27025A94009D52B5 /* TokenSet.swift */; };
 		92F8054E272B2DF3000EAFDB /* CardNudgeModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92079C8E26B66E5100D688DA /* CardNudgeModifiers.swift */; };
+		94679F2C2BF55059004A1560 /* FluentListSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94679F2A2BF55059004A1560 /* FluentListSection.swift */; };
+		94679F2D2BF55059004A1560 /* FluentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94679F2B2BF55059004A1560 /* FluentList.swift */; };
 		94A7EC1A2836DCB200BFFBAE /* CommandBarCommandGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */; };
 		A257F82C251D98F3002CAA6E /* FluentUI-ios.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */; };
 		A542A9D7226FC01100204A52 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = A559BB81212B6FA40055E107 /* Localizable.strings */; };
@@ -383,6 +385,8 @@
 		92ECB2DC2BE069D100404D79 /* Color+DynamicColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+DynamicColor.swift"; sourceTree = "<group>"; };
 		92ECB2DE2BE06BCB00404D79 /* FluentTheme+UIKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FluentTheme+UIKit.swift"; sourceTree = "<group>"; };
 		92EE82AC27025A94009D52B5 /* TokenSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenSet.swift; sourceTree = "<group>"; };
+		94679F2A2BF55059004A1560 /* FluentListSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentListSection.swift; sourceTree = "<group>"; };
+		94679F2B2BF55059004A1560 /* FluentList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FluentList.swift; sourceTree = "<group>"; };
 		94A7EC192836DCB100BFFBAE /* CommandBarCommandGroupsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandBarCommandGroupsView.swift; sourceTree = "<group>"; };
 		A257F82B251D98F3002CAA6E /* FluentUI-ios.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = "FluentUI-ios.xcassets"; path = "FluentUI/Resources/FluentUI-ios.xcassets"; sourceTree = "<group>"; };
 		A5237ACA21DED7030040BF27 /* ResizingHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizingHandleView.swift; sourceTree = "<group>"; };
@@ -1190,6 +1194,8 @@
 		F3F113872A705AC300DA852A /* List */ = {
 			isa = PBXGroup;
 			children = (
+				94679F2B2BF55059004A1560 /* FluentList.swift */,
+				94679F2A2BF55059004A1560 /* FluentListSection.swift */,
 				F3A87D5F2BF57421000D6A64 /* FluentListSectionFooter.swift */,
 				F3A87D5D2BF5606E000D6A64 /* FluentListSectionHeader.swift */,
 				F32E6E8A2A7997F3003F9AE7 /* ListActionItem.swift */,
@@ -1610,6 +1616,7 @@
 				5314E13725F016370099271A /* PopupMenuProtocols.swift in Sources */,
 				5314E19725F019650099271A /* TabBarItem.swift in Sources */,
 				EC98E2B4298D989100B9DF91 /* FluentTextInputError.swift in Sources */,
+				94679F2C2BF55059004A1560 /* FluentListSection.swift in Sources */,
 				6F2F218F2A12BFD900C50EAB /* BadgeLabelTokenSet.swift in Sources */,
 				6FC3705E29E7707F0096B239 /* BadgeViewTokenSet.swift in Sources */,
 				92B7E6A326864AE900EFC15E /* MSFPersonaButton.swift in Sources */,
@@ -1758,6 +1765,7 @@
 				5314E03B25F00E3D0099271A /* BadgeStringExtractor.swift in Sources */,
 				EC1C31732923022E00CF052C /* SegmentedControlTokenSet.swift in Sources */,
 				5314E19825F019650099271A /* SideTabBar.swift in Sources */,
+				94679F2D2BF55059004A1560 /* FluentList.swift in Sources */,
 				5314E10A25F014600099271A /* Obscurable.swift in Sources */,
 				F3F1138D2A705B6900DA852A /* ListItemModifiers.swift in Sources */,
 				5314E07D25F00F1A0099271A /* DateTimePickerViewComponentTableView.swift in Sources */,

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -9,27 +9,31 @@ import SwiftUI
 /// to provide a completely fluentized list, however, it can be used on it's own if desired.
 ///
 /// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
-public struct FluentList<ListContent: View>: View {
+public struct FluentList<ListContent: View, Style: ListStyle>: View {
 
     // MARK: Initializer
 
     /// Creates a `FluentList`
     /// - Parameters:
-    ///   - content: SwiftUI content to show inside of the list.
-    public init(@ViewBuilder content: @escaping () -> ListContent) {
+    ///   - listStyle: `ListStyle` to use to style the list contents
+    ///   - content: content to show inside of the list.
+    public init(listStyle: Style = .plain, @ViewBuilder content: @escaping () -> ListContent) {
         self.content = content
+        self.style = listStyle
     }
 
     public var body: some View {
         List {
             content()
         }
-        .listStyle(.insetGrouped)
+        .listStyle(style)
     }
 
     // MARK: Private variables
 
     /// Content to render inside the list
     private var content: () -> ListContent
+
+    private var style: Style
 
 }

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -5,36 +5,60 @@
 
 import SwiftUI
 
+/// Fluent specific list style enum
+public enum FluentListStyle {
+    case plain
+    case grouped
+    case insetGrouped
+    case inset
+}
+
 /// This a wrapper around `SwiftUI.List` that has fluent style applied. It is intended to be used in conjunction with `FluentUI.FluentListSection` and `FluentUI.ListItem`
 /// to provide a completely fluentized list, however, it can be used on it's own if desired.
 ///
 /// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
-public struct FluentList<ListContent: View, Style: ListStyle>: View {
+public struct FluentList<ListContent: View>: View {
 
     // MARK: Initializer
 
     /// Creates a `FluentList`
     /// - Parameters:
-    ///   - listStyle: `ListStyle` to use to style the list contents
     ///   - content: content to show inside of the list.
-    public init(listStyle: Style = .plain, @ViewBuilder content: @escaping () -> ListContent) {
+    public init(@ViewBuilder content: @escaping () -> ListContent) {
         self.content = content
-        self.style = listStyle
     }
 
     public var body: some View {
-        List {
-            content()
+        @ViewBuilder
+        var list: some View {
+            List {
+                content()
+            }
         }
-        .listStyle(style)
+
+        @ViewBuilder
+        var styledList: some View {
+            switch listStyle {
+            case .inset:
+                list.listStyle(.inset)
+            case .grouped:
+                list.listStyle(.grouped)
+            case .insetGrouped:
+                list.listStyle(.insetGrouped)
+            case .plain:
+                list.listStyle(.plain)
+            }
+        }
+
+        return styledList
     }
+
+    /// Style to be used by the list
+    var listStyle: FluentListStyle = .plain
 
     // MARK: Private variables
 
     /// Content to render inside the list
     private var content: () -> ListContent
-
-    /// Style to apply to list
-    private var style: Style
 
 }

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -7,6 +7,8 @@ import SwiftUI
 
 /// This a wrapper around `SwiftUI.List` that has fluent style applied. It is intended to be used in conjunction with `FluentUI.FluentListSection` and `FluentUI.ListItem`
 /// to provide a completely fluentized list, however, it can be used on it's own if desired.
+///
+/// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
 public struct FluentList<ListContent: View>: View {
 
     // MARK: Initializer

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -8,7 +8,6 @@ import SwiftUI
 /// Fluent specific list style enum
 public enum FluentListStyle {
     case plain
-    case grouped
     case insetGrouped
     case inset
 }
@@ -41,8 +40,6 @@ public struct FluentList<ListContent: View>: View {
             switch listStyle {
             case .inset:
                 list.listStyle(.inset)
-            case .grouped:
-                list.listStyle(.grouped)
             case .insetGrouped:
                 list.listStyle(.insetGrouped)
             case .plain:

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -34,6 +34,7 @@ public struct FluentList<ListContent: View, Style: ListStyle>: View {
     /// Content to render inside the list
     private var content: () -> ListContent
 
+    /// Style to apply to list
     private var style: Style
 
 }

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// This a wrapper around `SwiftUI.List` that has fluent style applied. It is intended to be used in conjunction with `FluentUI.FluentListSection` and `FluentUI.ListItem`
+/// to provide a completely fluentized list, however, it can be used on it's own if desired.
+public struct FluentList<ListContent: View>: View {
+
+    // MARK: Initializer
+
+    /// Creates a `FluentList`
+    /// - Parameters:
+    ///   - content: SwiftUI content to show inside of the list.
+    public init(@ViewBuilder content: @escaping () -> ListContent) {
+        self.content = content
+    }
+
+    public var body: some View {
+        List {
+            content()
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: Private variables
+
+    /// Content to render inside the list
+    private var content: () -> ListContent
+
+}

--- a/ios/FluentUI/List/FluentListModifiers.swift
+++ b/ios/FluentUI/List/FluentListModifiers.swift
@@ -1,0 +1,17 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public extension FluentList {
+    /// The list style type for the `FluentList`.
+    /// - Parameter listStyle: Type of style to display the list with.
+    /// - Returns: The modified `FluentList` with the style property set.
+    func fluentListStyle(_ listStyle: FluentListStyle) -> FluentList {
+        var list = self
+        list.listStyle = listStyle
+        return list
+    }
+}

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -7,6 +7,8 @@ import SwiftUI
 
 /// This a wrapper around `SwiftUI.Section` that has fluent style applied. It is intended to be used in conjunction with `FluentUI.FluentList` and `FluentUI.ListItem`
 /// to provide a completely fluentized list, however, it can be used on it's own if desired.
+///
+/// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
 public struct FluentListSection<SectionContent: View, SectionHeaderContent: View, SectionFooterContent: View>: View {
 
     // MARK: Initializer
@@ -14,11 +16,11 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
     /// Creates a `FluentListSection`
     /// - Parameters:
     ///   - content: content to show inside of the section.
-    ///   - header: content to show inside of the header. Defaults to an `EmptyView`.
-    ///   - footer: content to show inside of the footer. Defaults to an `EmptyView`.
+    ///   - header: content to show inside of the header.
+    ///   - footer: content to show inside of the footer.
     public init(@ViewBuilder content: @escaping () -> SectionContent,
-                @ViewBuilder header: @escaping () -> SectionHeaderContent = { EmptyView() },
-                @ViewBuilder footer: @escaping () -> SectionFooterContent = { EmptyView() }) {
+                @ViewBuilder header: @escaping () -> SectionHeaderContent,
+                @ViewBuilder footer: @escaping () -> SectionFooterContent) {
         self.content = content
         self.header = header
         self.footer = footer
@@ -30,9 +32,13 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
             Section {
                 content()
             } header: {
-                header()
+                if let header = header {
+                    header()
+                }
             } footer: {
-                footer()
+                if let footer = footer {
+                    footer()
+                }
             }
         }
         return sectionView
@@ -44,9 +50,29 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
     private var content: () -> SectionContent
 
     /// Content to display in the footer of the section
-    private var footer: () -> SectionFooterContent
+    private var footer: (() -> SectionFooterContent)?
 
     /// Content to display in the header of the section
-    private var header: () -> SectionHeaderContent
+    private var header: (() -> SectionHeaderContent)?
 
- }
+}
+
+public extension FluentListSection where SectionHeaderContent == EmptyView, SectionFooterContent == EmptyView {
+    init(@ViewBuilder content: @escaping () -> SectionContent) {
+        self.content = content
+    }
+}
+
+public extension FluentListSection where SectionFooterContent == EmptyView {
+    init(@ViewBuilder content: @escaping () -> SectionContent, @ViewBuilder header: @escaping () -> SectionHeaderContent) {
+        self.content = content
+        self.header = header
+    }
+}
+
+public extension FluentListSection where SectionHeaderContent == EmptyView {
+    init(@ViewBuilder content: @escaping () -> SectionContent, @ViewBuilder footer: @escaping () -> SectionFooterContent) {
+        self.content = content
+        self.footer = footer
+    }
+}

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -1,0 +1,52 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+/// This a wrapper around `SwiftUI.Section` that has fluent style applied. It is intended to be used in conjunction with `FluentUI.FluentList` and `FluentUI.ListItem`
+/// to provide a completely fluentized list, however, it can be used on it's own if desired.
+public struct FluentListSection<SectionContent: View, SectionHeaderContent: View, SectionFooterContent: View>: View {
+
+    // MARK: Initializer
+
+    /// Creates a `FluentListSection`
+    /// - Parameters:
+    ///   - content: content to show inside of the section.
+    ///   - header: content to show inside of the header. Defaults to an `EmptyView`.
+    ///   - footer: content to show inside of the footer. Defaults to an `EmptyView`.
+    public init(@ViewBuilder content: @escaping () -> SectionContent,
+                @ViewBuilder header: @escaping () -> SectionHeaderContent = { EmptyView() },
+                @ViewBuilder footer: @escaping () -> SectionFooterContent = { EmptyView() }) {
+        self.content = content
+        self.header = header
+        self.footer = footer
+    }
+
+    public var body: some View {
+        @ViewBuilder
+        var sectionView: some View {
+            Section {
+                content()
+            } header: {
+                header()
+            } footer: {
+                footer()
+            }
+        }
+        return sectionView
+    }
+
+    // MARK: Private variables
+
+    /// Content to display in the body of the section
+    private var content: () -> SectionContent
+
+    /// Content to display in the footer of the section
+    private var footer: () -> SectionFooterContent
+
+    /// Content to display in the header of the section
+    private var header: () -> SectionHeaderContent
+
+ }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

This is an initial version of `FluentList` and `FluentListSection`, wrappers around `SwiftUI.List` and `SwiftUI.Section` that apply the appropriate fluent style. The intention is that that these views can be used with `FluentUI.ListItem` to create a completely fluentized list or menu in SwiftUI.

### Binary change

Total increase: 76,760 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,668,792 bytes | 30,745,552 bytes | 🛑 76,760 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentListSection.o | 0 bytes | 38,448 bytes | ⚠️ 38,448 bytes |
| FluentList.o | 0 bytes | 27,368 bytes | ⚠️ 27,368 bytes |
| __.SYMDEF | 4,724,544 bytes | 4,734,424 bytes | ⚠️ 9,880 bytes |
| FocusRingView.o | 829,400 bytes | 829,992 bytes | ⚠️ 592 bytes |
| ListItem.o | 319,984 bytes | 320,456 bytes | ⚠️ 472 bytes |
</details>

### Verification

The changes have been validated in the 2 `ListItem` demo controllers to ensure there are no visual or functional regressions between the usage base SwiftUI components and the new FluentUI wrappers.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| NA | ![Screenshot 2024-05-15 at 2 43 00 PM](https://github.com/microsoft/fluentui-apple/assets/10938746/38ce5e8c-d4b4-4f6a-9319-5f5a55abc50a) |
| NA | ![Screenshot 2024-05-15 at 2 43 13 PM](https://github.com/microsoft/fluentui-apple/assets/10938746/d911f9b3-db41-4a6f-b766-64e78d424624) |

Demo of changing the ListStyle:

https://github.com/microsoft/fluentui-apple/assets/10938746/812c9712-ae57-4ad6-a048-e5cad8077a11


</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2019)