### PR TITLE
Calculate Bottom Commanding header height instead of using constant

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -46,7 +46,8 @@ class BottomCommandingDemoController: DemoController {
 
     private lazy var heroItems: [CommandingItem] = {
         return Array(1...25).map {
-            let item = CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
+            let title = ($0 == 4) ? "Two line item" : "Item"
+            let item = CommandingItem(title: title + String($0), image: homeImage, action: commandAction)
             item.selectedImage = homeSelectedImage
             item.isOn = ($0 % 3 == 1)
             item.isEnabled = ($0 % 2 == 1)

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -402,7 +402,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         headerView.addSubview(heroCommandStack)
 
         let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
-        sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
         sheetController.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth
@@ -534,6 +533,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         } else {
             tableView.tableHeaderView = nil
         }
+        updateHeaderHeight()
     }
 
     private func reloadHeroCommandOverflowStack() {
@@ -561,6 +561,11 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         if isInSheetMode {
             view.setNeedsLayout()
         }
+    }
+
+    private func updateHeaderHeight() {
+        headerHeight = heroCommandStack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + BottomSheetController.resizingHandleHeight
+        bottomSheetController?.headerContentHeight = headerHeight
     }
 
     private func updateAppearance() {
@@ -621,6 +626,8 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
+
+    private var headerHeight: CGFloat = 0
 
     private var sheetHeaderSeparator: Separator?
 
@@ -912,7 +919,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
     }
 
-    /// Recalculates header top margin constraint and updates the `collapsedContentHeight` and `isExpandable` properties of the sheet controller.
+    /// Recalculates header top margin constraint and updates the `collapsedContentHeight`, `isExpandable`, and `headerContentHeight` properties of the sheet controller.
     private func updateSheetHeaderSizingParameters() {
         guard let bottomSheetController = bottomSheetController else {
             return
@@ -922,8 +929,11 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         let maxHeroItemHeight = heroCommandStack.arrangedSubviews.map { $0.intrinsicContentSize.height }.max() ?? Constants.defaultHeroButtonHeight
         let headerHeightWithoutBottomWhitespace = BottomCommandingTokenSet.handleHeaderHeight + maxHeroItemHeight
 
+        // Update the header height in case a title change has caused a change
+        updateHeaderHeight()
+
         // How much more whitespace is required at the bottom of the sheet header
-        let requiredBottomWhitespace = max(0, Constants.BottomSheet.headerHeight - headerHeightWithoutBottomWhitespace)
+        let requiredBottomWhitespace = max(0, headerHeight - headerHeightWithoutBottomWhitespace)
 
         // The safe area inset can fulfill some or all of our bottom whitespace requirement.
         // This is how much more we need, taking the inset into account.
@@ -1117,10 +1127,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
 
             static let moreButtonIcon: UIImage? = UIImage.staticImageNamed("more-24x24")
             static let moreButtonTitle: String = "CommandingBottomBar.More".localized
-        }
-
-        struct BottomSheet {
-            static let headerHeight: CGFloat = 66
         }
     }
 }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -919,7 +919,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
     }
 
-    /// Recalculates header top margin constraint and updates the `collapsedContentHeight`, `isExpandable`, and `headerContentHeight` properties of the sheet controller.
+    /// Recalculates header top margin constraint and updates the `collapsedContentHeight` and `isExpandable` properties of the sheet controller.
     private func updateSheetHeaderSizingParameters() {
         guard let bottomSheetController = bottomSheetController else {
             return

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -533,7 +533,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         } else {
             tableView.tableHeaderView = nil
         }
-        updateHeaderHeight()
+        calculateHeaderHeight()
     }
 
     private func reloadHeroCommandOverflowStack() {
@@ -563,9 +563,11 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         }
     }
 
-    private func updateHeaderHeight() {
-        headerHeight = heroCommandStack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + BottomSheetController.resizingHandleHeight
+    @discardableResult
+    private func calculateHeaderHeight() -> CGFloat {
+        let headerHeight = heroCommandStack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + BottomSheetController.resizingHandleHeight
         bottomSheetController?.headerContentHeight = headerHeight
+        return headerHeight
     }
 
     private func updateAppearance() {
@@ -626,8 +628,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
-
-    private var headerHeight: CGFloat = 0
 
     private var sheetHeaderSeparator: Separator?
 
@@ -929,11 +929,8 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         let maxHeroItemHeight = heroCommandStack.arrangedSubviews.map { $0.intrinsicContentSize.height }.max() ?? Constants.defaultHeroButtonHeight
         let headerHeightWithoutBottomWhitespace = BottomCommandingTokenSet.handleHeaderHeight + maxHeroItemHeight
 
-        // Update the header height in case a title change has caused a change
-        updateHeaderHeight()
-
         // How much more whitespace is required at the bottom of the sheet header
-        let requiredBottomWhitespace = max(0, headerHeight - headerHeightWithoutBottomWhitespace)
+        let requiredBottomWhitespace = max(0, calculateHeaderHeight() - headerHeightWithoutBottomWhitespace)
 
         // The safe area inset can fulfill some or all of our bottom whitespace requirement.
         // This is how much more we need, taking the inset into account.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Currently, `BottomCommandingController`'s `headerContentHeight` is hard-coded in as a constant of 66. When the hero item's titles are one line, this is ok. However when it is multi-lined, there is not enough bottom padding. Update it so that `headerContentHeight` is calculated using `systemLayoutSizeFitting`.

### Binary change

Total increase: 6,072 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,087,872 bytes | 31,093,944 bytes | ⚠️ 6,072 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomCommandingController.o | 837,944 bytes | 840,832 bytes | ⚠️ 2,888 bytes |
| __.SYMDEF | 4,813,352 bytes | 4,815,168 bytes | ⚠️ 1,816 bytes |
| FocusRingView.o | 837,864 bytes | 839,232 bytes | ⚠️ 1,368 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/d2fdf4c7-0bf1-4099-b943-2ef567d88736) | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/06dda484-4b5f-49cb-805e-02ec6a586c9f) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2041)