### PR TITLE
[FluentList] Set environment variable for styling so child views can utilize it

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -219,7 +219,6 @@ struct ListItemDemoView: View {
                     controls
                 }
                 .fluentListStyle(listStyle)
-                .background(ListItem.listBackgroundColor(for: .grouped))
                 .fluentTheme(fluentTheme)
             }
         }

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -32,6 +32,7 @@ public struct FluentList<ListContent: View>: View {
         var list: some View {
             List {
                 content()
+                    .environment(\.listStyle, listStyle)
             }
         }
 
@@ -41,7 +42,11 @@ public struct FluentList<ListContent: View>: View {
             case .inset:
                 list.listStyle(.inset)
             case .insetGrouped:
-                list.listStyle(.insetGrouped)
+                list
+                    .listStyle(.insetGrouped)
+                    // TODO: Directly use `FluentList` token set instead of `ListItem`
+                    .background(ListItem.listBackgroundColor(for: .grouped))
+                    .listStyling_iOS17()
             case .plain:
                 list.listStyle(.plain)
             }
@@ -58,4 +63,42 @@ public struct FluentList<ListContent: View>: View {
     /// Content to render inside the list
     private var content: () -> ListContent
 
+}
+
+// MARK: - Environment
+
+public extension EnvironmentValues {
+    var listStyle: FluentListStyle {
+        get {
+            self[FluentListStyleKey.self]
+        }
+        set {
+            self[FluentListStyleKey.self] = newValue
+        }
+    }
+}
+
+struct FluentListStyleKey: EnvironmentKey {
+    static var defaultValue: FluentListStyle { .plain }
+}
+
+// MARK: - View
+
+extension View {
+    /// Abstracts away differences in pre-iOS 17 for list styling
+    ///
+    /// This function should be removed once we move to iOS 17 as a minimum target.
+    /// - Parameters:
+    ///   - spacing: The amount of spacing between sections.
+    ///   - minHeaderHeight: The minimum header height for sections in the list
+    /// - Returns: A view that has list section spacing applied if iOS 17 is available.
+    func listStyling_iOS17() -> some View {
+        if #available(iOS 17, *) {
+            return self
+                .listSectionSpacing(0)
+                .environment(\.defaultMinListHeaderHeight, 42)
+        } else {
+            return self
+        }
+    }
 }

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -95,8 +95,8 @@ extension View {
     func listStyling_iOS17() -> some View {
         if #available(iOS 17, *) {
             return self
-                .listSectionSpacing(0)
-                .environment(\.defaultMinListHeaderHeight, 42)
+                .listSectionSpacing(16)
+                .environment(\.defaultMinListHeaderHeight, 32)
         } else {
             return self
         }

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -48,7 +48,10 @@ public struct FluentList<ListContent: View>: View {
                     .background(ListItem.listBackgroundColor(for: .grouped))
                     .listStyling_iOS17()
             case .plain:
-                list.listStyle(.plain)
+                list
+                    .listStyle(.plain)
+                    // TODO: Directly use `FluentList` token set instead of `ListItem`
+                    .background(ListItem.listBackgroundColor(for: .plain))
             }
         }
 

--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -67,7 +67,7 @@ public struct FluentList<ListContent: View>: View {
 
 // MARK: - Environment
 
-public extension EnvironmentValues {
+extension EnvironmentValues {
     var listStyle: FluentListStyle {
         get {
             self[FluentListStyleKey.self]

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -34,6 +34,17 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
             } header: {
                 if let header = header {
                     header()
+                } else {
+                    if listStyle == .insetGrouped {
+                        // Currently only a minimum header height and section spacing can
+                        // be specified for a SwiftUI.List. To have a consistent
+                        // minimum height it needs to be specified but it doesn't account for section spacing.
+                        // This is an issue as it will always be larger then we want unless we set
+                        // section spacing to 0. If we do that and don't have a header, there will
+                        // be no spacing between sections so providing a default header.
+                        Text("")
+                            .accessibilityHidden(true)
+                    }
                 }
             } footer: {
                 if let footer = footer {
@@ -55,6 +66,8 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
     /// Content to display in the header of the section
     private var header: (() -> SectionHeaderContent)?
 
+    /// The style of the parent list for the section
+    @Environment(\.listStyle) private var listStyle: FluentListStyle
 }
 
 public extension FluentListSection where SectionHeaderContent == EmptyView, SectionFooterContent == EmptyView {

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -34,17 +34,6 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
             } header: {
                 if let header = header {
                     header()
-                } else {
-                    if listStyle == .insetGrouped {
-                        // Currently only a minimum header height and section spacing can
-                        // be specified for a SwiftUI.List. To have a consistent
-                        // minimum height it needs to be specified but it doesn't account for section spacing.
-                        // This is an issue as it will always be larger then we want unless we set
-                        // section spacing to 0. If we do that and don't have a header, there will
-                        // be no spacing between sections so providing a default header.
-                        Text("")
-                            .accessibilityHidden(true)
-                    }
                 }
             } footer: {
                 if let footer = footer {
@@ -65,9 +54,6 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
 
     /// Content to display in the header of the section
     private var header: (() -> SectionHeaderContent)?
-
-    /// The style of the parent list for the section
-    @Environment(\.listStyle) private var listStyle: FluentListStyle
 }
 
 public extension FluentListSection where SectionHeaderContent == EmptyView, SectionFooterContent == EmptyView {

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -54,6 +54,7 @@ public struct FluentListSection<SectionContent: View, SectionHeaderContent: View
 
     /// Content to display in the header of the section
     private var header: (() -> SectionHeaderContent)?
+
 }
 
 public extension FluentListSection where SectionHeaderContent == EmptyView, SectionFooterContent == EmptyView {

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -249,7 +249,7 @@ public struct ListItem<LeadingContent: View,
     /// The `ListItemAccessoryType` that the `ListItem` should display.
     var accessoryType: ListItemAccessoryType = .none
 
-    /// The custom background styling of the `ListItem`, which is preferred over the `ListStyle` environment value.
+    /// The custom background styling of the `ListItem`, which is preferred over the `FLuentListStyle` environment value.
     var customBackgroundStyleType: ListItemBackgroundStyleType?
 
     /// The handler for when the `detailButton` accessory view is tapped.

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -249,8 +249,8 @@ public struct ListItem<LeadingContent: View,
     /// The `ListItemAccessoryType` that the `ListItem` should display.
     var accessoryType: ListItemAccessoryType = .none
 
-    /// The background styling of the `ListItem` to match the type of `List` it is displayed in.
-    var backgroundStyleType: ListItemBackgroundStyleType = .plain
+    /// The custom background styling of the `ListItem`, which is preferred over the `ListStyle` environment value.
+    var customBackgroundStyleType: ListItemBackgroundStyleType?
 
     /// The handler for when the `detailButton` accessory view is tapped.
     var onAccessoryTapped: (() -> Void)?
@@ -281,8 +281,24 @@ public struct ListItem<LeadingContent: View,
 
     // MARK: Private variables
 
+    /// The background styling of the `ListItem`.
+    private var backgroundStyleType: ListItemBackgroundStyleType {
+        if let customBackgroundStyleType {
+                return customBackgroundStyleType
+        }
+
+        switch listStyle {
+        case .plain, .inset:
+            return .plain
+        case .insetGrouped:
+            return .grouped
+        }
+    }
+
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
     @Environment(\.isEnabled) private var isEnabled: Bool
+    /// The style of the parent list for the section
+    @Environment(\.listStyle) private var listStyle: FluentListStyle
 
     private var leadingContent: (() -> LeadingContent)?
     private var trailingContent: (() -> TrailingContent)?
@@ -316,6 +332,9 @@ private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
     let tokenSet: ListItemTokenSet
 
     @Environment(\.isEnabled) private var isEnabled: Bool
+
+    /// The style of the parent list for the section
+    @Environment(\.listStyle) private var listStyle: FluentListStyle
 }
 
 // MARK: Constants

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -249,7 +249,7 @@ public struct ListItem<LeadingContent: View,
     /// The `ListItemAccessoryType` that the `ListItem` should display.
     var accessoryType: ListItemAccessoryType = .none
 
-    /// The custom background styling of the `ListItem`, which is preferred over the `FLuentListStyle` environment value.
+    /// The custom background styling of the `ListItem`, which is preferred over the `FluentListStyle` environment value.
     var customBackgroundStyleType: ListItemBackgroundStyleType?
 
     /// The handler for when the `detailButton` accessory view is tapped.
@@ -283,16 +283,18 @@ public struct ListItem<LeadingContent: View,
 
     /// The background styling of the `ListItem`.
     private var backgroundStyleType: ListItemBackgroundStyleType {
+        let styleType: ListItemBackgroundStyleType
         if let customBackgroundStyleType {
-                return customBackgroundStyleType
+            styleType = customBackgroundStyleType
+        } else {
+            switch listStyle {
+            case .plain, .inset:
+                styleType = .plain
+            case .insetGrouped:
+                styleType = .grouped
+            }
         }
-
-        switch listStyle {
-        case .plain, .inset:
-            return .plain
-        case .insetGrouped:
-            return .grouped
-        }
+        return styleType
     }
 
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme

--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -297,7 +297,7 @@ public struct ListItem<LeadingContent: View,
 
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
     @Environment(\.isEnabled) private var isEnabled: Bool
-    /// The style of the parent list for the section
+    /// The style of the parent `FluentList`.
     @Environment(\.listStyle) private var listStyle: FluentListStyle
 
     private var leadingContent: (() -> LeadingContent)?
@@ -332,9 +332,6 @@ private struct ListItemButtonStyle: SwiftUI.ButtonStyle {
     let tokenSet: ListItemTokenSet
 
     @Environment(\.isEnabled) private var isEnabled: Bool
-
-    /// The style of the parent list for the section
-    @Environment(\.listStyle) private var listStyle: FluentListStyle
 }
 
 // MARK: Constants

--- a/ios/FluentUI/List/ListItemModifiers.swift
+++ b/ios/FluentUI/List/ListItemModifiers.swift
@@ -50,12 +50,12 @@ public extension ListItem {
         return listItem
     }
 
-    /// The background styling of the `ListItem` to match the type of `List` it is displayed in.
+    /// The background styling of the `ListItem` which overrides the inherited value from `FluentList`.
     /// - Parameter backgroundStyleType: The style of the background.
     /// - Returns: The modified `ListItem` with the property set.
     func backgroundStyleType(_ backgroundStyleType: ListItemBackgroundStyleType) -> ListItem {
         var listItem = self
-        listItem.backgroundStyleType = backgroundStyleType
+        listItem.customBackgroundStyleType = backgroundStyleType
         return listItem
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

The `FluentList` and `FluentItem` are designed to be used together but there will need to be some coordination between them for styling. This is so that the item can be styled to match the type of list. 

To achieve this, it seemed to make sense to use an environment variable so the list can set the list style and pass it to any child views that want to use it, like a `ListItem` view. This way implementors don't need to set a matching style on every `ListItem` to be the same as the style of the wrapping `FluentList`. We will be able to also use this value for `FluentListSection`, `FluentListSectionHeader`, and `FluentListSectionFooter`.

If an implementor for some reason still wanted to specify a different style on `ListItem`, we respect that value over the environment variable.

Updated both the background color and the spacing for the `insetGrouped` list style.

### Binary change

Total increase: 36,016 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,968,016 bytes | 31,004,032 bytes | ⚠️ 36,016 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentList.o | 49,288 bytes | 70,896 bytes | ⚠️ 21,608 bytes |
| ListItem.o | 319,352 bytes | 325,840 bytes | ⚠️ 6,488 bytes |
| __.SYMDEF | 4,750,168 bytes | 4,756,024 bytes | ⚠️ 5,856 bytes |
| IndeterminateProgressBar.o | 231,256 bytes | 232,400 bytes | ⚠️ 1,144 bytes |
| FocusRingView.o | 831,480 bytes | 832,400 bytes | ⚠️ 920 bytes |
</details>

### Verification


<details>
<summary>Visual Verification</summary>

| | Before                                       | After                                      |
|--|----------------------------------------------|--------------------------------------------|
| header height and spacing (with a header string, with an empty string, and with no header provided) | ![image](https://github.com/microsoft/fluentui-apple/assets/21343215/4b30a6e1-c658-4bbc-94b8-7a1a5cd1efbb)| ![image](https://github.com/microsoft/fluentui-apple/assets/21343215/e874d204-ecf2-402f-bf04-cdbd9fac04b2) |


With `.grouped` style specified for `ListItem`
<img src=https://github.com/microsoft/fluentui-apple/assets/21343215/cfa88fdc-8c81-49a0-a9f2-04558ae0f050 height=500px>

With `.plain` style specified for `ListItem`
<img src=https://github.com/microsoft/fluentui-apple/assets/21343215/ea93ad37-fd72-4d49-91b2-ac80eaf7c38f height=500px>



</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2023)