### PR TITLE
Reapply #1929 and fix issue where header title uses incorrect font

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -126,7 +126,7 @@ extension TableViewHeaderFooterViewDemoController {
             if section.footerLinkText.isEmpty {
                 footer?.setup(style: .footer, title: section.footerText)
             } else {
-                let title = NSMutableAttributedString(string: section.footerText)
+                let title = NSMutableAttributedString(string: section.footerText, attributes: [NSAttributedString.Key.foregroundColor: footer?.tokenSet[.textColor].uiColor ?? .white])
                 let range = (title.string as NSString).range(of: section.footerLinkText)
                 if range.location != -1 {
                     title.addAttribute(.link, value: "https://github.com/microsoft/fluentui-apple", range: range)

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -320,17 +320,12 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
                            accessoryButtonTitle: String = "",
                            accessoryView: UIView? = nil,
                            leadingView: UIView? = nil) {
-        attributedTitleFont = nil
-        attributedTitleColor = nil
-
-        if let attributedTitle = attributedTitle {
+        if let attributedTitle {
+            self.attributedTitle = attributedTitle
             titleView.attributedText = attributedTitle
             titleView.isSelectable = true
-
-            let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
-            attributedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
-            attributedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
         } else {
+            self.attributedTitle = nil
             titleView.attributedText = NSAttributedString(string: " ") // to clear attributes
             titleView.text = title
             titleView.isSelectable = false
@@ -458,8 +453,10 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     private func updateTitleViewFont() {
         if let window = window {
-            let titleFont = attributedTitleFont ?? tokenSet[.textFont].uiFont
-            titleView.font = titleFont
+            let titleFont = tokenSet[.textFont].uiFont
+            if !isUsingAttributedTitle {
+                titleView.font = titleFont
+            }
 
             // offset text container to center its content
 #if os(iOS)
@@ -474,8 +471,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     }
 
     private func updateTitleAndBackgroundColors() {
-        titleView.textColor = attributedTitleColor ?? tokenSet[.textColor].uiColor
-
         if tableViewCellStyle == .grouped {
             backgroundView?.backgroundColor = tokenSet[.backgroundColorGrouped].uiColor
         } else if tableViewCellStyle == .plain {
@@ -484,7 +479,10 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             backgroundView?.backgroundColor = .clear
         }
 
-        titleView.font = attributedTitleFont ?? tokenSet[.textFont].uiFont
+        if !isUsingAttributedTitle {
+            titleView.textColor = tokenSet[.textColor].uiColor
+            titleView.font = tokenSet[.textFont].uiFont
+        }
         titleView.linkColor = tokenSet[.linkTextColor].uiColor
     }
 
@@ -524,8 +522,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         onHeaderViewTapped?()
     }
 
-    private var attributedTitleFont: UIFont?
-    private var attributedTitleColor: UIColor?
+    private var attributedTitle: NSAttributedString? {
+        didSet {
+            isUsingAttributedTitle = attributedTitle != nil
+        }
+    }
+
+    private var isUsingAttributedTitle: Bool = false
 }
 
 // MARK: - TableViewHeaderFooterView: UITextViewDelegate

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -346,8 +346,12 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
         accessoryButton = !accessoryButtonTitle.isEmpty ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
 
+        /// `accessoryButton` and `accessoryView` occupy the same space at the trailing end of the view. If both are provided, the `accessoryView` will be given priority
+        if accessoryView != nil {
+            self.accessoryView = accessoryView
+        }
+
         self.leadingView = leadingView
-        self.accessoryView = accessoryView
 
         self.style = style
 

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -244,7 +244,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - title: The title string.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     @objc open func setup(style: Style, title: String, accessoryButtonTitle: String = "") {
-        setup(style: style, title: title, accessoryButtonTitle: accessoryButtonTitle, leadingView: nil)
+        setupBase(style: style, title: title, accessoryButtonTitle: accessoryButtonTitle)
     }
 
     /// - Parameters:
@@ -253,11 +253,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - accessoryButtonTitle: Optional accessory button title string.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     @objc open func setup(style: Style, title: String, accessoryButtonTitle: String = "", leadingView: UIView? = nil) {
-        titleView.attributedText = NSAttributedString(string: " ") // to clear attributes
-        titleView.text = title
-        titleView.isSelectable = false
-
-        setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
+        setupBase(style: style, title: title, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
     }
 
     /// - Parameters:
@@ -265,23 +261,25 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - attributedTitle: Title as an NSAttributedString for additional attributes.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     @objc open func setup(style: Style, attributedTitle: NSAttributedString, accessoryButtonTitle: String = "") {
-        setup(style: style, attributedTitle: attributedTitle, accessoryButtonTitle: accessoryButtonTitle, leadingView: nil)
+        setupBase(style: style, attributedTitle: attributedTitle, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
     }
-
+    
     /// - Parameters:
     ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
     ///   - attributedTitle: Title as an NSAttributedString for additional attributes.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     @objc open func setup(style: Style, attributedTitle: NSAttributedString, accessoryButtonTitle: String = "", leadingView: UIView? = nil) {
-        titleView.attributedText = attributedTitle
-        titleView.isSelectable = true
-
-        let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
-        attributedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
-        attributedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
-
-        setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
+//        titleView.attributedText = attributedTitle
+//        titleView.isSelectable = true
+//
+//        setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
+//
+//        let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
+//        attributedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
+//        attributedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
+        
+        setupBase(style: style, attributedTitle: attributedTitle, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
     }
 
     /// - Parameters:
@@ -289,7 +287,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - title: The title string.
     ///   - accessoryView: The optional custom accessory view in the trailing edge of this view.
     @objc open func setup(style: Style, title: String, accessoryView: UIView) {
-        setup(style: style, title: title, accessoryView: accessoryView, leadingView: nil)
+        setupBase(style: style, title: title, accessoryView: accessoryView)
     }
 
     /// - Parameters:
@@ -300,30 +298,50 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     /// If `accessoryView` is set, the accessory button (if any) will be replaced by this custom view. Clients are responsible
     /// for the appearance and behavior of both the `accessoryView` and `leadingView`, including event handling and accessibility.
     @objc open func setup(style: Style, title: String, accessoryView: UIView, leadingView: UIView? = nil) {
-        setup(style: style, title: title, accessoryButtonTitle: "")
-        self.accessoryView = accessoryView
-        self.leadingView = leadingView
+        setupBase(style: style, title: title, accessoryView: accessoryView, leadingView: leadingView)
     }
 
     /// - Parameters:
     ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     @objc open func setup(style: Style, accessoryButtonTitle: String) {
-        setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: nil)
+        setupBase(style: style, accessoryButtonTitle: accessoryButtonTitle)
     }
 
     /// - Parameters:
     ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
     ///   - title: The title string.
     @objc open func setup(style: Style, title: String) {
-        setup(style: style, title: title, accessoryButtonTitle: "")
+        setupBase(style: style, title: title)
     }
 
+    /// This is the base setup method. All other setup methods call this one at some point in their implementation.
     /// - Parameters:
     ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
-    private func setup(style: Style, accessoryButtonTitle: String, leadingView: UIView? = nil) {
+    private func setupBase(style: Style,
+                           title: String? = nil,
+                           attributedTitle: NSAttributedString? = nil,
+                           accessoryButtonTitle: String = "",
+                           accessoryView: UIView? = nil,
+                           leadingView: UIView? = nil) {
+        attributedTitleFont = nil
+        attributedTitleColor = nil
+
+        if let attributedTitle = attributedTitle {
+            titleView.attributedText = attributedTitle
+            titleView.isSelectable = true
+
+            let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
+            attributedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
+            attributedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
+        } else {
+            titleView.attributedText = NSAttributedString(string: " ") // to clear attributes
+            titleView.text = title
+            titleView.isSelectable = false
+        }
+
         updateTitleViewFont()
         switch style {
         case .header, .headerPrimary:
@@ -333,7 +351,9 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         }
 
         accessoryButton = !accessoryButtonTitle.isEmpty ? createAccessoryButton(withTitle: accessoryButtonTitle) : nil
+
         self.leadingView = leadingView
+        self.accessoryView = accessoryView
 
         self.style = style
 
@@ -504,6 +524,11 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     @objc private func handleHeaderViewTapped() {
         onHeaderViewTapped?()
+    }
+
+    private func cleanupAttributedProperties() {
+        attributedTitleFont = nil
+        attributedTitleColor = nil
     }
 
     private var attributedTitleFont: UIFont?

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -253,8 +253,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - accessoryButtonTitle: Optional accessory button title string.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     @objc open func setup(style: Style, title: String, accessoryButtonTitle: String = "", leadingView: UIView? = nil) {
-        resolvedTitleFont = tokenSet[.textFont].uiFont
-        resolvedTitleColor = tokenSet[.textColor].uiColor
         titleView.attributedText = NSAttributedString(string: " ") // to clear attributes
         titleView.text = title
         titleView.isSelectable = false
@@ -280,8 +278,8 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         titleView.isSelectable = true
 
         let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
-        resolvedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
-        resolvedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
+        attributedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
+        attributedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
 
         setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
     }
@@ -442,23 +440,23 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     private func updateTitleViewFont() {
         if let window = window {
-            titleView.font = resolvedTitleFont
-            if let resolvedTitleFont = resolvedTitleFont {
-                // offset text container to center its content
+            let titleFont = attributedTitleFont ?? tokenSet[.textFont].uiFont
+            titleView.font = titleFont
+
+            // offset text container to center its content
 #if os(iOS)
-                let scale = window.rootViewController?.view.contentScaleFactor ?? window.screen.scale
+            let scale = window.rootViewController?.view.contentScaleFactor ?? window.screen.scale
 #elseif os(visionOS)
-                let scale: CGFloat = 2.0
+            let scale: CGFloat = 2.0
 #endif // os(visionOS)
-                let offset = (floor((abs(resolvedTitleFont.leading) / 2) * scale) / scale) / 2
-                titleView.textContainerInset.top = offset
-                titleView.textContainerInset.bottom = -offset
-            }
+            let offset = (floor((abs(titleFont.leading) / 2) * scale) / scale) / 2
+            titleView.textContainerInset.top = offset
+            titleView.textContainerInset.bottom = -offset
         }
     }
 
     private func updateTitleAndBackgroundColors() {
-        titleView.textColor = resolvedTitleColor
+        titleView.textColor = attributedTitleColor ?? tokenSet[.textColor].uiColor
 
         if tableViewCellStyle == .grouped {
             backgroundView?.backgroundColor = tokenSet[.backgroundColorGrouped].uiColor
@@ -468,7 +466,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             backgroundView?.backgroundColor = .clear
         }
 
-        titleView.font = resolvedTitleFont
+        titleView.font = attributedTitleFont ?? tokenSet[.textFont].uiFont
         titleView.linkColor = tokenSet[.linkTextColor].uiColor
     }
 
@@ -508,8 +506,8 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         onHeaderViewTapped?()
     }
 
-    private var resolvedTitleFont: UIFont?
-    private var resolvedTitleColor: UIColor?
+    private var attributedTitleFont: UIFont?
+    private var attributedTitleColor: UIColor?
 }
 
 // MARK: - TableViewHeaderFooterView: UITextViewDelegate

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -261,24 +261,15 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     ///   - attributedTitle: Title as an NSAttributedString for additional attributes.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     @objc open func setup(style: Style, attributedTitle: NSAttributedString, accessoryButtonTitle: String = "") {
-        setupBase(style: style, attributedTitle: attributedTitle, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
+        setupBase(style: style, attributedTitle: attributedTitle, accessoryButtonTitle: accessoryButtonTitle)
     }
-    
+
     /// - Parameters:
     ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
     ///   - attributedTitle: Title as an NSAttributedString for additional attributes.
     ///   - accessoryButtonTitle: Optional accessory button title string.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     @objc open func setup(style: Style, attributedTitle: NSAttributedString, accessoryButtonTitle: String = "", leadingView: UIView? = nil) {
-//        titleView.attributedText = attributedTitle
-//        titleView.isSelectable = true
-//
-//        setup(style: style, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
-//
-//        let attributes = attributedTitle.attributes(at: 0, effectiveRange: nil)
-//        attributedTitleFont = attributes[NSAttributedString.Key.font] as? UIFont ?? tokenSet[.textFont].uiFont
-//        attributedTitleColor = attributes[NSAttributedString.Key.foregroundColor] as? UIColor ?? tokenSet[.textColor].uiColor
-        
         setupBase(style: style, attributedTitle: attributedTitle, accessoryButtonTitle: accessoryButtonTitle, leadingView: leadingView)
     }
 
@@ -315,10 +306,13 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         setupBase(style: style, title: title)
     }
 
-    /// This is the base setup method. All other setup methods call this one at some point in their implementation.
+    /// This is the base setup method. All other setup methods call this method with their parameters.
     /// - Parameters:
     ///   - style: The `TableViewHeaderFooterView.Style` used to set up the view.
+    ///   - title: The title string
+    ///   - attributedTitle: Title as an NSAttributedString for additional attributes.
     ///   - accessoryButtonTitle: Optional accessory button title string.
+    ///   - accessoryView: The optional custom accessory view in the trailing edge of this view.
     ///   - leadingView: An optional custom view that appears near the leading edge of the view.
     private func setupBase(style: Style,
                            title: String? = nil,
@@ -524,11 +518,6 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 
     @objc private func handleHeaderViewTapped() {
         onHeaderViewTapped?()
-    }
-
-    private func cleanupAttributedProperties() {
-        attributedTitleFont = nil
-        attributedTitleColor = nil
     }
 
     private var attributedTitleFont: UIFont?


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

**Issue:**
#1929 ensured that the `TableViewHeaderFooterView` does not override any font or color provided as part of the AttributedString. However, an issue was observed where headers that should be `headerPrimary` are showing up as `header` and vice versa. The change was reverted in #1945.

We were also seeing an issue where the title font would change after scroll where the title goes off screen.

This change reapplies #1929 and fixes the issue where headers that should be `headerPrimary` are showing up as `header` and vice versa, as well as the issue where the title font changes after it goes off screen.

**Root Cause:**
1. In #1929, if no attributed string was provided, the resolved `resolvedTitleFont` and `resolvedTitleColor` were only set once at inside `setup(...)`. This call occurs before the `tokenSet` is updated with overrides and the `resolvedTitleFont` would be set to the wrong font as a result. 
2. The setup method wasn't correctly "recycling" the views when `dequeueReusableHeaderFooterView` was called, so `resolvedTitleFont` and `resolvedTitleColor` properties were still set in some cases and the values would be used when rendering the header for a different header with a different font.

**Fix:**
- Change `resolvedTitleFont` and `resolvedTitleColor` to `attributedTitleFont` and `attributedTitleColor` as they'll only be used to hold values for the attributed string.
- Replace usages of `resolvedTitleFont` and `resolvedTitleColor` as an r-value with `attributedTitleFont ?? tokenSet[.textFont].uiFont` and `attributedTitleColor ?? tokenSet[.textColor].uiColor`.
- Cleanup the setup methods so they call `setupBase(...)` with their parameters. `setupBase` handles the cleanup and ensures all the properties are set in the same order for call cases.

### Binary change

Total increase: 19,968 bytes
Total decrease: -808 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,874,424 bytes | 30,893,584 bytes | ⚠️ 19,160 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterView.o | 277,496 bytes | 291,664 bytes | ⚠️ 14,168 bytes |
| __.SYMDEF | 4,751,744 bytes | 4,755,896 bytes | ⚠️ 4,152 bytes |
| FocusRingView.o | 832,280 bytes | 833,752 bytes | ⚠️ 1,472 bytes |
| PopupMenuSectionHeaderView.o | 24,504 bytes | 24,680 bytes | ⚠️ 176 bytes |
| PopupMenuController.o | 376,616 bytes | 375,808 bytes | 🎉 -808 bytes |
</details>

### Verification

- Validated that the header titles show in the correct font.
  - Verified that the font displayed matches the style listed in `TableViewHeaderFooterSampleData`
  - Verified that the font displayed matches the screenshots in the `After` category of this #1945

<details>
<summary>Visual Verification</summary>

**Before**

https://github.com/microsoft/fluentui-apple/assets/10938746/1668c82a-9199-45fe-8703-698221ae8dea

**After**

https://github.com/microsoft/fluentui-apple/assets/10938746/9f301eb3-c114-4215-aea5-748510ce2e84

</details>

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2040)