### PR TITLE
Switch to using Toggle in ActivityIndicatorDemoController

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorDemoController.swift
@@ -47,15 +47,16 @@ class ActivityIndicatorDemoController: DemoTableViewController {
                 self?.shouldHideWhenStopped = cell?.isOn ?? true
             }
             return cell
-        case .startStopActivity:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: ActionsCell.identifier) as? ActionsCell else {
+        case .isAnimating:
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
             }
 
-            cell.setup(action1Title: row.title)
-            cell.action1Button.addTarget(self,
-                                         action: #selector(startStopActivity),
-                                         for: .touchUpInside)
+            cell.setup(title: row.title, isOn: self.isAnimating)
+            cell.titleNumberOfLines = 0
+            cell.onValueChanged = { [weak self, weak cell] in
+                self?.isAnimating = cell?.isOn ?? true
+            }
             cell.bottomSeparatorType = .full
             return cell
         case .swiftUIDemo:
@@ -181,7 +182,7 @@ class ActivityIndicatorDemoController: DemoTableViewController {
     private enum ActivityIndicatorDemoRow: CaseIterable {
         case swiftUIDemo
         case hidesWhenStopped
-        case startStopActivity
+        case isAnimating
         case demoOfSize
 
         var title: String {
@@ -190,8 +191,8 @@ class ActivityIndicatorDemoController: DemoTableViewController {
                 return "SwiftUI Demo"
             case .hidesWhenStopped:
                 return "Hides when stopped"
-            case .startStopActivity:
-                return "Start / Stop activity"
+            case .isAnimating:
+                return "Animating"
             case .demoOfSize:
                 return ""
             }
@@ -222,7 +223,7 @@ class ActivityIndicatorDemoController: DemoTableViewController {
             case .swiftUI:
                 return [.swiftUIDemo]
             case .settings:
-                return [.hidesWhenStopped, .startStopActivity]
+                return [.hidesWhenStopped, .isAnimating]
             case .defaultColor, .customColor:
                 return [ActivityIndicatorDemoRow](repeating: .demoOfSize,
                                                   count: MSFActivityIndicatorSize.allCases.count)
@@ -232,10 +233,6 @@ class ActivityIndicatorDemoController: DemoTableViewController {
     }
 
     private let xLargeSize: CGFloat = 36
-
-    @objc private func startStopActivity() {
-        isAnimating.toggle()
-    }
 }
 
 extension MSFActivityIndicatorSize {

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -22,17 +22,17 @@ class ActivityIndicatorTest: BaseTest {
 
     // tests start/stop functionality as well as hiding (activity indicator should disappear when stopped)
     func testStartStopHide() throws {
-        let startStopButton: XCUIElement = app.cells.containing(.staticText, identifier: "Animating").firstMatch
+        let activityButton: XCUIElement = app.cells.containing(.staticText, identifier: "Animating").firstMatch
         let hidesWhenStoppedButton: XCUIElement = app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch
 
         XCTAssert(activityIndicatorExists(status: inProgress))
-        startStopButton.tap()
+        activityButton.tap()
         XCTAssert(!activityIndicatorExists(status: inProgress))
 
         hidesWhenStoppedButton.tap()
         XCTAssert(activityIndicatorExists(status: progressHalted))
 
-        startStopButton.tap()
+        activityButton.tap()
         XCTAssert(activityIndicatorExists(status: inProgress))
     }
 

--- a/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
+++ b/ios/FluentUI.Demo/FluentUIDemoTests/ActivityIndicatorTest.swift
@@ -22,7 +22,7 @@ class ActivityIndicatorTest: BaseTest {
 
     // tests start/stop functionality as well as hiding (activity indicator should disappear when stopped)
     func testStartStopHide() throws {
-        let startStopButton: XCUIElement = app.buttons["Start / Stop activity"]
+        let startStopButton: XCUIElement = app.cells.containing(.staticText, identifier: "Animating").firstMatch
         let hidesWhenStoppedButton: XCUIElement = app.cells.containing(.staticText, identifier: "Hides when stopped").firstMatch
 
         XCTAssert(activityIndicatorExists(status: inProgress))


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Update the demo app to use a Toggle for the `ActivityIndicator` animation property.

### Binary change

n/a - demo only

### Verification

Ran UI test for `ActivityIndicator` and verified all passes.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/microsoft/fluentui-apple/assets/4934719/f1eb17b3-350e-4ad5-950d-b9b1afbb25bd) | ![after](https://github.com/microsoft/fluentui-apple/assets/4934719/05dd2032-d588-445c-bf30-0c68782ea527) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2055)