### PR TITLE
Not show Profile button when avatarOverrideStyle is set

### DIFF
--- a/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
+++ b/ios/FluentUI/Navigation/Views/AvatarTitleView.swift
@@ -315,7 +315,7 @@ class AvatarTitleView: UIView, TokenizedControlInternal, TwoLineTitleViewDelegat
     // MARK: - Content Update Methods
 
     private func updateProfileButtonVisibility() {
-        showsProfileButton = titleStyle.usesLeadingAlignment && !hasLeftBarButtonItems && (personaData != nil || avatarOverrideStyle != nil)
+        showsProfileButton = titleStyle.usesLeadingAlignment && !hasLeftBarButtonItems && personaData != nil
     }
 
     private func updateTitleContainerView() {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

If we have set avatarOverrideStyle + using iPad size class, we end up having two avatars, one in the side bar and another in the navigation bar. The avatarOverrideStyle is used to override the style, it should not dictate if we show/hide the Profile button.

### Verification

Locally tested:
- No duplicate avatar showing up if we have a side bar + avatarOverrideStyle
- The empty avatar and profile avatar are displayed correctly (with and without side bar)

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)