### PR TITLE
Fix Xcode crash by not creating gigantic views

### DIFF
--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -125,8 +125,6 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         addSubview(topSeparator)
         addSubview(bottomSeparator)
 
-        // hide system separator so we can draw our own. We prefer the container UITableView to set separatorStyle = .none
-        separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
         updateHorizontalSeparator(topSeparator, with: topSeparatorType)
         updateHorizontalSeparator(bottomSeparator, with: bottomSeparatorType)
         setupBackgroundColors()
@@ -184,6 +182,14 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         if actionCount > 1 {
             action2Button.frame = CGRect(x: left, y: 0, width: frame.width - left, height: frame.height)
             verticalSeparator.frame = CGRect(x: left, y: 0, width: verticalSeparator.frame.width, height: frame.height)
+        }
+
+        // A hacky way to hide the system separator by squeezing it just enough to have zero width.
+        // This is the only known way to hide the separator without making the UITableView do it for us.
+        let boundsWidth = bounds.width
+        if separatorInset.left != boundsWidth || separatorInset.right != 0 {
+            separatorInset.left = boundsWidth
+            separatorInset.right = 0
         }
 
         layoutHorizontalSeparator(topSeparator, with: topSeparatorType, at: 0)

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1228,8 +1228,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         setupBackgroundColors()
 
-        // hide system separator so we can draw our own. We prefer the container UITableView to set separatorStyle = .none
-        separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
         updateSeparator(topSeparator, with: topSeparatorType)
         updateSeparator(bottomSeparator, with: bottomSeparatorType)
 
@@ -1436,6 +1434,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         layoutContentSubviews()
         contentView.flipSubviewsForRTL()
+
+        // A hacky way to hide the system separator by squeezing it just enough to have zero width.
+        // This is the only known way to hide the separator without making the UITableView do it for us.
+        let boundsWidth = bounds.width
+        if separatorInset.left != boundsWidth || separatorInset.right != 0 {
+            separatorInset.left = boundsWidth
+            separatorInset.right = 0
+        }
 
         layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
         layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

We've been seeing a mysterious Xcode crash whenever we tried to launch the view debugger while in the `NavigationControllerDemoController`.

Turns out this was caused by our logic to hide the system separator in `UITableViewCell`. We set `separatorInset.left` to `CGFloat.greatestFiniteMagnitude`. This does visually hide it, but also essentially inverts the underlying separator UIView and gives it a frame with a width of `~CGFloat.greatestFiniteMagnitude`. 

I'm amazed this didn't cause more issues, but it kills the view debugger which actually tries to draw a frame rectangle around this thing.

Here's a fun screenshot that shows the problem:

<img width="1036" src="https://github.com/microsoft/fluentui-apple/assets/3610850/37df1c82-3c1a-49e8-a30e-84c71641b890">

#### Solution
Let's only inset the separator by the exact amount it needs to get squeezed to `width == 0`. This needs to be done in `layoutSubviews` of the cell to always be kept up to date with the bounds. It's only done when necessary to avoid the risk of adding too many layout passes.

### Binary change

N/A, very minor change.

### Verification

Sanity tests in the test app. Verified using (the now working) view debugger that separators always end up width a zero width. Verified that we don't trigger noisy layout passes - the inset updates only happen when the cells actually resize, or first appear.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2056)