### PR TITLE
Fix ListItem padding bug on visionOS

### DIFF
--- a/ios/FluentUI/List/ListItem.swift
+++ b/ios/FluentUI/List/ListItem.swift
@@ -127,7 +127,7 @@ public struct ListItem<LeadingContent: View,
                         }
 #if os(visionOS)
                         .buttonStyle(.bordered)
-                        .clipShape(Circle())
+                        .buttonBorderShape(.circle)
 #else
                         .buttonStyle(.plain)
 #endif


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

On visionOS, `ListItem`'s detail button, with no modifications is a capsule. I initially used `clipShape` to force it to be a circle. However, when there is padding applied around the button, using `clipShape` applies it around the frame of the original capsule button, not the updated circle one. This results in extra padding around the button.

Use `buttonBorderShape` instead, which does what we want.

### Binary change

Total increase: 0 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,095,248 bytes | 31,095,248 bytes | 🎉 0 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
</details>

### Verification

<details>
<summary>Visual Verification</summary>

|                                       |                                      |
|----------------------------------------------|--------------------------------------------|
| Before | ![before](https://github.com/microsoft/fluentui-apple/assets/55368679/f98971af-307d-4c4f-8203-e7ec83b5601a) 
| After | ![after](https://github.com/microsoft/fluentui-apple/assets/55368679/d1fbc425-15bc-4735-804c-b37e4dc16c2c) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2049)