### PR TITLE
Avatar custom default image

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -55,7 +55,7 @@ class AvatarDemoController: DemoTableViewController {
              .activity,
              .ringInnerGap,
              .transparency,
-             .customDefaultImage:
+             .defaultImage:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
             }
@@ -291,7 +291,7 @@ class AvatarDemoController: DemoTableViewController {
         didSet {
             if oldValue != useCustomDefaultImage {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.customDefaultImage = useCustomDefaultImage ? UIImage(named: "flag-48x48") : nil
+                    avatar.state.defaultImage = useCustomDefaultImage ? UIImage(named: "flag-48x48") : nil
                 }
             }
         }
@@ -408,7 +408,7 @@ class AvatarDemoController: DemoTableViewController {
             return self.isShowingRingInnerGap
         case .transparency:
             return self.isTransparent
-        case .customDefaultImage:
+        case .defaultImage:
             return self.useCustomDefaultImage
         }
     }
@@ -446,7 +446,7 @@ class AvatarDemoController: DemoTableViewController {
             self.isShowingRingInnerGap = isOn
         case .transparency:
             self.isTransparent = isOn
-        case .customDefaultImage:
+        case .defaultImage:
             self.useCustomDefaultImage = isOn
         }
     }
@@ -525,7 +525,7 @@ class AvatarDemoController: DemoTableViewController {
                         .ring,
                         .ringInnerGap,
                         .imageBasedRingColor,
-                        .customDefaultImage]
+                        .defaultImage]
             case .size72,
                  .size56,
                  .size40,
@@ -567,7 +567,7 @@ class AvatarDemoController: DemoTableViewController {
         case ringInnerGap
         case swiftUIDemo
         case transparency
-        case customDefaultImage
+        case defaultImage
 
         var isDemoRow: Bool {
             switch self {
@@ -592,7 +592,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ringInnerGap,
                  .swiftUIDemo,
                  .transparency,
-                 .customDefaultImage:
+                 .defaultImage:
                 return false
             }
         }
@@ -621,7 +621,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ringInnerGap,
                  .swiftUIDemo,
                  .transparency,
-                 .customDefaultImage:
+                 .defaultImage:
                 return nil
             }
         }
@@ -652,7 +652,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ringInnerGap,
                  .swiftUIDemo,
                  .transparency,
-                 .customDefaultImage:
+                 .defaultImage:
                 return nil
             }
         }
@@ -685,7 +685,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ringInnerGap,
                  .swiftUIDemo,
                  .transparency,
-                 .customDefaultImage:
+                 .defaultImage:
                 preconditionFailure("Row does not have an associated avatar style")
             }
         }
@@ -732,7 +732,7 @@ class AvatarDemoController: DemoTableViewController {
                 return "SwiftUI Demo"
             case .transparency:
                 return "Use transparency"
-            case .customDefaultImage:
+            case .defaultImage:
                 return "Use custom default image"
             }
         }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -54,7 +54,8 @@ class AvatarDemoController: DemoTableViewController {
              .presence,
              .activity,
              .ringInnerGap,
-             .transparency:
+             .transparency,
+             .customDefaultImage:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
             }
@@ -286,6 +287,16 @@ class AvatarDemoController: DemoTableViewController {
         }
     }
 
+    private var useCustomDefaultImage: Bool = false {
+        didSet {
+            if oldValue != useCustomDefaultImage {
+                allDemoAvatarsCombined.forEach { avatar in
+                    avatar.state.customDefaultImage = useCustomDefaultImage ? UIImage(named: "flag-48x48") : nil
+                }
+            }
+        }
+    }
+
     private lazy var presenceIterator = MSFAvatarPresence.allCases.makeIterator()
 
     static var colorfulCustomImage: UIImage? {
@@ -397,6 +408,8 @@ class AvatarDemoController: DemoTableViewController {
             return self.isShowingRingInnerGap
         case .transparency:
             return self.isTransparent
+        case .customDefaultImage:
+            return self.useCustomDefaultImage
         }
     }
 
@@ -433,6 +446,8 @@ class AvatarDemoController: DemoTableViewController {
             self.isShowingRingInnerGap = isOn
         case .transparency:
             self.isTransparent = isOn
+        case .customDefaultImage:
+            self.useCustomDefaultImage = isOn
         }
     }
 
@@ -509,7 +524,8 @@ class AvatarDemoController: DemoTableViewController {
                         .outOfOffice,
                         .ring,
                         .ringInnerGap,
-                        .imageBasedRingColor]
+                        .imageBasedRingColor,
+                        .customDefaultImage]
             case .size72,
                  .size56,
                  .size40,
@@ -551,6 +567,7 @@ class AvatarDemoController: DemoTableViewController {
         case ringInnerGap
         case swiftUIDemo
         case transparency
+        case customDefaultImage
 
         var isDemoRow: Bool {
             switch self {
@@ -574,7 +591,8 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency:
+                 .transparency,
+                 .customDefaultImage:
                 return false
             }
         }
@@ -602,7 +620,8 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency:
+                 .transparency,
+                 .customDefaultImage:
                 return nil
             }
         }
@@ -632,7 +651,8 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency:
+                 .transparency,
+                 .customDefaultImage:
                 return nil
             }
         }
@@ -664,7 +684,8 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency:
+                 .transparency,
+                 .customDefaultImage:
                 preconditionFailure("Row does not have an associated avatar style")
             }
         }
@@ -711,6 +732,8 @@ class AvatarDemoController: DemoTableViewController {
                 return "SwiftUI Demo"
             case .transparency:
                 return "Use transparency"
+            case .customDefaultImage:
+                return "Use custom default image"
             }
         }
     }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -46,9 +46,18 @@ struct AvatarDemoView: View {
     @State var showActivityImage: Bool = false
     @State var showImage: Bool = false
     @State var showImageBasedRingColor: Bool = false
+    @State var useCustomDefaultImage: Bool = false
     @State var size: MSFAvatarSize = .size72
     @State var style: MSFAvatarStyle = .default
     @ObservedObject var fluentTheme: FluentTheme = .shared
+
+    var customDefaultImage: UIImage? {
+        if useCustomDefaultImage {
+            return UIImage(named: "flag-48x48")
+        } else {
+            return nil
+        }
+    }
 
     public var body: some View {
         VStack {
@@ -60,6 +69,7 @@ struct AvatarDemoView: View {
                 .isRingVisible(showImageBasedRingColor || isRingVisible)
                 .hasRingInnerGap(hasRingInnerGap)
                 .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
+                .customDefaultImage(customDefaultImage)
                 .isTransparent(isTransparent)
                 .presence(presence)
                 .activity(activityStyle, showActivityImage ? (activityStyle == .circle ? UIImage(named: "thumbs_up_3d_default") : UIImage(named: "excelIcon")) : nil)
@@ -94,6 +104,7 @@ struct AvatarDemoView: View {
                         FluentUIDemoToggle(titleKey: "Transparency", isOn: $isTransparent)
                         FluentUIDemoToggle(titleKey: "iPad Pointer interaction", isOn: $hasPointerInteraction)
                         FluentUIDemoToggle(titleKey: "Animate transitions", isOn: $isAnimated)
+                        FluentUIDemoToggle(titleKey: "Use custom default image", isOn: $useCustomDefaultImage)
                     }
 
                     Group {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -51,7 +51,7 @@ struct AvatarDemoView: View {
     @State var style: MSFAvatarStyle = .default
     @ObservedObject var fluentTheme: FluentTheme = .shared
 
-    var customDefaultImage: UIImage? {
+    var defaultImage: UIImage? {
         if useCustomDefaultImage {
             return UIImage(named: "flag-48x48")
         } else {
@@ -69,7 +69,7 @@ struct AvatarDemoView: View {
                 .isRingVisible(showImageBasedRingColor || isRingVisible)
                 .hasRingInnerGap(hasRingInnerGap)
                 .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
-                .customDefaultImage(customDefaultImage)
+                .defaultImage(defaultImage)
                 .isTransparent(isTransparent)
                 .presence(presence)
                 .activity(activityStyle, showActivityImage ? (activityStyle == .circle ? UIImage(named: "thumbs_up_3d_default") : UIImage(named: "excelIcon")) : nil)

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -166,8 +166,7 @@ public struct Avatar: View, TokenizedControlView {
             if shouldUseDefaultImage {
                 var defaultImage = state.defaultImage
                 if defaultImage == nil {
-                    let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
-                    defaultImage = UIImage.staticImageNamed(isOutlinedStyle ? "person_48_regular" : "person_48_filled")
+                    defaultImage = UIImage.staticImageNamed(AvatarTokenSet.defaultImageName(style))
                 }
                 return (defaultImage, .template)
             } else {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -34,6 +34,9 @@ import SwiftUI
     /// The image used to fill the ring as a custom color.
     var imageBasedRingColor: UIImage? { get set }
 
+    /// An override for the template icon to use when there is no set image or name.
+    var customDefaultImage: UIImage? { get set }
+
     /// Defines whether the avatar state transitions are animated or not. Animations are enabled by default.
     var isAnimated: Bool { get set }
 
@@ -161,11 +164,17 @@ public struct Avatar: View, TokenizedControlView {
 
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
             if shouldUseDefaultImage {
-                let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
-                return (UIImage.staticImageNamed(isOutlinedStyle ? "person_48_regular" : "person_48_filled"), .template)
+                var defaultImage: UIImage?
+                if let customDefaultImage = state.customDefaultImage {
+                    defaultImage = customDefaultImage
+                } else {
+                    let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
+                    defaultImage = UIImage.staticImageNamed(isOutlinedStyle ? "person_48_regular" : "person_48_filled")
+                }
+                return (defaultImage, .template)
+            } else {
+                return (state.image, .original)
             }
-
-            return (state.image, .original)
         }()
         let avatarImageSizeRatio: CGFloat = (shouldUseDefaultImage) ? 0.7 : 1
 
@@ -553,6 +562,7 @@ class MSFAvatarStateImpl: ControlState, MSFAvatarState {
     @Published var hasRingInnerGap: Bool = true
     @Published var image: UIImage?
     @Published var imageBasedRingColor: UIImage?
+    @Published var customDefaultImage: UIImage?
     @Published var isAnimated: Bool = true
     @Published var isOutOfOffice: Bool = false
     @Published var isRingVisible: Bool = false

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -35,7 +35,7 @@ import SwiftUI
     var imageBasedRingColor: UIImage? { get set }
 
     /// An override for the template icon to use when there is no set image or name.
-    var customDefaultImage: UIImage? { get set }
+    var defaultImage: UIImage? { get set }
 
     /// Defines whether the avatar state transitions are animated or not. Animations are enabled by default.
     var isAnimated: Bool { get set }
@@ -164,10 +164,8 @@ public struct Avatar: View, TokenizedControlView {
 
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
             if shouldUseDefaultImage {
-                var defaultImage: UIImage?
-                if let customDefaultImage = state.customDefaultImage {
-                    defaultImage = customDefaultImage
-                } else {
+                var defaultImage = state.defaultImage
+                if defaultImage == nil {
                     let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
                     defaultImage = UIImage.staticImageNamed(isOutlinedStyle ? "person_48_regular" : "person_48_filled")
                 }
@@ -562,7 +560,7 @@ class MSFAvatarStateImpl: ControlState, MSFAvatarState {
     @Published var hasRingInnerGap: Bool = true
     @Published var image: UIImage?
     @Published var imageBasedRingColor: UIImage?
-    @Published var customDefaultImage: UIImage?
+    @Published var defaultImage: UIImage?
     @Published var isAnimated: Bool = true
     @Published var isOutOfOffice: Bool = false
     @Published var isRingVisible: Bool = false

--- a/ios/FluentUI/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Avatar/AvatarModifiers.swift
@@ -50,6 +50,11 @@ public extension Avatar {
         return self
     }
 
+    func customDefaultImage(_ customDefaultImage: UIImage?) -> Avatar {
+        state.customDefaultImage = customDefaultImage
+        return self
+    }
+
     /// The image used to fill the ring as a custom color.
     /// - Parameter imageBasedRingColor: Image to be used as a the ring fill pattern.
     /// - Returns: The modified Avatar with the property set.

--- a/ios/FluentUI/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Avatar/AvatarModifiers.swift
@@ -51,10 +51,10 @@ public extension Avatar {
     }
 
     /// An override for the template icon to use when there is no set image or name.
-    /// - Parameter customDefaultImage: Image to be used as the Avatar's default image.
+    /// - Parameter defaultImage: Image to be used as the Avatar's default image.
     /// - Returns: The modified Avatar with the property set.
-    func customDefaultImage(_ customDefaultImage: UIImage?) -> Avatar {
-        state.customDefaultImage = customDefaultImage
+    func defaultImage(_ defaultImage: UIImage?) -> Avatar {
+        state.defaultImage = defaultImage
         return self
     }
 

--- a/ios/FluentUI/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Avatar/AvatarModifiers.swift
@@ -50,13 +50,16 @@ public extension Avatar {
         return self
     }
 
+    /// An override for the template icon to use when there is no set image or name.
+    /// - Parameter customDefaultImage: Image to be used as the Avatar's default image.
+    /// - Returns: The modified Avatar with the property set.
     func customDefaultImage(_ customDefaultImage: UIImage?) -> Avatar {
         state.customDefaultImage = customDefaultImage
         return self
     }
 
     /// The image used to fill the ring as a custom color.
-    /// - Parameter imageBasedRingColor: Image to be used as a the ring fill pattern.
+    /// - Parameter imageBasedRingColor: Image to be used as the ring fill pattern.
     /// - Returns: The modified Avatar with the property set.
     func imageBasedRingColor(_ imageBasedRingColor: UIImage?) -> Avatar {
         state.imageBasedRingColor = imageBasedRingColor

--- a/ios/FluentUI/Avatar/AvatarTokenSet.swift
+++ b/ios/FluentUI/Avatar/AvatarTokenSet.swift
@@ -273,6 +273,12 @@ extension AvatarTokenSet {
             return GlobalTokens.icon(.size280)
         }
     }
+
+    /// The name of the icon to use for the default image.
+    static func defaultImageName(_ style: MSFAvatarStyle) -> String {
+        let isOutlinedStyle = style == .outlined || style == .outlinedPrimary
+        return isOutlinedStyle ? "person_48_regular" : "person_48_filled"
+    }
 }
 
 /// Pre-defined styles of the avatar.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Add a new API to override the default image in `Avatar`. This is the little "person" image that is displayed when there is no text or image set.

New APIs: 
```swift
// MARK: - UIKit

@objc public protocol MSFAvatarState {
    /// An override for the template icon to use when there is no set image or name.
    var customDefaultImage: UIImage? { get set }
}

// MARK: - SwiftUI

extension Avatar {
    /// An override for the template icon to use when there is no set image or name.
    /// - Parameter customDefaultImage: Image to be used as the Avatar's default image.
    /// - Returns: The modified Avatar with the property set.
    func customDefaultImage(_ customDefaultImage: UIImage?) -> Avatar
}
```

### Binary change

Total increase: 8,424 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,086,904 bytes | 31,095,328 bytes | ⚠️ 8,424 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| Avatar.o | 604,704 bytes | 609,424 bytes | ⚠️ 4,720 bytes |
| AvatarModifiers.o | 44,312 bytes | 46,104 bytes | ⚠️ 1,792 bytes |
| __.SYMDEF | 4,849,552 bytes | 4,850,912 bytes | ⚠️ 1,360 bytes |
| FocusRingView.o | 839,832 bytes | 840,192 bytes | ⚠️ 360 bytes |
| AvatarGroup.o | 417,456 bytes | 417,648 bytes | ⚠️ 192 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| UIKit                                       | SwiftUI                                      |
|----------------------------------------------|--------------------------------------------|
| ![Avatar UIKit](https://github.com/microsoft/fluentui-apple/assets/4934719/045f6e5b-2aec-4fbe-a310-0edea9e98b2d) | ![Avatar SwiftUI](https://github.com/microsoft/fluentui-apple/assets/4934719/16ece3d8-9036-48fd-8bc6-2f90b0ccc89b) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2021)