### PR TITLE
Add a willMove method to bottom sheet delegate

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -24,7 +24,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     /// External changes to `isExpanded` or `isHidden` will not trigger this callback.
     /// - Parameters:
     ///   - bottomSheetController: The caller object.
-    ///   - expansionState: The expansion state that the sheet will moved to.
+    ///   - expansionState: The expansion state that the sheet will move to.
     ///   - interaction: The user interaction that caused the state change.
     @objc optional func bottomSheetController(_ bottomSheetController: BottomSheetController,
                                               willMoveTo expansionState: BottomSheetExpansionState,
@@ -917,7 +917,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         completeAnimationsIfNeeded()
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
-            self.delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)
+            delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)
 
             let animator = stateChangeAnimator(to: targetExpansionState,
                                                velocity: velocity,

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -21,7 +21,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 
     /// Called before a transition to a new expansion state starts.
     ///
-    /// External changes to`isExpanded` or `isHidden` will not trigger this callback.
+    /// External changes to `isExpanded` or `isHidden` will not trigger this callback.
     /// - Parameters:
     ///   - bottomSheetController: The caller object.
     ///   - expansionState: The expansion state that the sheet will moved to.

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -19,6 +19,17 @@ public protocol BottomSheetControllerDelegate: AnyObject {
                                               didMoveTo expansionState: BottomSheetExpansionState,
                                               interaction: BottomSheetInteraction)
 
+    /// Called before a transition to a new expansion state starts.
+    ///
+    /// External changes to`isExpanded` or `isHidden` will not trigger this callback.
+    /// - Parameters:
+    ///   - bottomSheetController: The caller object.
+    ///   - expansionState: The expansion state that the sheet will moved to.
+    ///   - interaction: The user interaction that caused the state change.
+    @objc optional func bottomSheetController(_ bottomSheetController: BottomSheetController,
+                                              willMoveTo expansionState: BottomSheetExpansionState,
+                                              interaction: BottomSheetInteraction)
+
     /// Called when `collapsedHeightInSafeArea` changes.
     @objc optional func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController)
 }
@@ -906,6 +917,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         completeAnimationsIfNeeded()
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
+            self.delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)
+
             let animator = stateChangeAnimator(to: targetExpansionState,
                                                velocity: velocity,
                                                interaction: interaction,


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
Add an entry point for bottom sheet consumer to be able to preform actions before the bottom sheet changes state.
Delegate method will inform consumers that a state change is about to happen.

### Binary change
Total increase: 888 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 32,274,112 bytes | 32,275,000 bytes | ⚠️ 888 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomSheetController.o | 543,560 bytes | 544,120 bytes | ⚠️ 560 bytes |
| FocusRingView.o | 847,760 bytes | 847,928 bytes | ⚠️ 168 bytes |
| BottomCommandingController.o | 865,040 bytes | 865,200 bytes | ⚠️ 160 bytes |
</details>


### Verification
Tested by changing the alpha on the bottom sheets view in the demo controller before planning to move to the expanded and the collapsed state.


### Pull request checklist

This PR has considered:
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2052)