### PR TITLE
Rename SwiftUI Color token APIs

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AliasColorTokensDemoController_SwiftUI.swift
@@ -47,7 +47,7 @@ struct AliasColorTokensDemoView: View {
                 }
             }
         }
-        .background(fluentTheme.color(.backgroundCanvas))
+        .background(fluentTheme.swiftUIColor(.backgroundCanvas))
     }
 
     @ViewBuilder
@@ -56,7 +56,7 @@ struct AliasColorTokensDemoView: View {
             ForEach(demoSection.rows, id: \.self) { colorRow in
                 Text(colorRow.text)
                     .frame(maxWidth: .infinity, alignment: .center)
-                    .listRowBackground(fluentTheme.color(colorRow))
+                    .listRowBackground(fluentTheme.swiftUIColor(colorRow))
                     .foregroundStyle(Color(colorRow.textColor(fluentTheme)))
             }
         }

--- a/ios/FluentUI/Button/FluentButtonToggleStyle.swift
+++ b/ios/FluentUI/Button/FluentButtonToggleStyle.swift
@@ -45,7 +45,7 @@ public struct FluentButtonToggleStyle: ToggleStyle {
     }
 
     private var buttonOnTokens: [ButtonToken: ControlTokenValue] {
-        let backgroundColor: Color = fluentTheme.color(.brandBackgroundTint)
+        let backgroundColor = fluentTheme.swiftUIColor(.brandBackgroundTint)
         var tokens: [ButtonToken: ControlTokenValue] = buttonTokens.merging([
             .backgroundColor: .color { backgroundColor },
             .backgroundPressedColor: .color { backgroundColor },

--- a/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+Tokens.swift
@@ -149,7 +149,7 @@ public extension FluentTheme {
     ///
     /// - Parameter token: The `ColorsTokens` value to be retrieved.
     /// - Returns: A `Color` for the given token.
-    func color(_ token: ColorToken) -> Color {
+    func swiftUIColor(_ token: ColorToken) -> Color {
         return Color(dynamicColor: colorTokenSet[token])
     }
 
@@ -201,281 +201,281 @@ extension FluentTheme {
     static func defaultColor(_ token: FluentTheme.ColorToken) -> DynamicColor {
         switch token {
         case .foreground1:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey14),
-                                dark: GlobalTokens.neutralColor(.white))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey14),
+                                dark: GlobalTokens.neutralSwiftUIColor(.white))
         case .foreground2:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey38),
-                                dark: GlobalTokens.neutralColor(.grey84))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey38),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey84))
         case .foreground3:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey50),
-                                dark: GlobalTokens.neutralColor(.grey68))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey50),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey68))
         case .foregroundDisabled1:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey74),
-                                dark: GlobalTokens.neutralColor(.grey36))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey74),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey36))
         case .foregroundDisabled2:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.grey18))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey18))
         case .foregroundOnColor:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.black))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.black))
         case .brandForegroundTint:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm60),
-                                dark: GlobalTokens.brandColor(.comm130))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm60),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm130))
         case .brandForeground1:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm80),
-                                dark: GlobalTokens.brandColor(.comm100))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm80),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm100))
         case .brandForeground1Pressed:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm50),
-                                dark: GlobalTokens.brandColor(.comm140))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm50),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm140))
         case .brandForeground1Selected:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm60),
-                                dark: GlobalTokens.brandColor(.comm120))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm60),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm120))
         case .brandForegroundDisabled1:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm90))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm90))
         case .brandForegroundDisabled2:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm140),
-                                dark: GlobalTokens.brandColor(.comm40))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm140),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm40))
         case .brandGradient1:
-            return DynamicColor(light: GlobalTokens.brandColor(.gradientPrimaryLight),
-                                dark: GlobalTokens.brandColor(.gradientPrimaryDark))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.gradientPrimaryLight),
+                                dark: GlobalTokens.brandSwiftUIColor(.gradientPrimaryDark))
         case .brandGradient2:
-            return DynamicColor(light: GlobalTokens.brandColor(.gradientSecondaryLight),
-                                dark: GlobalTokens.brandColor(.gradientSecondaryDark))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.gradientSecondaryLight),
+                                dark: GlobalTokens.brandSwiftUIColor(.gradientSecondaryDark))
         case .brandGradient3:
-            return DynamicColor(light: GlobalTokens.brandColor(.gradientTertiaryLight),
-                                dark: GlobalTokens.brandColor(.gradientTertiaryDark))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.gradientTertiaryLight),
+                                dark: GlobalTokens.brandSwiftUIColor(.gradientTertiaryDark))
         case .foregroundDarkStatic:
-            return DynamicColor(light: GlobalTokens.neutralColor(.black),
-                                dark: GlobalTokens.neutralColor(.black))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.black),
+                                dark: GlobalTokens.neutralSwiftUIColor(.black))
         case .foregroundLightStatic:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.white))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.white))
         case .background1:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.black),
-                                darkElevated: GlobalTokens.neutralColor(.grey4))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.black),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey4))
         case .background1Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey88),
-                                dark: GlobalTokens.neutralColor(.grey18),
-                                darkElevated: GlobalTokens.neutralColor(.grey18))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey88),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey18),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey18))
         case .background1Selected:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey92),
-                                dark: GlobalTokens.neutralColor(.grey14),
-                                darkElevated: GlobalTokens.neutralColor(.grey14))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey92),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey14),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey14))
         case .background2:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.grey12),
-                                darkElevated: GlobalTokens.neutralColor(.grey16))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey12),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey16))
         case .background2Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey88),
-                                dark: GlobalTokens.neutralColor(.grey30),
-                                darkElevated: GlobalTokens.neutralColor(.grey30))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey88),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey30),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey30))
         case .background2Selected:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey92),
-                                dark: GlobalTokens.neutralColor(.grey26),
-                                darkElevated: GlobalTokens.neutralColor(.grey26))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey92),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey26),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey26))
         case .background3:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.grey16),
-                                darkElevated: GlobalTokens.neutralColor(.grey20))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey16),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey20))
         case .background3Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey88),
-                                dark: GlobalTokens.neutralColor(.grey34),
-                                darkElevated: GlobalTokens.neutralColor(.grey34))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey88),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey34),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey34))
         case .background3Selected:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey92),
-                                dark: GlobalTokens.neutralColor(.grey30),
-                                darkElevated: GlobalTokens.neutralColor(.grey30))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey92),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey30),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey30))
         case .background4:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey98),
-                                dark: GlobalTokens.neutralColor(.grey20),
-                                darkElevated: GlobalTokens.neutralColor(.grey24))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey98),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey20),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey24))
         case .background4Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey86),
-                                dark: GlobalTokens.neutralColor(.grey38),
-                                darkElevated: GlobalTokens.neutralColor(.grey38))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey86),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey38),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey38))
         case .background4Selected:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey90),
-                                dark: GlobalTokens.neutralColor(.grey34),
-                                darkElevated: GlobalTokens.neutralColor(.grey34))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey90),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey34),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey34))
         case .background5:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey94),
-                                dark: GlobalTokens.neutralColor(.grey24),
-                                darkElevated: GlobalTokens.neutralColor(.grey28))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey94),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey24),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey28))
         case .background5Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey82),
-                                dark: GlobalTokens.neutralColor(.grey42),
-                                darkElevated: GlobalTokens.neutralColor(.grey42))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey82),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey42),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey42))
         case .background5Selected:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey86),
-                                dark: GlobalTokens.neutralColor(.grey38),
-                                darkElevated: GlobalTokens.neutralColor(.grey38))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey86),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey38),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey38))
         case .background6:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey82),
-                                dark: GlobalTokens.neutralColor(.grey36),
-                                darkElevated: GlobalTokens.neutralColor(.grey40))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey82),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey36),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey40))
         case .backgroundDisabled:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey88),
-                                dark: GlobalTokens.neutralColor(.grey32),
-                                darkElevated: GlobalTokens.neutralColor(.grey32))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey88),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey32),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey32))
         case .brandBackgroundTint:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm150),
-                                dark: GlobalTokens.brandColor(.comm40))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm150),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm40))
         case .brandBackground1:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm80),
-                                dark: GlobalTokens.brandColor(.comm100))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm80),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm100))
         case .brandBackground1Pressed:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm50),
-                                dark: GlobalTokens.brandColor(.comm140))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm50),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm140))
         case .brandBackground1Selected:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm60),
-                                dark: GlobalTokens.brandColor(.comm120))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm60),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm120))
         case .brandBackground2:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm70))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm70))
         case .brandBackground2Pressed:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm40))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm40))
         case .brandBackground2Selected:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm80))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm80))
         case .brandBackground3:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm60),
-                                dark: GlobalTokens.brandColor(.comm120))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm60),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm120))
         case .brandBackgroundDisabled:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm140),
-                                dark: GlobalTokens.brandColor(.comm40))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm140),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm40))
         case .stencil1:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey90),
-                                dark: GlobalTokens.neutralColor(.grey34))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey90),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey34))
         case .stencil2:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey98),
-                                dark: GlobalTokens.neutralColor(.grey20))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey98),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey20))
         case .backgroundCanvas:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey96),
-                                dark: GlobalTokens.neutralColor(.grey8),
-                                darkElevated: GlobalTokens.neutralColor(.grey14))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey96),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey8),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey14))
         case .backgroundDarkStatic:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey14),
-                                dark: GlobalTokens.neutralColor(.grey24),
-                                darkElevated: GlobalTokens.neutralColor(.grey30))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey14),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey24),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey30))
         case .backgroundInverted:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey46),
-                                dark: GlobalTokens.neutralColor(.grey72),
-                                darkElevated: GlobalTokens.neutralColor(.grey78))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey46),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey72),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey78))
         case .backgroundLightStatic:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.white),
-                                darkElevated: GlobalTokens.neutralColor(.white))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.white),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.white))
         case .backgroundLightStaticDisabled:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.grey68),
-                                darkElevated: GlobalTokens.neutralColor(.grey42))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey68),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey42))
         case .stroke1:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey82),
-                                dark: GlobalTokens.neutralColor(.grey30),
-                                darkElevated: GlobalTokens.neutralColor(.grey36))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey82),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey30),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey36))
         case .stroke1Pressed:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey70),
-                                dark: GlobalTokens.neutralColor(.grey48))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey70),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey48))
         case .stroke2:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey88),
-                                dark: GlobalTokens.neutralColor(.grey24),
-                                darkElevated: GlobalTokens.neutralColor(.grey30))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey88),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey24),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey30))
         case .strokeAccessible:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey38),
-                                dark: GlobalTokens.neutralColor(.grey62),
-                                darkElevated: GlobalTokens.neutralColor(.grey68))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey38),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey62),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey68))
         case .strokeFocus1:
-            return DynamicColor(light: GlobalTokens.neutralColor(.white),
-                                dark: GlobalTokens.neutralColor(.black))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.white),
+                                dark: GlobalTokens.neutralSwiftUIColor(.black))
         case .strokeFocus2:
-            return DynamicColor(light: GlobalTokens.neutralColor(.black),
-                                dark: GlobalTokens.neutralColor(.white))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.black),
+                                dark: GlobalTokens.neutralSwiftUIColor(.white))
         case .strokeDisabled:
-            return DynamicColor(light: GlobalTokens.neutralColor(.grey88),
-                                dark: GlobalTokens.neutralColor(.grey26),
-                                darkElevated: GlobalTokens.neutralColor(.grey32))
+            return DynamicColor(light: GlobalTokens.neutralSwiftUIColor(.grey88),
+                                dark: GlobalTokens.neutralSwiftUIColor(.grey26),
+                                darkElevated: GlobalTokens.neutralSwiftUIColor(.grey32))
         case .brandStroke1:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm80),
-                                dark: GlobalTokens.brandColor(.comm100))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm80),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm100))
         case .brandStroke1Pressed:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm50),
-                                dark: GlobalTokens.brandColor(.comm140))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm50),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm140))
         case .brandStroke1Selected:
-            return DynamicColor(light: GlobalTokens.brandColor(.comm60),
-                                dark: GlobalTokens.brandColor(.comm120))
+            return DynamicColor(light: GlobalTokens.brandSwiftUIColor(.comm60),
+                                dark: GlobalTokens.brandSwiftUIColor(.comm120))
         case .dangerBackground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .tint60),
-                                dark: GlobalTokens.sharedColor(.red, .shade40))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .tint60),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .shade40))
         case .dangerBackground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .primary),
-                                dark: GlobalTokens.sharedColor(.red, .shade10))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .shade10))
         case .dangerForeground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .shade10),
-                                dark: GlobalTokens.sharedColor(.red, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .shade10),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .tint30))
         case .dangerForeground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .primary),
-                                dark: GlobalTokens.sharedColor(.red, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .tint30))
         case .dangerStroke1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .tint20),
-                                dark: GlobalTokens.sharedColor(.red, .tint20))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .tint20),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .tint20))
         case .dangerStroke2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .primary),
-                                dark: GlobalTokens.sharedColor(.red, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .tint30))
         case .successBackground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.green, .tint60),
-                                dark: GlobalTokens.sharedColor(.green, .shade40))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.green, .tint60),
+                                dark: GlobalTokens.sharedSwiftUIColor(.green, .shade40))
         case .successBackground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.green, .primary),
-                                dark: GlobalTokens.sharedColor(.green, .shade10))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.green, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.green, .shade10))
         case .successForeground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.green, .shade10),
-                                dark: GlobalTokens.sharedColor(.green, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.green, .shade10),
+                                dark: GlobalTokens.sharedSwiftUIColor(.green, .tint30))
         case .successForeground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.green, .primary),
-                                dark: GlobalTokens.sharedColor(.green, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.green, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.green, .tint30))
         case .successStroke1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.green, .tint20),
-                                dark: GlobalTokens.sharedColor(.green, .tint20))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.green, .tint20),
+                                dark: GlobalTokens.sharedSwiftUIColor(.green, .tint20))
         case .severeBackground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.darkOrange, .tint60),
-                                dark: GlobalTokens.sharedColor(.darkOrange, .shade40))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.darkOrange, .tint60),
+                                dark: GlobalTokens.sharedSwiftUIColor(.darkOrange, .shade40))
         case .severeBackground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.darkOrange, .primary),
-                                dark: GlobalTokens.sharedColor(.darkOrange, .shade10))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.darkOrange, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.darkOrange, .shade10))
         case .severeForeground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.darkOrange, .shade10),
-                                dark: GlobalTokens.sharedColor(.darkOrange, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.darkOrange, .shade10),
+                                dark: GlobalTokens.sharedSwiftUIColor(.darkOrange, .tint30))
         case .severeForeground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.darkOrange, .shade20),
-                                dark: GlobalTokens.sharedColor(.darkOrange, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.darkOrange, .shade20),
+                                dark: GlobalTokens.sharedSwiftUIColor(.darkOrange, .tint30))
         case .severeStroke1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.darkOrange, .tint10),
-                                dark: GlobalTokens.sharedColor(.darkOrange, .tint20))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.darkOrange, .tint10),
+                                dark: GlobalTokens.sharedSwiftUIColor(.darkOrange, .tint20))
         case .warningBackground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.yellow, .tint60),
-                                dark: GlobalTokens.sharedColor(.yellow, .shade40))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.yellow, .tint60),
+                                dark: GlobalTokens.sharedSwiftUIColor(.yellow, .shade40))
         case .warningBackground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.yellow, .primary),
-                                dark: GlobalTokens.sharedColor(.yellow, .shade10))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.yellow, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.yellow, .shade10))
         case .warningForeground1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.yellow, .shade30),
-                                dark: GlobalTokens.sharedColor(.yellow, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.yellow, .shade30),
+                                dark: GlobalTokens.sharedSwiftUIColor(.yellow, .tint30))
         case .warningForeground2:
-            return DynamicColor(light: GlobalTokens.sharedColor(.yellow, .shade30),
-                                dark: GlobalTokens.sharedColor(.yellow, .tint30))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.yellow, .shade30),
+                                dark: GlobalTokens.sharedSwiftUIColor(.yellow, .tint30))
         case .warningStroke1:
-            return DynamicColor(light: GlobalTokens.sharedColor(.yellow, .shade30),
-                                dark: GlobalTokens.sharedColor(.yellow, .shade20))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.yellow, .shade30),
+                                dark: GlobalTokens.sharedSwiftUIColor(.yellow, .shade20))
         case .presenceAway:
-            return DynamicColor(light: GlobalTokens.sharedColor(.marigold, .primary))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.marigold, .primary))
         case .presenceDnd:
-            return DynamicColor(light: GlobalTokens.sharedColor(.red, .primary),
-                                dark: GlobalTokens.sharedColor(.red, .tint10))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.red, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.red, .tint10))
         case .presenceAvailable:
-            return DynamicColor(light: GlobalTokens.sharedColor(.lightGreen, .primary),
-                                dark: GlobalTokens.sharedColor(.lightGreen, .tint20))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.lightGreen, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.lightGreen, .tint20))
         case .presenceOof:
-            return DynamicColor(light: GlobalTokens.sharedColor(.berry, .primary),
-                                dark: GlobalTokens.sharedColor(.berry, .tint20))
+            return DynamicColor(light: GlobalTokens.sharedSwiftUIColor(.berry, .primary),
+                                dark: GlobalTokens.sharedSwiftUIColor(.berry, .tint20))
         }
     }
 

--- a/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/ControlTokenSet.swift
@@ -309,9 +309,9 @@ public enum ControlTokenValue {
     private var fallbackColor: Color {
 #if DEBUG
         // Use our global "Hot Pink" in debug builds, to help identify unintentional conversions.
-        return GlobalTokens.sharedColor(.hotPink, .primary)
+        return GlobalTokens.sharedSwiftUIColor(.hotPink, .primary)
 #else
-        return GlobalTokens.neutralColor(.black)
+        return GlobalTokens.neutralSwiftUIColor(.black)
 #endif
     }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens+UIKit.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens+UIKit.swift
@@ -11,20 +11,20 @@ public extension GlobalTokens {
 
     @objc(colorForBrandColorToken:)
     static func brandColor(_ token: BrandColorToken) -> UIColor {
-        return UIColor(GlobalTokens.brandColor(token))
+        return UIColor(GlobalTokens.brandSwiftUIColor(token))
     }
 
     // MARK: - NeutralColor
 
     @objc(colorForNeutralColorToken:)
     static func neutralColor(_ token: NeutralColorToken) -> UIColor {
-        return UIColor(GlobalTokens.neutralColor(token))
+        return UIColor(GlobalTokens.neutralSwiftUIColor(token))
     }
 
     // MARK: - SharedColor
 
     @objc(colorForSharedColorSet:token:)
     static func sharedColor(_ sharedColor: SharedColorSet, _ token: SharedColorToken) -> UIColor {
-        return UIColor(GlobalTokens.sharedColor(sharedColor, token))
+        return UIColor(GlobalTokens.sharedSwiftUIColor(sharedColor, token))
     }
 }

--- a/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
+++ b/ios/FluentUI/Core/Theme/Tokens/GlobalTokens.swift
@@ -42,7 +42,7 @@ public class GlobalTokens: NSObject {
         case gradientTertiaryDark
     }
 
-    public static func brandColor(_ token: BrandColorToken) -> Color {
+    public static func brandSwiftUIColor(_ token: BrandColorToken) -> Color {
         switch token {
         case .comm10:
             return Color(hexValue: 0x061724)
@@ -147,7 +147,7 @@ public class GlobalTokens: NSObject {
         case grey98
         case white
     }
-    public static func neutralColor(_ token: NeutralColorToken) -> Color {
+    public static func neutralSwiftUIColor(_ token: NeutralColorToken) -> Color {
         switch token {
         case .black:
             return Color(hexValue: 0x000000)
@@ -325,7 +325,7 @@ public class GlobalTokens: NSObject {
         case tint60
     }
 
-    public static func sharedColor(_ sharedColor: SharedColorSet, _ token: SharedColorToken) -> Color {
+    public static func sharedSwiftUIColor(_ sharedColor: SharedColorSet, _ token: SharedColorToken) -> Color {
         switch sharedColor {
         case .anchor:
             switch token {

--- a/ios/FluentUI/Notification/NotificationTokenSet.swift
+++ b/ios/FluentUI/Notification/NotificationTokenSet.swift
@@ -112,17 +112,17 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.color(.brandBackgroundTint)
+                        return theme.swiftUIColor(.brandBackgroundTint)
                     case .neutralToast:
-                        return theme.color(.background4)
+                        return theme.swiftUIColor(.background4)
                     case .primaryOutlineBar:
-                        return theme.color(.background1)
+                        return theme.swiftUIColor(.background1)
                     case .neutralBar:
-                        return theme.color(.background5)
+                        return theme.swiftUIColor(.background5)
                     case .dangerToast:
-                        return theme.color(.dangerBackground1)
+                        return theme.swiftUIColor(.dangerBackground1)
                     case .warningToast:
-                        return theme.color(.warningBackground1)
+                        return theme.swiftUIColor(.warningBackground1)
                     }
                 }
 
@@ -131,16 +131,16 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.color(.brandForegroundTint)
+                        return theme.swiftUIColor(.brandForegroundTint)
                     case .neutralToast,
                             .neutralBar:
-                        return theme.color(.foreground2)
+                        return theme.swiftUIColor(.foreground2)
                     case .primaryOutlineBar:
-                        return theme.color(.brandForeground1)
+                        return theme.swiftUIColor(.brandForeground1)
                     case .dangerToast:
-                        return theme.color(.dangerForeground1)
+                        return theme.swiftUIColor(.dangerForeground1)
                     case .warningToast:
-                        return theme.color(.warningForeground1)
+                        return theme.swiftUIColor(.warningForeground1)
                     }
                 }
 
@@ -149,16 +149,16 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     switch style() {
                     case .primaryToast,
                             .primaryBar:
-                        return theme.color(.brandForegroundTint)
+                        return theme.swiftUIColor(.brandForegroundTint)
                     case .neutralToast,
                             .neutralBar:
-                        return theme.color(.foreground2)
+                        return theme.swiftUIColor(.foreground2)
                     case .primaryOutlineBar:
-                        return theme.color(.brandForeground1)
+                        return theme.swiftUIColor(.brandForeground1)
                     case .dangerToast:
-                        return theme.color(.dangerForeground1)
+                        return theme.swiftUIColor(.dangerForeground1)
                     case .warningToast:
-                        return theme.color(.warningForeground1)
+                        return theme.swiftUIColor(.warningForeground1)
                     }
                 }
 
@@ -197,7 +197,7 @@ public class NotificationTokenSet: ControlTokenSet<NotificationTokenSet.Tokens> 
                     case .primaryToast, .neutralToast, .primaryBar, .neutralBar, .dangerToast, .warningToast:
                         return .clear
                     case .primaryOutlineBar:
-                        return theme.color(.stroke2)
+                        return theme.swiftUIColor(.stroke2)
                     }
                 }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

PR #2014 introduced a conflicting set of APIs for color, with the hope that most callers Swift callers would auto-resolve to the correct one. We've gotten customer feedback that this is not the case, so to unblock in the short term we'll be renaming the SwiftUI API. Longer-term, we'll come up with better names for both, but this should get folks unblocked quickly.

### Binary change

n/a, only a method name change

### Verification

Build and basic run of demo app.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2025)