### PR TITLE
[TableViewCell] fix height calculation based on font size

### DIFF
--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -351,7 +351,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             subtitleHeight: labelSize(text: subtitle,
                                       attributedText: attributedSubtitle,
                                       isAttributedTextSet: isAttributedSubtitleSet,
-                                      font: subtitleFont ?? (layoutType == .twoLines ? tokenSet[.subtitleTwoLinesFont].uiFont : tokenSet[.subtitleThreeLinesFont].uiFont),
+                                      font: subtitleFont ?? (layoutType == .threeLines ? tokenSet[.subtitleThreeLinesFont].uiFont : tokenSet[.subtitleTwoLinesFont].uiFont),
                                       numberOfLines: subtitleNumberOfLines,
                                       textAreaWidth: textAreaWidth,
                                       leadingAccessoryView: subtitleLeadingAccessoryView,
@@ -1232,7 +1232,7 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             titleLabel.font = tokenSet[.titleFont].uiFont
         }
         if !isAttributedSubtitleSet {
-            subtitleLabel.font = (layoutType == .twoLines ? tokenSet[.subtitleTwoLinesFont].uiFont : tokenSet[.subtitleThreeLinesFont].uiFont)
+            subtitleLabel.font = (layoutType == .threeLines ? tokenSet[.subtitleThreeLinesFont].uiFont : tokenSet[.subtitleTwoLinesFont].uiFont)
         }
         if !isAttributedFooterSet {
             footerLabel.font = tokenSet[.footerFont].uiFont


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

When calculating the height of a table view cell, we are incorrectly accounting for which subtitle font to use. This means we are calculating using a font that is bigger than what is expected, meaning our table view cell is rendered larger than needed. 

The fix is to ensure we only use the 3 line font if we have 3 lines, otherwise default back to the two line font, which is also the font for one line.

### Binary change

N/A

### Verification

| Before  rendered height: 66, calculated height: 64                                     | After    rendered height: 64, calculated height: 64                                        |
|----------------------------------------------|--------------------------------------------|
|![image](https://github.com/microsoft/fluentui-apple/assets/21343215/0c75cf22-0a6f-493f-938e-afa8f4210f84)|![image](https://github.com/microsoft/fluentui-apple/assets/21343215/2279f30f-69c8-4ef8-b656-154509cce2d1)|



saw the height of each cell in the view debugger and compared the value. All of these scenarios it was still as expected

regular text size

|scenario | Before                                       | After                                      |
| --- |----------------------------------------------|--------------------------------------------|
| single line cell  48 height |![Screenshot 2024-05-22 at 11 45 53 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/1d5ac448-c574-4380-82cd-512df94199a8)|![Screenshot 2024-05-22 at 11 39 22 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/eb839191-6b25-4c37-95c2-195f151e23e8)|
| double line cell  64 height| ![Screenshot 2024-05-22 at 11 46 01 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/9172da45-3f03-4ec4-a5d4-34a0ce9bce56)|![Screenshot 2024-05-22 at 11 39 31 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/be283a45-f5a3-4a6f-9548-c5e85ee4427a)|
| triple line cell 84 height| ![Screenshot 2024-05-22 at 11 46 19 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/689148e9-5e08-4da6-a824-172355d8b5ec) | ![Screenshot 2024-05-22 at 11 40 02 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/5b033211-76fb-46fa-be3c-f367f6019ce2) |
| cell without custom view 64 height | ![Screenshot 2024-05-22 at 11 46 45 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/57274b3a-ab60-49c8-908e-613ec28b9e44) |![Screenshot 2024-05-22 at 11 40 23 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/d7ed56d0-133f-4940-b527-c5ca4893888f)|
| cell with custom accessory view 48 height | ![Screenshot 2024-05-22 at 11 46 51 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/6111e10b-eb41-4914-bfdf-9bd6b30135a1) |![Screenshot 2024-05-22 at 11 40 32 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/7eae544a-555e-4008-858d-f14a609106af)|
| cell with text truncation 84 height |![Screenshot 2024-05-22 at 11 47 00 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/cdbd4180-b65a-4a96-9129-7f4d165657b1)|![Screenshot 2024-05-22 at 11 40 40 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/2e47ba9a-aa69-4634-95ba-054e3c1d3f78)|
| cell with text wrapping  84 height|![Screenshot 2024-05-22 at 11 47 08 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/1048e8d8-99b5-46ff-b562-4df332eb8bb7)|![Screenshot 2024-05-22 at 11 41 11 AM](https://github.com/microsoft/fluentui-apple/assets/21343215/659966ec-f317-4b46-a2be-95fa3c960853)|


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2031)