### PR TITLE
Initial Implementation of FluentListSectionHeader and FluentListSectionFooter

### DIFF
--- a/ios/FluentUI.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.xcodeproj/project.pbxproj
@@ -234,6 +234,8 @@
 		ECA9218A27A33A2D00B66117 /* AvatarGroupModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECA9218927A33A2D00B66117 /* AvatarGroupModifiers.swift */; };
 		ECF3C9882A67495A00CA35FC /* BottomCommandingTokenSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */; };
 		F32E6E8B2A7997F3003F9AE7 /* ListActionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F32E6E8A2A7997F3003F9AE7 /* ListActionItem.swift */; };
+		F3A87D5E2BF5606E000D6A64 /* FluentListSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A87D5D2BF5606E000D6A64 /* FluentListSectionHeader.swift */; };
+		F3A87D602BF57421000D6A64 /* FluentListSectionFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3A87D5F2BF57421000D6A64 /* FluentListSectionFooter.swift */; };
 		F3DFD3612A7B210100014C6E /* ListActionItemModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3DFD3602A7B210100014C6E /* ListActionItemModifiers.swift */; };
 		F3F113892A705AD500DA852A /* ListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F113882A705AD500DA852A /* ListItem.swift */; };
 		F3F1138D2A705B6900DA852A /* ListItemModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3F1138C2A705B6900DA852A /* ListItemModifiers.swift */; };
@@ -451,6 +453,8 @@
 		ECEBA8FB25EDF3380048EE24 /* SegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SegmentedControl.swift; sourceTree = "<group>"; };
 		ECF3C9872A67495A00CA35FC /* BottomCommandingTokenSet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BottomCommandingTokenSet.swift; sourceTree = "<group>"; };
 		F32E6E8A2A7997F3003F9AE7 /* ListActionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListActionItem.swift; sourceTree = "<group>"; };
+		F3A87D5D2BF5606E000D6A64 /* FluentListSectionHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentListSectionHeader.swift; sourceTree = "<group>"; };
+		F3A87D5F2BF57421000D6A64 /* FluentListSectionFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FluentListSectionFooter.swift; sourceTree = "<group>"; };
 		F3DFD3602A7B210100014C6E /* ListActionItemModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListActionItemModifiers.swift; sourceTree = "<group>"; };
 		F3F113882A705AD500DA852A /* ListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItem.swift; sourceTree = "<group>"; };
 		F3F1138C2A705B6900DA852A /* ListItemModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListItemModifiers.swift; sourceTree = "<group>"; };
@@ -1186,6 +1190,8 @@
 		F3F113872A705AC300DA852A /* List */ = {
 			isa = PBXGroup;
 			children = (
+				F3A87D5F2BF57421000D6A64 /* FluentListSectionFooter.swift */,
+				F3A87D5D2BF5606E000D6A64 /* FluentListSectionHeader.swift */,
 				F32E6E8A2A7997F3003F9AE7 /* ListActionItem.swift */,
 				F3DFD3602A7B210100014C6E /* ListActionItemModifiers.swift */,
 				F3F113882A705AD500DA852A /* ListItem.swift */,
@@ -1612,6 +1618,7 @@
 				5314E0B325F010400099271A /* EasyTapButton.swift in Sources */,
 				F32E6E8B2A7997F3003F9AE7 /* ListActionItem.swift in Sources */,
 				5314E19625F019650099271A /* TabBarView.swift in Sources */,
+				F3A87D5E2BF5606E000D6A64 /* FluentListSectionHeader.swift in Sources */,
 				C708B05F260A8778007190FA /* SegmentPillButton.swift in Sources */,
 				5314E13525F016370099271A /* PopupMenuItemCell.swift in Sources */,
 				5314E2A025F024860099271A /* NSLayoutConstraint+Extensions.swift in Sources */,
@@ -1646,6 +1653,7 @@
 				530D9C5127EE388200BDCBBF /* SwiftUI+ViewPresentation.swift in Sources */,
 				92ECB2DD2BE069D100404D79 /* Color+DynamicColor.swift in Sources */,
 				6F050B6D29D3D1A90070D3D5 /* TabBarTokenSet.swift in Sources */,
+				F3A87D602BF57421000D6A64 /* FluentListSectionFooter.swift in Sources */,
 				5314E0E725F012C00099271A /* UINavigationItem+Navigation.swift in Sources */,
 				920945492703DDA000B38E1A /* CardNudgeTokenSet.swift in Sources */,
 				92D49054278FF4E50085C018 /* PersonaButtonCarouselModifiers.swift in Sources */,

--- a/ios/FluentUI/List/FluentListSectionFooter.swift
+++ b/ios/FluentUI/List/FluentListSectionFooter.swift
@@ -1,0 +1,27 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public struct FluentListSectionFooter<Description: StringProtocol>: View {
+
+    // MARK: Initializer
+
+    /// Creates a `FluentListSectionFooter`
+    /// - Parameters:
+    ///   - description: description of the section to be shown in the footer.
+    public init(description: Description) {
+        self.description = description
+    }
+
+    public var body: some View {
+        Text(description)
+            .textCase(nil)
+    }
+
+    // MARK: Private variables
+
+    private let description: Description
+}

--- a/ios/FluentUI/List/FluentListSectionFooter.swift
+++ b/ios/FluentUI/List/FluentListSectionFooter.swift
@@ -5,6 +5,9 @@
 
 import SwiftUI
 
+/// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
+///
+/// It is intended to be used in conjunction with `FluentUI.FluentListSection` and `FluentUI.ListItem`
 public struct FluentListSectionFooter<Description: StringProtocol>: View {
 
     // MARK: Initializer

--- a/ios/FluentUI/List/FluentListSectionHeader.swift
+++ b/ios/FluentUI/List/FluentListSectionHeader.swift
@@ -5,6 +5,9 @@
 
 import SwiftUI
 
+/// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
+///
+/// It is intended to be used in conjunction with `FluentUI.FluentListSection` and `FluentUI.ListItem`
 public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: View>: View {
 
     // MARK: Initializer

--- a/ios/FluentUI/List/FluentListSectionHeader.swift
+++ b/ios/FluentUI/List/FluentListSectionHeader.swift
@@ -1,0 +1,55 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+
+public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: View>: View {
+
+    // MARK: Initializer
+
+    /// Creates a `FluentListSectionHeader`
+    /// - Parameters:
+    ///   - title: title of the section to be shown in the header.
+    ///   - trailingContent: content that appears on the trailing edge of the view.
+    public init(title: Title,
+                @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
+        self.title = title
+        self.trailingContent = trailingContent
+    }
+
+    public var body: some View {
+        @ViewBuilder var titleView: some View {
+            Text(title)
+                .textCase(nil)
+        }
+
+        @ViewBuilder var contentView: some View {
+            if let trailingContent {
+                HStack {
+                    titleView
+                    Spacer(minLength: 0)
+                    trailingContent()
+                }
+            } else {
+                titleView
+            }
+        }
+
+        return contentView
+    }
+
+    // MARK: Private variables
+
+    private var trailingContent: (() -> TrailingContent)?
+    private let title: Title
+}
+
+// MARK: Additional Initializers
+
+public extension FluentListSectionHeader where TrailingContent == EmptyView {
+    init(title: Title) {
+        self.title = title
+    }
+}

--- a/ios/FluentUI/List/FluentListSectionHeader.swift
+++ b/ios/FluentUI/List/FluentListSectionHeader.swift
@@ -25,6 +25,7 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
     public var body: some View {
         @ViewBuilder var titleView: some View {
             Text(title)
+                // By default uppercasing is applied, setting nil to not enforce casing
                 .textCase(nil)
         }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

An initial swiftUI view for the section header and footer to be used in combination with `FluentList`.

This is a work in progress, so adding examples in the test app, implementing tokens, and updating the design to make fluent will be in future iterations.

### Binary change

Total increase: 94,264 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,757,792 bytes | 30,852,056 bytes | 🛑 94,264 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentListSectionHeader.o | 0 bytes | 47,520 bytes | ⚠️ 47,520 bytes |
| FluentListSectionFooter.o | 0 bytes | 34,752 bytes | ⚠️ 34,752 bytes |
| __.SYMDEF | 4,724,544 bytes | 4,736,200 bytes | ⚠️ 11,656 bytes |
</details>

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| N/A | 
![Simulator Screenshot - iPad Air (5th generation) - 2024-05-15 at 16 33 09](https://github.com/microsoft/fluentui-apple/assets/21343215/99e7af20-41ba-4719-b082-d81986871e78)|
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)