### PR TITLE
Adding a convenience init for `FluentListSection`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListActionItemDemoController_SwiftUI.swift
@@ -94,7 +94,7 @@ struct ListActionItemDemoView: View {
 
         @ViewBuilder
         var content: some View {
-            FluentListSection {
+            FluentListSection("ListActionItem") {
                 if showSecondaryAction {
                     ListActionItem(primaryActionTitle: primaryActionTitle,
                                    onPrimaryActionTapped: {
@@ -119,21 +119,17 @@ struct ListActionItemDemoView: View {
                     .bottomSeparatorType(bottomSeparatorType)
                     .backgroundStyleType(backgroundStyleType)
                 }
-            } header: {
-                Text("ListActionItem")
             }
             .alert("Action tapped", isPresented: $showingAlert) {
                 Button("OK", role: .cancel) { }
                     .accessibilityIdentifier("DismissAlertButton")
             }
 
-            FluentListSection {
+            FluentListSection("Settings") {
                 FluentUIDemoToggle(titleKey: "Show secondary action", isOn: $showSecondaryAction)
                     .accessibilityIdentifier("showSecondaryActionSwitch")
                 textFields
                 pickers
-            } header: {
-                Text("Settings")
             }
         }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -210,10 +210,8 @@ struct ListItemDemoView: View {
                 }
                 FluentList {
                     if !renderStandalone {
-                        FluentListSection {
+                        FluentListSection("ListItem") {
                             listItem
-                        } header: {
-                            Text("ListItem")
                         }
                     }
                     controls

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -76,3 +76,12 @@ public extension FluentListSection where SectionHeaderContent == EmptyView {
         self.footer = footer
     }
 }
+
+public extension FluentListSection where SectionHeaderContent == Text, SectionFooterContent == EmptyView {
+    init(_ titleKey: LocalizedStringKey, @ViewBuilder content: @escaping () -> SectionContent) {
+        self.content = content
+        self.header = {
+            Text(titleKey)
+        }
+    }
+}

--- a/ios/FluentUI/List/FluentListSection.swift
+++ b/ios/FluentUI/List/FluentListSection.swift
@@ -77,11 +77,9 @@ public extension FluentListSection where SectionHeaderContent == EmptyView {
     }
 }
 
-public extension FluentListSection where SectionHeaderContent == Text, SectionFooterContent == EmptyView {
-    init(_ titleKey: LocalizedStringKey, @ViewBuilder content: @escaping () -> SectionContent) {
+public extension FluentListSection where SectionHeaderContent == FluentListSectionHeader<String, EmptyView>, SectionFooterContent == EmptyView {
+    init(_ title: String, @ViewBuilder content: @escaping () -> SectionContent) {
         self.content = content
-        self.header = {
-            Text(titleKey)
-        }
+        self.header = { FluentListSectionHeader(title: title) }
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Adding a convenience initializer for `FluentListSection where SectionHeaderContent == Text, SectionFooterContent == EmptyView`.

```swift
// MARK: - Before

FluentListSection {
    // ...
} header {
    Text("Hello!")
}

// MARK: - After

FluentListSection("Hello!") {
    // ...
}
```

### Binary change

Total increase: 6,576 bytes
Total decrease: -8 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,212,536 bytes | 31,219,104 bytes | ⚠️ 6,568 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentListSection.o | 38,992 bytes | 44,392 bytes | ⚠️ 5,400 bytes |
| __.SYMDEF | 4,865,344 bytes | 4,866,520 bytes | ⚠️ 1,176 bytes |
| FluentListSectionHeader.o | 47,632 bytes | 47,624 bytes | 🎉 -8 bytes |
</details>

### Verification

No changes to FluentListSection uses.

<details>
<summary>Visual Verification</summary>

| ListItem                                       | ListActionItem                                      |
|----------------------------------------------|--------------------------------------------|
| ![ListItem](https://github.com/microsoft/fluentui-apple/assets/4934719/d75c327b-cf4d-4fc5-92c1-1b34fa74b117) | ![ListActionItem](https://github.com/microsoft/fluentui-apple/assets/4934719/5b1087da-a38a-40fe-927e-eccd4152e92b) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2024)