### PR TITLE
Fix crash with #available and .environment on visionOS

### DIFF
--- a/ios/FluentUI/List/FluentList.swift
+++ b/ios/FluentUI/List/FluentList.swift
@@ -96,12 +96,20 @@ extension View {
     ///   - minHeaderHeight: The minimum header height for sections in the list
     /// - Returns: A view that has list section spacing applied if iOS 17 is available.
     func listStyling_iOS17() -> some View {
+#if os(visionOS)
+        // On visionOS, using #available and .environment crashes.
+        // As a workaround, move this to a separate ifdef
+        return self
+            .listSectionSpacing(GlobalTokens.spacing(.size160))
+            .environment(\.defaultMinListHeaderHeight, GlobalTokens.spacing(.size320))
+#else
         if #available(iOS 17, *) {
             return self
-                .listSectionSpacing(16)
-                .environment(\.defaultMinListHeaderHeight, 32)
+                .listSectionSpacing(GlobalTokens.spacing(.size160))
+                .environment(\.defaultMinListHeaderHeight, GlobalTokens.spacing(.size320))
         } else {
             return self
         }
+#endif // os(visionOS)
     }
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

There seems to be an apple bug where using `#available` with `.environment` causes a crash on visionOS. Potentially related to #1984. As a workaround, move the modifier to its own ifdef.

While I'm here, replace magic numbers with global tokens.

### Binary change

Total increase: 1,240 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,099,792 bytes | 31,101,032 bytes | ⚠️ 1,240 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| FluentList.o | 72,352 bytes | 73,400 bytes | ⚠️ 1,048 bytes |
| __.SYMDEF | 4,811,616 bytes | 4,811,808 bytes | ⚠️ 192 bytes |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2030)