### PR TITLE
Add a willMove method to bottom sheet delegate

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -2,12 +2,9 @@
 //  Copyright (c) Microsoft Corporation. All rights reserved.
 //  Licensed under the MIT License.
 //
-
 import UIKit
-
 @objc(MSFBottomSheetControllerDelegate)
 public protocol BottomSheetControllerDelegate: AnyObject {
-
     /// Called after a transition to a new expansion state completes.
     ///
     /// External changes to`isExpanded` or `isHidden` will not trigger this callback.
@@ -19,10 +16,20 @@ public protocol BottomSheetControllerDelegate: AnyObject {
                                               didMoveTo expansionState: BottomSheetExpansionState,
                                               interaction: BottomSheetInteraction)
 
+    /// Called before a transition to a new expansion state starts.
+    ///
+    /// External changes to `isExpanded` or `isHidden` will not trigger this callback.
+    /// - Parameters:
+    ///   - bottomSheetController: The caller object.
+    ///   - expansionState: The expansion state that the sheet will move to.
+    ///   - interaction: The user interaction that caused the state change.
+    @objc optional func bottomSheetController(_ bottomSheetController: BottomSheetController,
+                                              willMoveTo expansionState: BottomSheetExpansionState,
+                                              interaction: BottomSheetInteraction)
+
     /// Called when `collapsedHeightInSafeArea` changes.
     @objc optional func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController)
 }
-
 /// Interactions that can trigger a state change.
 @objc public enum BottomSheetInteraction: Int {
     case noUserAction // No user action, used for events not triggered by users
@@ -30,7 +37,6 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     case resizingHandleTap // Tap on the sheet resizing handle
     case dimmingViewTap // Tap on the dimming view
 }
-
 /// Defines the position the sheet is currently in
 @objc public enum BottomSheetExpansionState: Int {
     case expanded // Sheet is fully expanded
@@ -38,17 +44,14 @@ public protocol BottomSheetControllerDelegate: AnyObject {
     case hidden // Sheet is hidden (fully off-screen)
     case transitioning // Sheet is between states, only used during user interaction / animation
 }
-
 /// Defines where the sheet should be postionioned relative to the screen space
 @objc(MSFBottomSheetAnchorEdge) public enum BottomSheetAnchorEdge: Int {
     case center // Sheet is centered on the screen
     case leading // Sheet is constrained to the leading edge
     case trailing // Sheet is constrained to the trailing edge
 }
-
 @objc(MSFBottomSheetController)
 public class BottomSheetController: UIViewController, Shadowable, TokenizedControlInternal {
-
     /// Initializes the bottom sheet controller
     /// - Parameters:
     ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.
@@ -60,22 +63,17 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         self.shouldShowDimmingView = shouldShowDimmingView
         super.init(nibName: nil, bundle: nil)
     }
-
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         preconditionFailure("init(coder:) has not been implemented")
     }
-
     /// Top part of the sheet content that is visible in both collapsed and expanded state.
     @objc public let headerContentView: UIView?
-
     /// Sheet content below the header which is only visible when the sheet is expanded.
     @objc public let expandedContentView: UIView
-
     /// A scroll view in `expandedContentView`'s view hierarchy.
     /// Provide this to ensure the bottom sheet pan gesture recognizer coordinates with the scroll view to enable scrolling based on current bottom sheet position and content offset.
     @objc open var hostedScrollView: UIScrollView?
-
     /// Indicates if the bottom sheet is expandable.
     @objc open var isExpandable: Bool = true {
         didSet {
@@ -85,7 +83,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 if isViewLoaded {
                     move(to: .collapsed, animated: false)
                 }
-
 #if DEBUG
                 if isExpandable {
                     bottomSheetView.accessibilityIdentifier?.append(", a resizing handle")
@@ -96,7 +93,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             }
         }
     }
-
     /// Indicates if the bottom sheet view is hidden.
     ///
     /// Changes to this property are animated. When hiding, new value is reflected after the animation completes.
@@ -108,7 +104,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             setIsHidden(newValue)
         }
     }
-
     /// Indicates if the sheet height is flexible.
     ///
     /// When set to `false`, the sheet height is static and always corresponds to the height of the maximum expansion state.
@@ -125,7 +120,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.setNeedsLayout()
         }
     }
-
     /// Height of `headerContentView`.
     ///
     /// Setting this is required when the `headerContentView` is non-nil.
@@ -138,7 +132,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             headerContentViewHeightConstraint?.constant = headerContentHeight
         }
     }
-
     /// Preferred height of `expandedContentView`.
     ///
     /// The default value is 0, which results in a full screen sheet expansion.
@@ -151,7 +144,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.setNeedsLayout()
         }
     }
-
     /// A string to optionally customize the accessibility label of the bottom sheet handle.
     /// The message should convey the "Expand" action and will be used when the bottom sheet is collapsed.
     @objc public var handleExpandCustomAccessibilityLabel: String? {
@@ -159,7 +151,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             updateResizingHandleViewAccessibility()
         }
     }
-
     /// A string to optionally customize the accessibility label of the bottom sheet handle.
     /// The message should convey the "Collapse" action and will be used when the bottom sheet is expanded.
     @objc public var handleCollapseCustomAccessibilityLabel: String? {
@@ -167,7 +158,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             updateResizingHandleViewAccessibility()
         }
     }
-
     /// Indicates if the bottom sheet is expanded.
     ///
     /// Changes to this property are animated. A new value is reflected in the getter only after the animation completes.
@@ -179,7 +169,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             setIsExpanded(newValue)
         }
     }
-
     /// A closure for resolving the desired collapsed sheet height given a resolution context.
     @objc open var collapsedHeightResolver: ((ContentHeightResolutionContext) -> CGFloat)? {
         didSet {
@@ -188,7 +177,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             }
         }
     }
-
     /// Height of the top portion of the content view that should be visible when the bottom sheet is collapsed.
     ///
     /// When set to 0, `headerContentHeight` will be used.
@@ -201,7 +189,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.setNeedsLayout()
         }
     }
-
     /// Indicates if the content should be hidden when the sheet is collapsed
     @objc open var shouldHideCollapsedContent: Bool = true {
         didSet {
@@ -211,7 +198,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.setNeedsLayout()
         }
     }
-
     /// Indicates if the sheet should always fill the available width. The default value is true.
     @objc open var shouldAlwaysFillWidth: Bool = true {
         didSet {
@@ -219,7 +205,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 return
             }
             view.setNeedsLayout()
-
 #if DEBUG
                 if shouldAlwaysFillWidth {
                     bottomSheetView.accessibilityIdentifier?.append(", filled width")
@@ -229,7 +214,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 #endif
         }
     }
-
     /// Setting this property  will result in the sheet trying to be as close to this width as possible.
     /// If the declared width is too large it will roll back to the maximum width
     @objc open var preferredWidth: CGFloat = 0 {
@@ -240,8 +224,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             }
         }
     }
-
-    /// Represents where the sheet should appear on the screen. 
+    /// Represents where the sheet should appear on the screen.
     /// Defaults to being centered
     @objc open var anchoredEdge: BottomSheetAnchorEdge = .center {
         didSet {
@@ -251,10 +234,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.setNeedsLayout()
         }
     }
-
     /// When enabled, users will be able to move the sheet to the hidden state by swiping down.
     @objc open var allowsSwipeToHide: Bool = false
-
     /// Current height of the portion of a collapsed sheet that's in the safe area.
     @objc public private(set) var collapsedHeightInSafeArea: CGFloat = 0 {
         didSet {
@@ -264,20 +245,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             delegate?.bottomSheetControllerCollapsedHeightInSafeAreaDidChange?(self)
         }
     }
-
     /// A layout guide that covers the on-screen portion of the sheet view.
     @objc public let sheetLayoutGuide = UILayoutGuide()
-
     /// The object that acts as the delegate of the bottom sheet.
     @objc open weak var delegate: BottomSheetControllerDelegate?
-
     /// Height of the resizing handle
     @objc public static var resizingHandleHeight: CGFloat {
         return ResizingHandleView.height
     }
-
     // MARK: - Parametrized setters
-
     /// Sets the `isExpanded` property with a completion handler.
     /// - Parameters:
     ///   - isExpanded: The new value.
@@ -287,7 +263,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         guard isExpanded != self.isExpanded, !isHiddenOrHiding, isExpandable else {
             return
         }
-
         let targetExpansionState: BottomSheetExpansionState = isExpanded ? .expanded : .collapsed
         if isViewLoaded {
             move(to: targetExpansionState, animated: animated, shouldNotifyDelegate: false) { finalPosition in
@@ -298,7 +273,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             completion?(true)
         }
     }
-
     /// Changes the `isHidden` state with a completion handler.
     /// - Parameters:
     ///   - isHidden: The new value.
@@ -310,9 +284,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         } else {
             presentSheet(expandedState: .collapsed, animated: animated, completion: completion)
         }
-
     }
-
     /// Presents the bottom sheet view
     /// - Parameters:
     ///   - expandedState: The state the bottom sheet should expand to when presented
@@ -320,7 +292,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     ///   - completion: Closure to be called when the state change completes.
     @objc public func presentSheet(expandedState: BottomSheetExpansionState, animated: Bool = true, completion: ((_ isFinished: Bool) -> Void)? = nil) {
         let finishedState: BottomSheetExpansionState
-
         switch expandedState {
         case .collapsed:
             finishedState = expandedState
@@ -331,7 +302,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         default:
             finishedState = .collapsed
         }
-
         if isViewLoaded {
             move(to: finishedState, animated: animated, allowUnhiding: true) { finalPosition in
                 completion?(finalPosition == .end)
@@ -341,7 +311,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             completion?(true)
         }
     }
-
     /// Dismiss the bottom the bottom sheet view
     /// - Parameters:
     ///   - animated: Indicates if the change should be animated. The default value is `true`.
@@ -356,7 +325,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             completion?(true)
         }
     }
-
     /// Initiates an interactive `isHidden` state change driven by the returned `UIViewPropertyAnimator`.
     ///
     /// The returned animator comes preloaded with all the animations required to reach the target `isHidden` state.
@@ -374,42 +342,32 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         guard isViewLoaded else {
             return nil
         }
-
         completeAnimationsIfNeeded(skipToEnd: true)
-
         var animator: UIViewPropertyAnimator?
         if isHidden != self.isHidden {
             let initialState: BottomSheetExpansionState = isHidden ? .collapsed : .hidden
             let targetState: BottomSheetExpansionState = isHidden ? .hidden : .collapsed
-
             move(to: initialState, animated: false, allowUnhiding: true)
             animator = stateChangeAnimator(to: targetState)
-
             currentStateChangeAnimator = animator
             animator?.addCompletion { finalPosition in
                 completion?(finalPosition)
             }
         }
-
         return animator
     }
-
     /// Forces a call to `collapsedHeightResolver` to fetch the latest desired sheet height.
     @objc public func invalidateSheetSize() {
         guard isViewLoaded else {
             return
         }
-
         lastCollapsedSheetHeightResolutionContext = nil
-
         // If we are animating to .collapsed or already collapsed, we need to move to refresh the animation target.
         if targetExpansionState == .collapsed || (currentExpansionState == .collapsed && targetExpansionState == nil) {
             move(to: .collapsed)
         }
     }
-
     // MARK: - View loading
-
     // View hierarchy
     // self.view - BottomSheetPassthroughView (full overlay area)
     // |--dimmingView (spans self.view)
@@ -423,9 +381,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         view = BottomSheetPassthroughView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addLayoutGuide(sheetLayoutGuide)
-
         var constraints = [NSLayoutConstraint]()
-
         if shouldShowDimmingView {
             view.addSubview(dimmingView)
             constraints.append(contentsOf: [
@@ -435,64 +391,50 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 dimmingView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
         }
-
         view.addSubview(bottomSheetView)
         bottomSheetView.isHidden = currentExpansionState == .hidden
-
         // The non-zero frame here ensures the layout engine won't complain if it tries to calculate
         // sheet content layout before view.bounds is set to a non-zero rect.
         // We will set the sheet frame to a more meaningful rect after the first layout pass.
         bottomSheetView.frame = CGRect(x: 0, y: 0, width: Constants.minSheetWidth, height: expandedSheetHeight)
-
         overflowView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(overflowView)
-
         if let headerContentView = headerContentView {
             let heightConstraint = headerContentView.heightAnchor.constraint(equalToConstant: headerContentHeight)
             constraints.append(heightConstraint)
             headerContentViewHeightConstraint = heightConstraint
         }
-
         constraints.append(contentsOf: [
             overflowView.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
             overflowView.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
             overflowView.heightAnchor.constraint(equalToConstant: Constants.Spring.overflowHeight),
             overflowView.topAnchor.constraint(equalTo: bottomSheetView.bottomAnchor)
         ])
-
         constraints.append(contentsOf: makeLayoutGuideConstraints())
-
         NSLayoutConstraint.activate(constraints)
-
         // Update appearance whenever `tokenSet` changes.
         tokenSet.registerOnUpdate(for: view) { [weak self] in
             self?.updateAppearance()
         }
     }
-
     // MARK: - Shadow Layers
     public var ambientShadow: CALayer?
     public var keyShadow: CALayer?
-
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
         tokenSet.update(fluentTheme)
     }
-
     public override func viewDidLayoutSubviews() {
         let newHeight = view.bounds.height
         if currentRootViewHeight != newHeight && currentExpansionState == .transitioning {
             // The view height has changed and we can't guarantee the animation target frame is valid anymore.
             // Let's complete animations and cancel ongoing gestures to guarantee we end up in a good state.
             completeAnimationsIfNeeded(skipToEnd: true)
-
             if panGestureRecognizer.state != .possible {
                 panGestureRecognizer.state = .cancelled
             }
         }
         currentRootViewHeight = newHeight
-
         // In the transitioning state a pan gesture or an animator temporarily owns the sheet frame updates,
         // so to avoid interfering we won't update the frame here.
         if currentExpansionState != .transitioning {
@@ -503,70 +445,55 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             updateDimmingViewAccessibility()
         }
         collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
-
         updateAppearance()
         super.viewDidLayoutSubviews()
     }
-
     public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
         completeAnimationsIfNeeded(skipToEnd: true)
     }
-
     public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
         completeAnimationsIfNeeded(skipToEnd: true)
     }
-
     public typealias TokenSetKeyType = BottomSheetTokenSet.Tokens
     public var tokenSet: BottomSheetTokenSet = .init()
-
     var fluentTheme: FluentTheme { return view.fluentTheme }
-
     private func updateAppearance() {
         updateBackgroundColor()
         updateResizingHandleColor()
         updateShadow()
         updateCornerRadius()
     }
-
     private func updateBackgroundColor() {
         let backgroundColor = tokenSet[.backgroundColor].uiColor
         bottomSheetView.subviews[0].backgroundColor = backgroundColor
         overflowView.backgroundColor = backgroundColor
     }
-
     private func updateResizingHandleColor() {
         resizingHandleView.tokenSet.setOverrideValue(tokenSet[.resizingHandleMarkColor], forToken: .markColor)
     }
-
     private func updateShadow() {
         let shadowInfo = tokenSet[.shadow].shadowInfo
         // We need to have the shadow on a parent of the view that does the corner masking.
         // Otherwise the view will mask its own shadow.
         shadowInfo.applyShadow(to: bottomSheetView, parentController: self)
     }
-
     private func updateCornerRadius() {
         bottomSheetView.subviews[0].layer.cornerRadius = tokenSet[.cornerRadius].float
     }
-
     private lazy var overflowView: UIView = UIView()
-
     private lazy var dimmingView: DimmingView = {
         var dimmingView = DimmingView(type: .black)
         dimmingView.translatesAutoresizingMaskIntoConstraints = false
         dimmingView.alpha = 0.0
-
         dimmingView.accessibilityLabel = "Accessibility.Dismiss.Label".localized
         dimmingView.accessibilityHint = "Accessibility.Dismiss.Hint".localized
         dimmingView.accessibilityTraits = .button
-
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleDimmingViewTap))
         dimmingView.addGestureRecognizer(tapGesture)
         return dimmingView
     }()
-
     private lazy var resizingHandleView: ResizingHandleView = {
         let resizingHandleView = ResizingHandleView()
         resizingHandleView.isAccessibilityElement = true
@@ -576,79 +503,61 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         resizingHandleView.tokenSet.setOverrideValue(tokenSet[.resizingHandleMarkColor], forToken: .markColor)
         return resizingHandleView
     }()
-
     private lazy var bottomSheetView: UIView = {
         let bottomSheetContentView = UIView()
         bottomSheetContentView.translatesAutoresizingMaskIntoConstraints = false
-
         bottomSheetContentView.addGestureRecognizer(panGestureRecognizer)
         panGestureRecognizer.delegate = self
-
         let stackView = UIStackView(arrangedSubviews: [resizingHandleView])
         stackView.spacing = 0.0
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
-
         // Some types of content (like navigation controllers) can mess up the VO order.
         // Explicitly specifying a11y elements helps prevents this.
         bottomSheetContentView.accessibilityElements = [resizingHandleView]
-
         if let headerView = headerContentView {
             stackView.addArrangedSubview(headerView)
             bottomSheetContentView.accessibilityElements?.append(headerView)
         }
-
         stackView.addArrangedSubview(expandedContentView)
         bottomSheetContentView.accessibilityElements?.append(expandedContentView)
         bottomSheetContentView.addSubview(stackView)
-
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: bottomSheetContentView.topAnchor),
             stackView.leadingAnchor.constraint(equalTo: bottomSheetContentView.leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: bottomSheetContentView.trailingAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomSheetContentView.bottomAnchor)
         ])
-
         return makeBottomSheetByEmbedding(contentView: bottomSheetContentView)
     }()
-
     private func makeBottomSheetByEmbedding(contentView: UIView) -> UIView {
         let bottomSheetView = UIView()
-
         contentView.translatesAutoresizingMaskIntoConstraints = false
         contentView.layer.cornerCurve = .continuous
         contentView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         contentView.clipsToBounds = true
-
         // We need to set the background color of the embedding view otherwise the shadows will not display
         bottomSheetView.backgroundColor = tokenSet[.backgroundColor].uiColor
         bottomSheetView.layer.cornerRadius = tokenSet[.cornerRadius].float
         bottomSheetView.addSubview(contentView)
-
         NSLayoutConstraint.activate([
             contentView.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
             contentView.topAnchor.constraint(equalTo: bottomSheetView.topAnchor),
             contentView.bottomAnchor.constraint(equalTo: bottomSheetView.bottomAnchor)
         ])
-
 #if DEBUG
         bottomSheetView.accessibilityIdentifier = "Bottom Sheet View"
 #endif
-
         return bottomSheetView
     }
-
     // MARK: - Gesture handling
-
     @objc private func handleDimmingViewTap(_ sender: UITapGestureRecognizer) {
         move(to: .collapsed, interaction: .dimmingViewTap)
     }
-
     @objc private func handleResizingHandleViewTap(_ sender: UITapGestureRecognizer) {
         move(to: isExpanded ? .collapsed : .expanded, interaction: .resizingHandleTap)
     }
-
     private func updateResizingHandleViewAccessibility() {
         if currentExpansionState == .expanded {
             resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Collapse".localized
@@ -658,12 +567,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
         }
     }
-
     private func updateExpandedContentAlpha() {
         let currentOffset = currentSheetVerticalOffset
         let collapsedOffset = offset(for: .collapsed)
         let expandedOffset = offset(for: .expanded)
-
         var targetAlpha: CGFloat = 1.0
         if shouldHideCollapsedContent && !isHeightRestricted {
             let transitionLength = min(Constants.expandedContentAlphaTransitionLength, abs(collapsedOffset - expandedOffset))
@@ -674,7 +581,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             }
         }
         expandedContentView.alpha = targetAlpha
-
 #if DEBUG
         if targetAlpha == 1.0 {
             bottomSheetView.accessibilityIdentifier?.append(", an expanded content view")
@@ -683,12 +589,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
 #endif
     }
-
     private func updateDimmingViewAlpha() {
         guard shouldShowDimmingView else {
             return
         }
-
         var targetAlpha: CGFloat = 0.0
         if isExpandable {
             // Offset marks top of the sheet in UIView coord space, so counterintuitively,
@@ -709,11 +613,9 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             // -------- fully undimmed (0.0)-----------
             // ----------------------------------------
             // ---------------------------------------- <--- high offset
-
             let currentOffset = currentSheetVerticalOffset
             let highestDimmedOffset = offset(for: .expanded)
             let lowestUndimmedOffset = isHeightRestricted ? offset(for: .hidden) : offset(for: .collapsed)
-
             if currentOffset <= highestDimmedOffset {
                 targetAlpha = 1.0
             } else if currentOffset >= lowestUndimmedOffset {
@@ -724,14 +626,12 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
         dimmingView.alpha = targetAlpha
     }
-
     // When the bottomsheet is expanded and dimmingView is shown, we should make dimmingView accessibility
     // DimmingView is technically full screen. However, for accessibility users, we should update the dimmingView's accessibilityFrame to be only the offset from bottomsheet's frame.
     private func updateDimmingViewAccessibility() {
         guard shouldShowDimmingView else {
             return
         }
-
         if dimmingView.alpha == 0 {
             dimmingView.isAccessibilityElement = false
             view.accessibilityViewIsModal = false
@@ -743,13 +643,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.accessibilityViewIsModal = true
         }
     }
-
     private func updateSheetLayoutGuideTopConstraint() {
         if sheetLayoutGuideTopConstraint.constant != currentSheetVerticalOffset {
             sheetLayoutGuideTopConstraint.constant = currentSheetVerticalOffset
         }
     }
-
     @objc private func handlePan(_ sender: UIPanGestureRecognizer) {
         switch sender.state {
         case .began:
@@ -765,43 +663,34 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             break
         }
     }
-
     private func translateSheet(by translationDelta: CGPoint) {
         let expandedOffset = offset(for: .expanded)
         let collapsedOffset = offset(for: .collapsed)
         let hiddenOffset = offset(for: .hidden)
-
         let minOffset = expandedOffset - Constants.maxRubberBandOffset
         let maxOffset = allowsSwipeToHide ? hiddenOffset : (collapsedOffset + Constants.maxRubberBandOffset)
-
         var offsetDelta = translationDelta.y
         if (currentSheetVerticalOffset >= collapsedOffset && !allowsSwipeToHide) || currentSheetVerticalOffset <= expandedOffset {
             offsetDelta *= translationRubberBandFactor(for: currentSheetVerticalOffset)
         }
-
         let targetOffset = min(max(bottomSheetView.frame.origin.y + offsetDelta, minOffset), maxOffset)
         bottomSheetView.frame = sheetFrame(offset: targetOffset)
-
         updateSheetLayoutGuideTopConstraint()
         updateExpandedContentAlpha()
         updateDimmingViewAlpha()
         updateDimmingViewAccessibility()
     }
-
     // Source of truth for the sheet frame at a given offset from the top of the root view bounds.
     // The output is only meaningful once view.bounds is non-zero i.e. a layout pass has occured.
     private func sheetFrame(offset: CGFloat) -> CGRect {
         let sheetWidth: CGFloat = determineSheetWidth()
-
         let sheetHeight: CGFloat
-
         if isFlexibleHeight {
             let minSheetHeight = collapsedSheetHeight
             sheetHeight = max(minSheetHeight, view.bounds.maxY - offset)
         } else {
             sheetHeight = expandedSheetHeight
         }
-
         // Calculates the location to put the left edge of the sheet relative to the view
         // For right aligned we get the width of the view offset by the sheets width and the padding
         // For left aligned we only need to add in the padding
@@ -824,12 +713,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 xPosition = Constants.horizontalSheetPadding
             }
         }
-
         let frame = CGRect(origin: CGPoint(x: xPosition, y: offset),
                              size: CGSize(width: sheetWidth, height: sheetHeight))
         return frame
     }
-
     // Helper function to determine how wide the sheet should be
     private func determineSheetWidth() -> CGFloat {
         // Width will the fill the screen if should always fill width
@@ -847,12 +734,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
         return determinedWidth
     }
-
     private func translationRubberBandFactor(for currentOffset: CGFloat) -> CGFloat {
         let offLimitsOffset: CGFloat
         let expandedOffset = offset(for: .expanded)
         let collapsedOffset = offset(for: .collapsed)
-
         if currentOffset < expandedOffset {
             offLimitsOffset = min(expandedOffset - currentOffset, Constants.maxRubberBandOffset)
         } else if currentOffset > collapsedOffset {
@@ -860,26 +745,20 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         } else {
             offLimitsOffset = 0.0
         }
-
         return max(1.0 - offLimitsOffset / Constants.maxRubberBandOffset, Constants.minRubberBandScaleFactor)
     }
-
     // MARK: - Animations
-
     private func completePan(with velocity: CGFloat) {
         var targetState: BottomSheetExpansionState
-
         if abs(velocity) < Constants.directionOverrideVelocityThreshold {
             // Velocity too low, snap to the closest expansion state
             var distances: [BottomSheetExpansionState: CGFloat] = [
                 .expanded: abs(offset(for: .expanded) - currentSheetVerticalOffset),
                 .collapsed: abs(offset(for: .collapsed) - currentSheetVerticalOffset)
             ]
-
             if allowsSwipeToHide {
                 distances[.hidden] = abs(offset(for: .hidden) - currentSheetVerticalOffset)
             }
-
             targetState = distances.min(by: { $0.value < $1.value })?.key ?? .collapsed
         } else {
             // Velocity high enough, animate to the state we're swiping towards
@@ -891,7 +770,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
         move(to: targetState, velocity: velocity, interaction: .swipe)
     }
-
     private func move(to targetExpansionState: BottomSheetExpansionState,
                       animated: Bool = true,
                       velocity: CGFloat = 0.0,
@@ -902,10 +780,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         guard targetExpansionState == .hidden || !isHiddenOrHiding || allowUnhiding else {
             return
         }
-
         completeAnimationsIfNeeded()
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
+            delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)
+
             let animator = stateChangeAnimator(to: targetExpansionState,
                                                velocity: velocity,
                                                interaction: interaction,
@@ -913,7 +792,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             animator.addCompletion({ finalPosition in
                 completion?(finalPosition)
             })
-
             if animated {
                 currentStateChangeAnimator = animator
                 animator.startAnimation()
@@ -926,7 +804,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             handleCompletedStateChange(to: targetExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
         }
     }
-
     private func stateChangeAnimator(to targetExpansionState: BottomSheetExpansionState,
                                      velocity: CGFloat = 0.0,
                                      interaction: BottomSheetInteraction = .noUserAction,
@@ -937,21 +814,16 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         let damping: CGFloat = abs(velocity) > Constants.Spring.flickVelocityThreshold
             ? Constants.Spring.oscillatingDampingRatio
             : Constants.Spring.defaultDampingRatio
-
         let springParams = UISpringTimingParameters(dampingRatio: damping,
                                                     initialVelocity: CGVector(dx: springVelocity, dy: springVelocity))
         let translationAnimator = UIViewPropertyAnimator(duration: Constants.Spring.animationDuration, timingParameters: springParams)
-
         self.targetExpansionState = targetExpansionState
-
         // Disable dragging while hiding the sheet
         if targetExpansionState == .hidden {
             panGestureRecognizer.isEnabled = false
         }
-
         // Animation might be reversed, so we need to remember the original state
         let originalExpansionState = currentExpansionState
-
         bottomSheetView.isHidden = false
         translationAnimator.addAnimations { [weak self] in
             guard let strongSelf = self else {
@@ -959,43 +831,36 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             }
             strongSelf.bottomSheetView.frame = strongSelf.sheetFrame(offset: targetVerticalOffset)
             strongSelf.sheetLayoutGuideTopConstraint.constant = targetVerticalOffset
-
             strongSelf.updateDimmingViewAlpha()
             strongSelf.updateExpandedContentAlpha()
             strongSelf.view.layoutIfNeeded()
             strongSelf.updateDimmingViewAccessibility()
         }
-
         translationAnimator.addCompletion({ [weak self] finalPosition in
             guard let strongSelf = self else {
                 return
             }
-
             // It's important we drop the reference to the animator as early as possible.
             // Otherwise we could accidentally try modifying the animator while it's calling out to its completion handler, which can lead to a crash.
             if let animator = strongSelf.currentStateChangeAnimator, animator == translationAnimator {
                 strongSelf.currentStateChangeAnimator = nil
             }
-
             strongSelf.targetExpansionState = nil
             strongSelf.panGestureRecognizer.isEnabled = strongSelf.isExpandable
             strongSelf.handleCompletedStateChange(to: finalPosition == .start ? originalExpansionState : targetExpansionState,
                                                   interaction: interaction,
                                                   shouldNotifyDelegate: shouldNotifyDelegate && finalPosition != .current)
         })
-
         view.layoutIfNeeded()
         currentExpansionState = .transitioning
         return translationAnimator
     }
-
     // Vertical offset of bottomSheetView.origin for the given expansion state
     //
     // Note: Since .transitioning state doesn't have a well defined offset, this function will
     // only return the current sheet offset in that case.
     private func offset(for expansionState: BottomSheetExpansionState) -> CGFloat {
         let offset: CGFloat
-
         switch expansionState {
         case .collapsed:
             if !isHeightRestricted || !isExpandable {
@@ -1012,10 +877,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         case .transitioning:
             offset = bottomSheetView.frame.minY
         }
-
         return offset
     }
-
     private func handleCompletedStateChange(to targetExpansionState: BottomSheetExpansionState,
                                             interaction: BottomSheetInteraction = .noUserAction,
                                             shouldNotifyDelegate: Bool = true) {
@@ -1023,18 +886,14 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         if shouldNotifyDelegate {
             self.delegate?.bottomSheetController?(self, didMoveTo: targetExpansionState, interaction: interaction)
         }
-
         if targetExpansionState == .collapsed {
             hostedScrollView?.setContentOffset(.zero, animated: true)
         }
-
         bottomSheetView.isHidden = targetExpansionState == .hidden
-
         // UIKit doesn't properly handle interrupted constraint animations, so we need to
         // detect and fix a possible desync here
         updateSheetLayoutGuideTopConstraint()
     }
-
     private func completeAnimationsIfNeeded(skipToEnd: Bool = false) {
         if let currentAnimator = currentStateChangeAnimator, currentAnimator.isRunning, currentAnimator.state == .active {
             let endPosition: UIViewAnimatingPosition = currentAnimator.isReversed ? .start : .end
@@ -1043,7 +902,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             currentStateChangeAnimator = nil
         }
     }
-
     private func makeLayoutGuideConstraints() -> [NSLayoutConstraint] {
         let requiredConstraints = [
             sheetLayoutGuide.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
@@ -1051,37 +909,29 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             sheetLayoutGuide.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             sheetLayoutGuide.topAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor)
         ]
-
         // This constraint is used to align the top of the layout guide with the top of the bottomSheetView.
         // BottomSheetView will go off-screen when it's hidden, so this constraint is not always required.
         let breakableTopConstraint = sheetLayoutGuideTopConstraint
         breakableTopConstraint.priority = .defaultHigh
-
         return requiredConstraints + [breakableTopConstraint]
     }
-
     private lazy var sheetLayoutGuideTopConstraint: NSLayoutConstraint = sheetLayoutGuide.topAnchor.constraint(equalTo: view.topAnchor)
-
     // Height of the sheet in the fully expanded state
     private var expandedSheetHeight: CGFloat {
         guard isExpandable else {
             return collapsedSheetHeight
         }
-
         let height: CGFloat
-
         if preferredExpandedContentHeight == 0 {
             height = maxSheetHeight
         } else {
             let idealHeight = currentResizingHandleHeight + headerContentHeight + preferredExpandedContentHeight + view.safeAreaInsets.bottom
             height = min(maxSheetHeight, idealHeight)
         }
-
         // One case when the lower bound is required is when view.frame is .zero (like before the initial layout pass)
         // This gives the sheet some space to layout in so the layout engine doesn't complain.
         return max(collapsedSheetHeight, height)
     }
-
     // Height of the sheet in collapsed state
     private var collapsedSheetHeight: CGFloat {
         let safeAreaSheetHeight: CGFloat
@@ -1092,29 +942,23 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         } else {
             safeAreaSheetHeight = headerContentHeight + currentResizingHandleHeight
         }
-
         let idealHeight = safeAreaSheetHeight + view.safeAreaInsets.bottom
         return min(idealHeight, maxSheetHeight)
     }
-
     // Maximum total sheet height including parts outside of the safe area.
     private var maxSheetHeight: CGFloat {
         let maxHeight: CGFloat
-
         if view.frame != .zero {
             maxHeight = view.frame.height - view.safeAreaInsets.top - Constants.minimumTopExpandedPadding
         } else {
             maxHeight = Constants.defaultMaxSheetHeight
         }
-
         return maxHeight
     }
-
     // Output of `collapsedHeightResolver` wrapped in a cache.
     private var resolvedCollapsedSheetHeight: CGFloat {
         let oldContext = lastCollapsedSheetHeightResolutionContext
         let newContext = ContentHeightResolutionContext(maximumHeight: maxSheetHeight - view.safeAreaInsets.bottom, containerTraitCollection: view.traitCollection)
-
         if oldContext?.maximumHeight != newContext.maximumHeight
             || oldContext?.containerTraitCollection.horizontalSizeClass != newContext.containerTraitCollection.horizontalSizeClass
             || oldContext?.containerTraitCollection.verticalSizeClass != newContext.containerTraitCollection.verticalSizeClass {
@@ -1123,103 +967,74 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
         return lastResolvedCollapsedSheetHeight
     }
-
     // Last output of `collapsedHeightResolver`.
     private var lastResolvedCollapsedSheetHeight: CGFloat = 0
-
     // Context we last used for height resolving.
     private var lastCollapsedSheetHeightResolutionContext: ContentHeightResolutionContext?
-
     private var currentResizingHandleHeight: CGFloat {
         (isExpandable ? ResizingHandleView.height : 0.0)
     }
-
     private lazy var panGestureRecognizer: UIPanGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handlePan))
-
     private var headerContentViewHeightConstraint: NSLayoutConstraint?
-
     private var currentStateChangeAnimator: UIViewPropertyAnimator?
-
     private var currentExpansionState: BottomSheetExpansionState = .collapsed {
         didSet {
             updateResizingHandleViewAccessibility()
         }
     }
-
     private var targetExpansionState: BottomSheetExpansionState?
-
     private var isHiddenOrHiding: Bool { isHidden || targetExpansionState == .hidden }
-
     private var isHeightRestricted: Bool {
         maxSheetHeight - collapsedSheetHeight < Constants.heightRestrictedThreshold
     }
-
     private var currentSheetVerticalOffset: CGFloat {
         bottomSheetView.frame.minY
     }
-
     // Only used for height change detection.
     // For all other cases you should probably directly use self.view.bounds.height.
     private var currentRootViewHeight: CGFloat = 0
-
     private let shouldShowDimmingView: Bool
-
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance
         static let maxRubberBandOffset: CGFloat = 20.0
         static let minRubberBandScaleFactor: CGFloat = 0.05
-
         // Swipes over this velocity ignore proximity to the collapsed / expanded offset and fly towards
         // the offset that makes sense given the swipe direction
         static let directionOverrideVelocityThreshold: CGFloat = 150
-
         // Minimum padding from top when the sheet is fully expanded
         static let minimumTopExpandedPadding: CGFloat = 25.0
-
         // The padding allocated to the space between the sheet and the edge when attached to the leading or trailing edge
         static let horizontalSheetPadding: CGFloat = GlobalTokens.spacing(.size80)
-
         static let expandedContentAlphaTransitionLength: CGFloat = 30
-
         static let maxSheetWidth: CGFloat = 610
         static let minSheetWidth: CGFloat = 300
         static let defaultMaxSheetHeight: CGFloat = 600
-
         // When the difference in collapsed height and max sheet height is less than this,
         // we go into height restricted mode which skips the collapsed state and adjusts dimming.
         static let heightRestrictedThreshold: CGFloat = 50
-
         struct Spring {
             // Spring used in slow swipes - no oscillation
             static let defaultDampingRatio: CGFloat = 1.0
-
             // Spring used in fast swipes - slight oscillation
             static let oscillatingDampingRatio: CGFloat = 0.8
-
             // Swipes over this velocity get slight spring oscillation
             static let flickVelocityThreshold: CGFloat = 800
-
             static let maxInitialVelocity: CGFloat = 40.0
             static let animationDuration: TimeInterval = 0.4
-
             // Off-screen overflow that can be partially revealed during spring oscillation or rubber banding (dragging the sheet beyond limits)
             static let overflowHeight: CGFloat = 50.0
         }
     }
 }
-
 extension BottomSheetController: UIGestureRecognizerDelegate {
-
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return gestureRecognizer == panGestureRecognizer && otherGestureRecognizer == hostedScrollView?.panGestureRecognizer
     }
-
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         // Enables other gesture recognizers to occur inside the bottom sheet alongside the `panGestureRecognizer`.
         // The `otherGestureRecognizer` will be required to fail if it is not a tap gesture and it is not the `hostedScrollView` pan gesture.
         return !(otherGestureRecognizer is UITapGestureRecognizer) && (otherGestureRecognizer != hostedScrollView?.panGestureRecognizer)
     }
-
     public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let scrollView = hostedScrollView,
               let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
@@ -1227,7 +1042,6 @@ extension BottomSheetController: UIGestureRecognizerDelegate {
         }
         var shouldBegin = true
         let fullyExpanded = currentSheetVerticalOffset <= offset(for: .expanded)
-
         if fullyExpanded {
             let scrolledToTop = scrollView.contentOffset.y <= 0
             let panningDown = panGesture.velocity(in: view).y > 0


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
Add an entry point for bottom sheet consumer to be able to preform actions before the bottom sheet changes state.
Delegate method will inform consumers that a state change is about to happen.

### Binary change
Total increase: 888 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 32,274,112 bytes | 32,275,000 bytes | ⚠️ 888 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomSheetController.o | 543,560 bytes | 544,120 bytes | ⚠️ 560 bytes |
| FocusRingView.o | 847,760 bytes | 847,928 bytes | ⚠️ 168 bytes |
| BottomCommandingController.o | 865,040 bytes | 865,200 bytes | ⚠️ 160 bytes |
</details>


### Verification
Tested by changing the alpha on the bottom sheets view in the demo controller before planning to move to the expanded and the collapsed state.


### Pull request checklist

This PR has considered:
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2052)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2053)