### PR TITLE
Remove space after @objc

### DIFF
--- a/ios/FluentUI/Label/LabelTokenSet.swift
+++ b/ios/FluentUI/Label/LabelTokenSet.swift
@@ -7,7 +7,7 @@ import UIKit
 
 // MARK: TextColorStyle
 
-@objc (MSFTextColorStyle)
+@objc(MSFTextColorStyle)
 public enum TextColorStyle: Int, CaseIterable {
     case regular
     case secondary


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Removes a space after @objc to fix build in new Xcode/Swift tooling.

### Binary change

n/a, no code changes

### Verification

Builds and runs in new version of Xcode as well as our existing supported build.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2043)