### PR TITLE
Fix sizing of FluentNotification

### DIFF
--- a/ios/FluentUI/Notification/FluentNotification.swift
+++ b/ios/FluentUI/Notification/FluentNotification.swift
@@ -147,7 +147,7 @@ public struct FluentNotification: View, TokenizedControlView {
             if state.style.isToast && hasSecondTextRow {
                 if let attributedTitle = state.attributedTitle {
                     Text(AttributedString(attributedTitle))
-                        .frame(idealWidth: attributedTitleSize.width)
+                        .fixedSize(horizontal: false, vertical: true)
                 } else if let title = state.title {
                     Text(title)
                         .font(.init(tokenSet[.boldTextFont].uiFont))
@@ -159,7 +159,7 @@ public struct FluentNotification: View, TokenizedControlView {
         var messageLabel: some View {
             if let attributedMessage = state.attributedMessage {
                 Text(AttributedString(attributedMessage))
-                    .frame(idealWidth: attributedMessageSize.width)
+                    .fixedSize(horizontal: false, vertical: true)
             } else if let message = state.message {
                 Text(message)
                     .font(.init(tokenSet[.regularTextFont].uiFont))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Fluent Notification requires a fixed vertical size, otherwise it may attempt to take too much space when placed in vertical stacks.

### Binary change

n/a - single line layout diff

### Verification

![notification](https://github.com/microsoft/fluentui-apple/assets/4934719/09cb8f6c-b52f-4a38-86da-03f6871d1f39)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2036)