### PR TITLE
[SwiftUI] `AvatarGroup` SwiftUI API

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/ios/FluentUI.Demo/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -94,6 +94,7 @@
 		928C00B12B8920E60023ECE7 /* View+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928C00B02B8920E60023ECE7 /* View+Extensions.swift */; };
 		92B45E4E279A1A0B00E72517 /* DemoAppearanceControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92B45E4D279A1A0B00E72517 /* DemoAppearanceControlView.swift */; };
 		92BF13322BE405710068422C /* AliasColorTokensDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92BF13312BE405710068422C /* AliasColorTokensDemoController_SwiftUI.swift */; };
+		92C55CB72BEAA94500E0AB8D /* AvatarGroupDemoController_SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C55CB62BEAA94500E0AB8D /* AvatarGroupDemoController_SwiftUI.swift */; };
 		92D5598426A1523400328FD3 /* CardNudgeDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */; };
 		92D5FDFD28AC57650087894B /* TypographyTokensDemoController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */; };
 		92DD1E8D279F496300FDEE0F /* DemoAppearanceMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DD1E8C279F496300FDEE0F /* DemoAppearanceMenu.swift */; };
@@ -233,6 +234,7 @@
 		928C00B02B8920E60023ECE7 /* View+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Extensions.swift"; sourceTree = "<group>"; };
 		92B45E4D279A1A0B00E72517 /* DemoAppearanceControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppearanceControlView.swift; sourceTree = "<group>"; };
 		92BF13312BE405710068422C /* AliasColorTokensDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AliasColorTokensDemoController_SwiftUI.swift; sourceTree = "<group>"; };
+		92C55CB62BEAA94500E0AB8D /* AvatarGroupDemoController_SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarGroupDemoController_SwiftUI.swift; sourceTree = "<group>"; };
 		92D5598326A1523400328FD3 /* CardNudgeDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardNudgeDemoController.swift; sourceTree = "<group>"; };
 		92D5FDFC28AC57650087894B /* TypographyTokensDemoController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypographyTokensDemoController.swift; sourceTree = "<group>"; };
 		92DD1E8C279F496300FDEE0F /* DemoAppearanceMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoAppearanceMenu.swift; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 				5373D55E2694C3070032A3B4 /* AvatarDemoController.swift */,
 				5303259226B3198A00611D05 /* AvatarDemoController_SwiftUI.swift */,
 				5306075826A1E73F002D49CF /* AvatarGroupDemoController.swift */,
+				92C55CB62BEAA94500E0AB8D /* AvatarGroupDemoController_SwiftUI.swift */,
 				B45EB79121A4D047008646A2 /* BadgeFieldDemoController.swift */,
 				B444D6B72183BA4B0002B4D4 /* BadgeViewDemoController.swift */,
 				80AECC0B2630F1BB005AF2F3 /* BottomCommandingDemoController.swift */,
@@ -875,6 +878,7 @@
 				FDCF7C8321BF35680058E9E6 /* SegmentedControlDemoController.swift in Sources */,
 				92DD1E8D279F496300FDEE0F /* DemoAppearanceMenu.swift in Sources */,
 				53097D4027028AE500A6E4DC /* PersonaButtonCarouselDemoController.swift in Sources */,
+				92C55CB72BEAA94500E0AB8D /* AvatarGroupDemoController_SwiftUI.swift in Sources */,
 				C0938E4A235F733100256251 /* ShimmerLinesViewDemoController.swift in Sources */,
 				EC1C31752923032000CF052C /* ColoredPillBackgroundView.swift in Sources */,
 				80AECC0C2630F1BB005AF2F3 /* BottomCommandingDemoController.swift in Sources */,

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -51,6 +51,15 @@ class AvatarGroupDemoController: DemoTableViewController {
         let row = section.rows[indexPath.row]
 
         switch row {
+        case .swiftUIDemo:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier) as? ActionsCell else {
+                return UITableViewCell()
+            }
+            cell.setup(action1Title: "Show SwiftUI Demo")
+            cell.action1Button.addTarget(self, action: #selector(showSwiftUIDemo(_:)), for: .touchUpInside)
+
+            return cell
+
         case .avatarCount:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier) as? ActionsCell else {
                 return UITableViewCell()
@@ -168,6 +177,7 @@ class AvatarGroupDemoController: DemoTableViewController {
     // MARK: - Helpers
 
     private enum AvatarGroupDemoSection: CaseIterable {
+        case swiftUIDemo
         case settings
         case avatarStackNoActivityRing
         case avatarStackWithActivityRing
@@ -186,8 +196,9 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .avatarPileWithActivityRing,
                  .avatarPileWithMixedActivityRing:
                 return .pile
-            case .settings:
-                preconditionFailure("Settings rows should not display an Avatar Group")
+            case .settings,
+                 .swiftUIDemo:
+                preconditionFailure("Settings and SwiftUI rows should not display an Avatar Group")
             }
         }
 
@@ -201,8 +212,9 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .avatarPileWithActivityRing,
                  .avatarPileWithMixedActivityRing:
                 return true
-            case .settings:
-                preconditionFailure("Settings rows should not display an Avatar Group")
+            case .settings,
+                 .swiftUIDemo:
+                preconditionFailure("Settings and SwiftUI rows should not display an Avatar Group")
             }
         }
 
@@ -216,17 +228,25 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .avatarPileWithActivityRing,
                  .avatarPileNoActivityRing:
                 return false
-            case .settings:
-                preconditionFailure("Settings rows should not display an Avatar Group")
+            case .settings,
+                 .swiftUIDemo:
+                preconditionFailure("Settings and SwiftUI rows should not display an Avatar Group")
             }
         }
 
         var isDemoSection: Bool {
-            return self != .settings
+            switch self {
+            case .settings, .swiftUIDemo:
+                return false
+            default:
+                return true
+            }
         }
 
         var title: String {
             switch self {
+            case .swiftUIDemo:
+                return "SwiftUI Demo"
             case .settings:
                 return "Settings"
             case .avatarStackNoActivityRing:
@@ -246,6 +266,8 @@ class AvatarGroupDemoController: DemoTableViewController {
 
         var rows: [AvatarGroupDemoRow] {
             switch self {
+            case .swiftUIDemo:
+                return [.swiftUIDemo]
             case .settings:
                 return [.avatarCount,
                         .alternateBackground,
@@ -277,6 +299,7 @@ class AvatarGroupDemoController: DemoTableViewController {
     }
 
     private enum AvatarGroupDemoRow: CaseIterable {
+        case swiftUIDemo
         case avatarCount
         case alternateBackground
         case customRingColor
@@ -318,7 +341,8 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .alternateBackground,
                  .customRingColor,
                  .maxDisplayedAvatars,
-                 .overflow:
+                 .overflow,
+                 .swiftUIDemo:
                 return false
             }
         }
@@ -350,13 +374,16 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .alternateBackground,
                  .customRingColor,
                  .maxDisplayedAvatars,
-                 .overflow:
+                 .overflow,
+                 .swiftUIDemo:
                 preconditionFailure("Row should not display an Avatar Group")
             }
         }
 
         var title: String {
             switch self {
+            case .swiftUIDemo:
+                return "SwiftUI Demo"
             case .avatarCount:
                 return "Avatar count"
             case .alternateBackground:
@@ -515,6 +542,11 @@ class AvatarGroupDemoController: DemoTableViewController {
                 demoAvatarGroupsBySection.updateValue(avatarGroupsForCurrentSection, forKey: section)
             }
         }
+    }
+
+    @objc private func showSwiftUIDemo(_ cell: ActionsCell) {
+        navigationController?.pushViewController(AvatarGroupDemoControllerSwiftUI(),
+                                                 animated: true)
     }
 
     @objc private func addAvatarCount(_ cell: ActionsCell) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
@@ -59,7 +59,7 @@ struct AvatarGroupDemoView: View {
     var body: some View {
         VStack(spacing: 0) {
             ZStack {
-                fluentTheme.color(useAlternateBackground ? .backgroundCanvas : .background1)
+                fluentTheme.swiftUIColor(useAlternateBackground ? .backgroundCanvas : .background1)
                 AvatarGroup(style: style,
                             size: size,
                             avatarCount: avatarCount,
@@ -68,7 +68,6 @@ struct AvatarGroupDemoView: View {
                             isUnread: isUnread) { index in
                     avatarFromSamplePersona(index)
                 }.fixedSize()
-                
             }
             .frame(height: 120, alignment: .center)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
@@ -72,7 +72,7 @@ struct AvatarGroupDemoView: View {
             .frame(height: 120, alignment: .center)
 
             FluentList {
-                Section("Content") {
+                FluentListSection("Content") {
                     Stepper("Avatar Count: \(avatarCount)", value: $avatarCount, in: (0...Int.max))
                     Stepper("Max Displayed Avatars: \(maxDisplayedAvatars)", value: $maxDisplayedAvatars)
                     Stepper("Overflow Count: \(overflowCount)", value: $overflowCount)
@@ -81,12 +81,12 @@ struct AvatarGroupDemoView: View {
                     Toggle("Alternate Background", isOn: $useAlternateBackground)
                 }
 
-                Section("Ring") {
+                FluentListSection("Ring") {
                     Toggle("Ring Visible", isOn: $isRingVisible)
                     Toggle("Image Based Ring Color", isOn: $showImageBasedRingColor)
                 }
 
-                Section("Style") {
+                FluentListSection("Style") {
                     Picker(selection: $style, label: EmptyView()) {
                         Text(".stack").tag(MSFAvatarGroupStyle.stack)
                         Text(".pile").tag(MSFAvatarGroupStyle.pile)
@@ -95,7 +95,7 @@ struct AvatarGroupDemoView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
-                Section("Size") {
+                FluentListSection("Size") {
                     Picker("Avatar Size", selection: $size) {
                         ForEach(MSFAvatarSize.allCases.reversed(), id: \.self) { avatarSize in
                             Text("\(avatarSize.description)").tag(avatarSize)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
@@ -48,10 +48,10 @@ struct AvatarGroupDemoView: View {
     func avatarFromSamplePersona(_ index: Int) -> Avatar {
         let samplePersona = samplePersonas[index % samplePersonas.count]
         Avatar(style: .default,
-                      size: size,
-                      image: showImage ? samplePersona.image : nil,
-                      primaryText: samplePersona.name,
-                      secondaryText: samplePersona.email)
+               size: size,
+               image: showImage ? samplePersona.image : nil,
+               primaryText: samplePersona.name,
+               secondaryText: samplePersona.email)
         .isRingVisible(isRingVisible)
         .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
     }
@@ -67,8 +67,8 @@ struct AvatarGroupDemoView: View {
                             overflowCount: overflowCount,
                             isUnread: isUnread) { index in
                     avatarFromSamplePersona(index)
-                }
-                .fixedSize()
+                }.fixedSize()
+                
             }
             .frame(height: 120, alignment: .center)
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
@@ -1,0 +1,135 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import FluentUI
+import UIKit
+import SwiftUI
+
+class AvatarGroupDemoControllerSwiftUI: DemoHostingController {
+    required init(rootView: AnyView) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        preconditionFailure("init(coder:) has not been implemented")
+    }
+
+    init() {
+        super.init(rootView: AnyView(AvatarGroupDemoView()))
+        self.title = "AvatarGroup (SwiftUI)"
+    }
+}
+
+struct AvatarGroupDemoView: View {
+    static let defaultSize: MSFAvatarSize = .size72
+    static let startingAvatarCount: Int = 5
+    static let startingMaxDisplayedAvatars: Int = 3
+
+    @Environment(\.fluentTheme) var fluentTheme: FluentTheme
+
+    @State var useAlternateBackground: Bool = false
+
+    // Avatar settings
+    @State var isRingVisible: Bool = false
+    @State var showImage: Bool = true
+    @State var showImageBasedRingColor: Bool = false
+
+    // AvatarGroup settings
+    @State var maxDisplayedAvatars: Int = startingMaxDisplayedAvatars
+    @State var overflowCount: Int = 0
+    @State var isUnread: Bool = false
+    @State var size: MSFAvatarSize = AvatarGroupDemoView.defaultSize
+    @State var style: MSFAvatarGroupStyle = .stack
+    @State var avatarCount: Int = startingAvatarCount
+
+    @ViewBuilder
+    func avatarFromSamplePersona(_ index: Int) -> Avatar {
+        let samplePersona = samplePersonas[index % samplePersonas.count]
+        Avatar(style: .default,
+                      size: size,
+                      image: showImage ? samplePersona.image : nil,
+                      primaryText: samplePersona.name,
+                      secondaryText: samplePersona.email)
+        .isRingVisible(isRingVisible)
+        .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                fluentTheme.color(useAlternateBackground ? .backgroundCanvas : .background1)
+                AvatarGroup(style: style,
+                            size: size,
+                            avatarCount: avatarCount,
+                            maxDisplayedAvatars: maxDisplayedAvatars,
+                            overflowCount: overflowCount,
+                            isUnread: isUnread) { index in
+                    avatarFromSamplePersona(index)
+                }
+                .fixedSize()
+            }
+            .frame(height: 120, alignment: .center)
+
+            FluentList {
+                Section("Content") {
+                    Stepper("Avatar Count: \(avatarCount)", value: $avatarCount, in: (0...Int.max))
+                    Stepper("Max Displayed Avatars: \(maxDisplayedAvatars)", value: $maxDisplayedAvatars)
+                    Stepper("Overflow Count: \(overflowCount)", value: $overflowCount)
+                    Toggle("Show Avatar Images", isOn: $showImage)
+                    Toggle("Unread Dot", isOn: $isUnread)
+                    Toggle("Alternate Background", isOn: $useAlternateBackground)
+                }
+
+                Section("Ring") {
+                    Toggle("Ring Visible", isOn: $isRingVisible)
+                    Toggle("Image Based Ring Color", isOn: $showImageBasedRingColor)
+                }
+
+                Section("Style") {
+                    Picker(selection: $style, label: EmptyView()) {
+                        Text(".stack").tag(MSFAvatarGroupStyle.stack)
+                        Text(".pile").tag(MSFAvatarGroupStyle.pile)
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Section("Size") {
+                    Picker("Avatar Size", selection: $size) {
+                        ForEach(MSFAvatarSize.allCases.reversed(), id: \.self) { avatarSize in
+                            Text("\(avatarSize.description)").tag(avatarSize)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .fluentListStyle(.insetGrouped)
+        }
+        .fluentTheme(fluentTheme)
+        .tint(Color(fluentTheme.color(.brandForeground1)))
+    }
+}
+
+extension MSFAvatarSize {
+    var description: String {
+        switch self {
+        case .size16:
+            return ".size16"
+        case .size20:
+            return ".size20"
+        case .size24:
+            return ".size24"
+        case .size32:
+            return ".size32"
+        case .size40:
+            return ".size40"
+        case .size56:
+            return ".size56"
+        case .size72:
+            return ".size72"
+        }
+    }
+}

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -82,7 +82,11 @@ import SwiftUI
 }
 
 /// View that represents the avatar.
-public struct Avatar: View, TokenizedControlView {
+public struct Avatar: View, TokenizedControlView, Equatable {
+    public static func == (lhs: Avatar, rhs: Avatar) -> Bool {
+        lhs.state == rhs.state
+    }
+
     public typealias TokenSetKeyType = AvatarTokenSet.Tokens
     @ObservedObject public var tokenSet: AvatarTokenSet
 

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -95,14 +95,39 @@ public struct AvatarGroup: View, TokenizedControlView {
     public typealias TokenSetKeyType = AvatarGroupTokenSet.Tokens
     @ObservedObject public var tokenSet: AvatarGroupTokenSet
 
-    /// Creates and initializes a SwiftUI AvatarGroup.
+    /// Creates and initializes a SwiftUI `AvatarGroup`.
     /// - Parameters:
     ///   - style: The style of the avatar group.
     ///   - size: The size of the avatars displayed in the avatar group.
+    ///   - avatarCount: The number of Avatars in this group.
+    ///   - maxDisplayedAvatars: Caps the number of displayed avatars and shows the remaining not displayed in the overflow avatar.
+    ///   - overflowCount: Adds to the overflow count in case the calling code did not provide all the avatars, but still wants to convey more
+    ///                    items than just the remainder of the avatars that could not be displayed due to the maxDisplayedAvatars property.
+    ///   - isUnread: Show a top-trailing aligned unread dot when set to true.
+    ///   - avatarBuilder: A ViewBuilder that creates an `Avatar` for a given index.
     public init(style: MSFAvatarGroupStyle,
-                size: MSFAvatarSize) {
+                size: MSFAvatarSize,
+                avatarCount: Int = 0,
+                maxDisplayedAvatars: Int = 5,
+                overflowCount: Int = 0,
+                isUnread: Bool = false,
+                @ViewBuilder avatarBuilder: @escaping (_ index: Int) -> Avatar) {
+        // Configure the avatars
+        let avatars = (0..<avatarCount).map { index in
+            let avatar = avatarBuilder(index)
+            avatar.state.size = size
+            avatar.state.style = .default
+            avatar.state.isTransparent = false
+            return avatar
+        }
+
         let state = MSFAvatarGroupStateImpl(style: style,
                                             size: size)
+        state.avatars = avatars
+        state.maxDisplayedAvatars = maxDisplayedAvatars
+        state.overflowCount = overflowCount
+        state.isUnread = isUnread
+
         self.state = state
         self.tokenSet = AvatarGroupTokenSet(style: { state.style },
                                             size: { state.size })
@@ -110,9 +135,7 @@ public struct AvatarGroup: View, TokenizedControlView {
 
     public var body: some View {
         tokenSet.update(fluentTheme)
-        let avatars: [MSFAvatarStateImpl] = state.avatars
-        let avatarViews: [Avatar] = avatars.map { Avatar($0) }
-        let enumeratedAvatars = Array(avatars.enumerated())
+        let avatars = state.avatars
         let avatarCount: Int = avatars.count
         let maxDisplayedAvatars: Int = state.maxDisplayedAvatars
         let avatarsToDisplay = avatarsToDisplay
@@ -126,7 +149,7 @@ public struct AvatarGroup: View, TokenizedControlView {
 
         let groupHeight: CGFloat = {
             let avatarMaxHeight: CGFloat
-            if let avatar = avatarViews.first {
+            if let avatar = avatars.first {
                 let avatarSize = avatar.contentSize
                 let ringThickness = avatar.tokenSet[.ringThickness].float
                 let ringInnerGap = avatar.tokenSet[.ringInnerGap].float
@@ -149,57 +172,33 @@ public struct AvatarGroup: View, TokenizedControlView {
         }()
 
         @ViewBuilder
-        func avatarView(at index: Int, for avatar: MSFAvatarStateImpl) -> some View {
+        func avatarView(at index: Int, for avatar: Avatar) -> some View {
             let nextIndex = index + 1
             let isLastDisplayed = nextIndex == avatarsToDisplay
-            // If the avatar is part of Stack style and is not the last avatar in the sequence, create a cutout.
-            let avatarView = avatarViews[index]
-            let needsCutout = isStackStyle && (hasOverflow || !isLastDisplayed)
-            let avatarSize: CGFloat = avatarView.totalSize
-            let nextAvatarSize: CGFloat = isLastDisplayed ? overflowAvatar.totalSize : avatarViews[nextIndex].totalSize
 
             // Calculating the size delta of the current and next avatar based off of ring visibility, which helps determine
             // starting coordinates for the cutout.
-            let currentAvatarHasRing = avatar.isRingVisible
-            let nextAvatarHasRing = !isLastDisplayed ? avatars[nextIndex].isRingVisible : false
+            let currentAvatarHasRing = avatar.state.isRingVisible
+            let nextAvatarHasRing = !isLastDisplayed ? avatars[nextIndex].state.isRingVisible : false
 
             // Calculating the different interspace scenarios considering rings.
-            let ringOuterGap = avatarView.tokenSet[.ringOuterGap].float
-            let ringOffset = avatarView.tokenSet[.ringInnerGap].float + avatarView.tokenSet[.ringThickness].float + ringOuterGap
+            let ringOuterGap = avatar.tokenSet[.ringOuterGap].float
+            let ringOffset = avatar.tokenSet[.ringInnerGap].float + avatar.tokenSet[.ringThickness].float + ringOuterGap
             let stackPadding = interspace - (currentAvatarHasRing ? ringOffset : 0) - (nextAvatarHasRing ? ringOuterGap : 0)
 
-            // Finalized calculations for x and y coordinates of the Avatar if it needs a cutout, including RTL.
-            let ringGapOffset = 2 * ringOuterGap
-            let xOrigin: CGFloat = {
-                if layoutDirection == .rightToLeft {
-                    return -nextAvatarSize - interspace + ringOuterGap + (currentAvatarHasRing ? ringOffset : 0)
+            avatar
+                .transition(.identity)
+                .onChange_iOS17(of: state.size) { size in
+                    avatar.state.size = size
                 }
-                return avatarSize + interspace - ringGapOffset - ringOuterGap - (currentAvatarHasRing ? ringOuterGap : 0)
-            }()
-
-            let sizeDiff = avatarSize - nextAvatarSize - (currentAvatarHasRing ? 0 : ringGapOffset)
-            let yOrigin = sizeDiff / 2
-
-            // Hand the rendering of the avatar to a helper function to appease Swift's
-            // strict type-checking timeout.
-            VStack {
-                avatarView
-                    .transition(.identity)
-                    .modifyIf(needsCutout, { view in
-                        view.clipShape(ShapeCutout(xOrigin: xOrigin,
-                                                   yOrigin: yOrigin,
-                                                   cornerRadius: .infinity,
-                                                   cutoutSize: nextAvatarSize),
-                                       style: FillStyle(eoFill: true))
-                    })
-            }
             .padding(.trailing, (isLastDisplayed && !hasOverflow) ? 0 : isStackStyle ? stackPadding : interspace)
         }
 
         @ViewBuilder
         var avatarGroup: some View {
             HStack(spacing: 0) {
-                ForEach(enumeratedAvatars.prefix(avatarsToDisplay), id: \.1) { index, avatar in
+                ForEach(0..<avatarsToDisplay, id: \.self) { index in
+                    let avatar = avatars[index]
                     avatarView(at: index, for: avatar)
                         .transition(AnyTransition.opacity)
                 }
@@ -266,8 +265,8 @@ public struct AvatarGroup: View, TokenizedControlView {
     var displayedAvatarAccessibilityLabels: [String] {
         var labels: [String] = []
         for i in 0..<avatarsToDisplay {
-            let avatar = state.avatars[i]
-            labels.append(avatar.accessibilityLabel ?? avatar.primaryText ?? avatar.secondaryText ?? "")
+            let avatarState = state.avatars[i].state
+            labels.append(avatarState.accessibilityLabel ?? avatarState.primaryText ?? avatarState.secondaryText ?? "")
         }
         let overflowCount = state.avatars.count - avatarsToDisplay + state.overflowCount
         if overflowCount > 0 {
@@ -295,6 +294,22 @@ public struct AvatarGroup: View, TokenizedControlView {
         return str
     }
 
+    /// Creates and initializes a SwiftUI `AvatarGroup`.
+    ///
+    /// This internal initializer is used exclusively for our UIKit wrapper, and should not be made public.
+    ///
+    /// - Parameters:
+    ///   - style: The style of the avatar group.
+    ///   - size: The size of the avatars displayed in the avatar group.
+    init(style: MSFAvatarGroupStyle,
+         size: MSFAvatarSize) {
+        self.init(style: style,
+                  size: size,
+                  avatarCount: 0) { _ in
+            Avatar(style: .default, size: .size32)
+        }
+    }
+
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
     @Environment(\.layoutDirection) var layoutDirection: LayoutDirection
     @ObservedObject var state: MSFAvatarGroupStateImpl
@@ -319,16 +334,17 @@ class MSFAvatarGroupStateImpl: ControlState, MSFAvatarGroupState {
         guard index <= avatars.count && index >= 0 else {
             preconditionFailure("Index is out of bounds")
         }
-        let avatar = MSFAvatarGroupAvatarStateImpl(size: size)
+        let avatar = Avatar(style: .default, size: size)
+        avatar.state.isTransparent = false
         avatars.insert(avatar, at: index)
-        return avatar
+        return avatar.state
     }
 
     func getAvatarState(at index: Int) -> MSFAvatarGroupAvatarState {
         guard avatars.indices.contains(index) else {
             preconditionFailure("Index is out of bounds")
         }
-        return avatars[index]
+        return avatars[index].state
     }
 
     func removeAvatar(at index: Int) {
@@ -338,7 +354,7 @@ class MSFAvatarGroupStateImpl: ControlState, MSFAvatarGroupState {
         avatars.remove(at: index)
     }
 
-    @Published var avatars: [MSFAvatarGroupAvatarStateImpl] = []
+    @Published var avatars: [Avatar] = []
     @Published var maxDisplayedAvatars: Int = Int.max
     @Published var overflowCount: Int = 0
     @Published var isUnread: Bool = false
@@ -355,8 +371,6 @@ class MSFAvatarGroupStateImpl: ControlState, MSFAvatarGroupState {
     }
 }
 
-class MSFAvatarGroupAvatarStateImpl: MSFAvatarStateImpl, MSFAvatarGroupAvatarState {
-    init(size: MSFAvatarSize) {
-        super.init(style: .default, size: size)
-    }
+/// Simple extension to `MSFAvatarStateImpl` to prove conformance to `MSFAvatarGroupAvatarState`.
+extension MSFAvatarStateImpl: MSFAvatarGroupAvatarState {
 }

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -108,7 +108,7 @@ public struct AvatarGroup: View, TokenizedControlView {
     public init(style: MSFAvatarGroupStyle,
                 size: MSFAvatarSize,
                 avatarCount: Int = 0,
-                maxDisplayedAvatars: Int = 5,
+                maxDisplayedAvatars: Int = Int.max,
                 overflowCount: Int = 0,
                 isUnread: Bool = false,
                 @ViewBuilder avatarBuilder: @escaping (_ index: Int) -> Avatar) {
@@ -266,7 +266,9 @@ public struct AvatarGroup: View, TokenizedControlView {
         var labels: [String] = []
         for i in 0..<avatarsToDisplay {
             let avatarState = state.avatars[i].state
-            labels.append(avatarState.accessibilityLabel ?? avatarState.primaryText ?? avatarState.secondaryText ?? "")
+            if let label = avatarState.accessibilityLabel ?? avatarState.primaryText ?? avatarState.secondaryText {
+                labels.append(label)
+            }
         }
         let overflowCount = state.avatars.count - avatarsToDisplay + state.overflowCount
         if overflowCount > 0 {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Creating a SwiftUI API for `AvatarGroup`.

Yes, it's always been a SwiftUI control, but the API was only ever designed to be used in a UIKit wrapper, where `Avatar` elements could be added and removed via event-driven method calls. Our new API is fully data-driven, as befits a native SwiftUI control.

```swift
let style = MSFAvatarGroupStyle.stack
let size = MSFAvatarSize.size40
let avatarCount = 5

// Basic initializer--there are more properties to explore!
AvatarGroup(style: style,
            size: size,
            avatarCount: avatarCount) { index in

    // Create and yield an Avatar for the given callback index.
    Avatar(style: style,
           size: size,
           image: fetchImage(index),
           primaryText: fetchName(index))
}
```

As part of this change, I've also avoided the ability to mark an `AvatarGroup` as transparent, aligning with our latest designs. This will eventually be deprecated across all existing `Avatar` endpoints.

### Binary change

Total increase: 12,544 bytes
Total decrease: -52,432 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,203,440 bytes | 31,163,552 bytes | 🎉 -39,888 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| CalendarViewWeekdayHeadingView.o | 77,928 bytes | 83,480 bytes | ⚠️ 5,552 bytes |
| SegmentedControl.o | 330,216 bytes | 333,640 bytes | ⚠️ 3,424 bytes |
| PopupMenuController.o | 375,464 bytes | 378,064 bytes | ⚠️ 2,600 bytes |
| MSFAvatarGroup.o | 31,184 bytes | 32,152 bytes | ⚠️ 968 bytes |
| BottomSheetController.o | 525,872 bytes | 525,512 bytes | 🎉 -360 bytes |
| MultilineCommandBar.o | 140,104 bytes | 139,352 bytes | 🎉 -752 bytes |
| IndeterminateProgressBar.o | 231,928 bytes | 231,112 bytes | 🎉 -816 bytes |
| HUD.o | 267,176 bytes | 266,200 bytes | 🎉 -976 bytes |
| Avatar.o | 604,704 bytes | 596,968 bytes | 🎉 -7,736 bytes |
| __.SYMDEF | 4,863,752 bytes | 4,855,520 bytes | 🎉 -8,232 bytes |
| AvatarGroup.o | 417,456 bytes | 383,896 bytes | 🎉 -33,560 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>
SwiftUI

https://github.com/microsoft/fluentui-apple/assets/4934719/e2fb5aa0-23d2-4e17-b27c-9ce1e92fbbd1

### UIKit

https://github.com/microsoft/fluentui-apple/assets/4934719/c5f694fb-bd74-4942-b73e-c9b2f9a2863c

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2022)