### PR TITLE
Expose Tab Bar Token Pad Height to Consumers

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -185,6 +185,8 @@ open class TabBarView: UIView, TokenizedControlInternal {
         }
     }
 
+    @objc public static let tabBarPadHeight: CGFloat = TabBarTokenSet.padHeight
+
     public typealias TokenSetKeyType = TabBarTokenSet.Tokens
     public var tokenSet: TabBarTokenSet = .init()
 

--- a/ios/FluentUI/Tab Bar/TabBarView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarView.swift
@@ -146,6 +146,8 @@ open class TabBarView: UIView, TokenizedControlInternal {
         return nil
     }
 
+    @objc public static let tabBarPadHeight: CGFloat = TabBarTokenSet.padHeight
+
     private struct Constants {
         static let maxTabCount: Int = 5
     }
@@ -184,8 +186,6 @@ open class TabBarView: UIView, TokenizedControlInternal {
             delegate?.tabBarView?(self, didSelect: item)
         }
     }
-
-    @objc public static let tabBarPadHeight: CGFloat = TabBarTokenSet.padHeight
 
     public typealias TokenSetKeyType = TabBarTokenSet.Tokens
     public var tokenSet: TabBarTokenSet = .init()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
Exposed a public let of `TabBarTokenSet.padHeight` for consumers to be able to use if they need to access the iPad height constant for the tab bar view.

### Binary change
Total increase: 2,048 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,258,848 bytes | 31,260,896 bytes | ⚠️ 2,048 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TabBarView.o | 140,080 bytes | 141,816 bytes | ⚠️ 1,736 bytes |
| __.SYMDEF | 4,881,488 bytes | 4,881,800 bytes | ⚠️ 312 bytes |
</details>

### Verification
Was able to access the value from an external objective c file.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2032)