### PR TITLE
remove forcing the app nav bar to be all translucent

### DIFF
--- a/ios/FluentUI/Core/FluentUIFramework.swift
+++ b/ios/FluentUI/Core/FluentUIFramework.swift
@@ -85,8 +85,6 @@ public class FluentUIFramework: NSObject {
     }
 
     static func initializeUINavigationBarAppearance(_ navigationBar: UINavigationBar, traits: UITraitCollection? = nil, navigationBarStyle: NavigationBarStyle = .normal, fluentTheme: FluentTheme? = nil) {
-        navigationBar.isTranslucent = false
-
         let standardAppearance = navigationBar.standardAppearance
 
         let fluentTheme = fluentTheme ?? FluentTheme.shared


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Anytime client apps tries to initialize FluentUIFramework with the app branding color, Fluent takes the opportunity to set up overall UINavigationBar appearance to update its own fluent 2 colors for background, tinting etc.
By forcing isTranslucent = false in all of UINavgationBar.appearance(), it makes it harder for client apps when we do want to have transparent navigation bar in certain scenarios.

The changes remove this line, but from my test, the overall navigationbar color seems to be the same because we are overriding the standardappearance background value.

### Binary change

n/a

### Verification

Double check fluentui custom naviation bar in light and dark mode.
Checked datetimepicker chrome color

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2039)