### PR TITLE
Various a11y fixes for SearchBar and BadgeView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/SearchBarDemoController.swift
@@ -10,7 +10,6 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
     private struct Constants {
         static let badgeViewCornerRadius: CGFloat = 10
         static let badgeViewSideLength: CGFloat = 20
-        static let badgeViewMaxFontSize: CGFloat = 40
         static let searchBarStackviewMargin: CGFloat = 16
     }
 
@@ -110,7 +109,7 @@ class SearchBarDemoController: DemoController, SearchBarDelegate {
         badge.tokenSet[.backgroundDisabledColor] = .uiColor { .init(light: GlobalTokens.sharedColor(.purple, .primary)) }
         badge.tokenSet[.foregroundDisabledColor] = .uiColor { .init(light: GlobalTokens.neutralColor(.white)) }
         badge.isActive = false
-        badge.maxFontSize = Constants.badgeViewMaxFontSize
+        badge.showsLargeContentViewer = true
         return badge
     }
 

--- a/ios/FluentUI/Badge Field/BadgeView.swift
+++ b/ios/FluentUI/Badge Field/BadgeView.swift
@@ -254,7 +254,9 @@ open class BadgeView: UIView, TokenizedControlInternal {
     }
 
     func reload() {
-        label.text = dataSource?.text
+        let text = dataSource?.text
+        label.text = text
+        largeContentTitle = text
         style = dataSource?.style ?? .default
         sizeCategory = dataSource?.sizeCategory ?? .medium
 

--- a/ios/FluentUI/Navigation/SearchBar/SearchBar.swift
+++ b/ios/FluentUI/Navigation/SearchBar/SearchBar.swift
@@ -151,6 +151,7 @@ open class SearchBar: UIView, TokenizedControlInternal {
         button.addTarget(self, action: #selector(SearchBar.cancelButtonTapped(sender:)), for: .touchUpInside)
         button.alpha = 0.0
         button.showsLargeContentViewer = true
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.isPointerInteractionEnabled = true
         if #available(iOS 17, *) {
             button.hoverStyle = UIHoverStyle(shape: .capsule)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

#### Problems
Our SearchBar and BadgeView have a few a11y and layout issues.
- the clear text button is not accessible (no large content viewer)
- fonts are adjusting for dynamic type only on initial load. This is because our tokens auto-scale, but only when you fetch the token. The control needs to track subsequent content size category updates.
- the space we give the `leadingView` is only calculated once, and doesn't react to parent view size changes or content size category updates (where the leading view may need more space).
- SearchBar has fixed height, and the largest content size categories were causing the fonts to get clipped
- BadgeView doesn't fill its `largeContentTitle` prop, so when largeContentViewer is enabled it shows a blank view.

For this PR, I'm assuming our SearchBar fixed height is a hard limit - changing this could have major fallout for clients. Instead let's make this view as accessible as we can within the limits.
- Introduce a max size category - still fairly large, but not large enough to break the view.
- Cover the edge cases with large content viewer support on all the subviews.
- Rewrite our layout code for `leadingView` - this now uses pure Auto Layout to enforce min width for the input field, but also good amount of space for `leadingView`
- Ensure fonts adjust to all subsequent dynamic type updates
- Reuse existing localized string for the clear button a11y label and large content title

### Binary change

Total increase: 6,464 bytes
Total decrease: -1,776 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,961,480 bytes | 30,966,168 bytes | ⚠️ 4,688 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| SearchBar.o | 371,312 bytes | 376,888 bytes | ⚠️ 5,576 bytes |
| BadgeView.o | 628,352 bytes | 629,240 bytes | ⚠️ 888 bytes |
| FocusRingView.o | 835,736 bytes | 835,656 bytes | 🎉 -80 bytes |
| SearchBarTokenSet.o | 82,256 bytes | 81,528 bytes | 🎉 -728 bytes |
| __.SYMDEF | 4,754,288 bytes | 4,753,320 bytes | 🎉 -968 bytes |
</details>

### Verification

Local testing in sim, various dynamic type size, restricted width scenarios, screen rotation, usage inside Fluent NavigationController.

<details>
<summary>Visual Verification</summary>

| | Before                                       | After                                      |
|----------------------------------------------|----------------------------------------------|--------------------------------------------|
|Default dynamic type | <img width="958" alt="Screenshot 2024-07-03 at 4 18 54 PM" src="https://github.com/microsoft/fluentui-apple/assets/3610850/84d1c01c-fdf9-43d4-b11a-cc114698c69e"> | <img width="971" alt="Screenshot 2024-07-03 at 4 16 54 PM" src="https://github.com/microsoft/fluentui-apple/assets/3610850/b15ebc6b-f36b-4b04-b75f-85cee99a689e">
|Max dynamic type before reload|<img width="981" alt="Screenshot 2024-07-03 at 11 26 18 AM" src="https://github.com/microsoft/fluentui-apple/assets/3610850/3f04201b-bfea-4173-8113-d347167d255e">|<img width="957" alt="Screenshot 2024-07-03 at 11 30 03 AM" src="https://github.com/microsoft/fluentui-apple/assets/3610850/4a0c13a5-22ed-4106-96f8-158f5c39daa3">|
|Max dynamic type after reload| <img width="964" alt="Screenshot 2024-07-03 at 11 26 35 AM" src="https://github.com/microsoft/fluentui-apple/assets/3610850/0a3e4609-c56d-48d8-ab84-0e60377d03f0"> | <img width="957" alt="Screenshot 2024-07-03 at 11 30 41 AM" src="https://github.com/microsoft/fluentui-apple/assets/3610850/32003821-6f01-4539-8b99-dfa6d84f2afe">|
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2054)