### PR TITLE
Fix color type mismatch on visionOS

### DIFF
--- a/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
@@ -14,7 +14,7 @@ extension FluentTheme {
         // need to provide multiple values (e.g. light + dark, elevated, etc).
         switch token {
         case .foreground1:
-            visionColorDark = GlobalTokens.neutralColor(.white)
+            visionColorDark = GlobalTokens.neutralSwiftUIColor(.white)
         case .foreground2:
             visionColorDark = .white
         case .foreground3:
@@ -46,7 +46,7 @@ extension FluentTheme {
         case .stroke2:
             visionColorDark = .white.opacity(0.5)
         case .dangerForeground2:
-            visionColorDark = GlobalTokens.sharedColor(.red, .primary)
+            visionColorDark = GlobalTokens.sharedSwiftUIColor(.red, .primary)
 
         default:
             // Return the standard iOS color by default.

--- a/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
+++ b/ios/FluentUI/Core/Theme/FluentTheme+visionOS.swift
@@ -14,7 +14,7 @@ extension FluentTheme {
         // need to provide multiple values (e.g. light + dark, elevated, etc).
         switch token {
         case .foreground1:
-            visionColorDark = GlobalTokens.neutralSwiftUIColor(.white)
+            visionColorDark = .white
         case .foreground2:
             visionColorDark = .white
         case .foreground3:


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

PR #2025 renamed some color token APIs which are returning SwiftUI `Color` types instead of `UIColor`. There's one leftover visionOS file which also needs to transition to the new naming, otherwise we get a type mismatch (the original token API returning `UIColor` when we need SwiftUI `Color`).

### Binary change

n/a

### Verification

Fluent builds for visionOS again! Sanity pass through the demo app shows that color make sense.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2028)