### PR TITLE
use ios 17 api to improve BooleanCell voiceover hint

### DIFF
--- a/ios/FluentUI/Other Cells/BooleanCell.swift
+++ b/ios/FluentUI/Other Cells/BooleanCell.swift
@@ -81,6 +81,9 @@ open class BooleanCell: TableViewCell {
         setup(title: title, customView: customView, customAccessoryView: `switch`)
         self.isOn = isOn
         self.isSwitchEnabled = isSwitchEnabled
+        if #available(iOS 17, *) {
+            self.accessibilityTraits.insert(.toggleButton)
+        }
     }
 
     @objc private func handleOnSwitchValueChanged() {

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1037,7 +1037,13 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
             }
             if let customSwitch = customAccessoryView as? UISwitch {
                 if isEnabled && customSwitch.isEnabled {
-                    return "Accessibility.TableViewCell.Switch.Hint".localized
+                    var allowOSHint = false
+                    if #available(iOS 17, *) {
+                        if accessibilityTraits.contains(.toggleButton) {
+                            allowOSHint = true
+                        }
+                    }
+                    return allowOSHint ? super.accessibilityHint : "Accessibility.TableViewCell.Switch.Hint".localized
                 } else {
                     return nil
                 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
iOS 17 added new accessibility trait which custom control that now notify to users it is a toggle. BooleanCell is a custom UITableViewCell which we had our own accessibility strings to mimic OS behavior. We can eventually remove this custom string if all of our cells with uiswitch contains .toggleButton trait.

### Binary change
Total increase: 1,792 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,973,728 bytes | 30,975,520 bytes | ⚠️ 1,792 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewCell.o | 794,896 bytes | 796,064 bytes | ⚠️ 1,168 bytes |
| BooleanCell.o | 83,352 bytes | 83,976 bytes | ⚠️ 624 bytes |
</details>

### Verification
VO on other cell 
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![IMG_0060](https://github.com/microsoft/fluentui-apple/assets/20715435/11471dfb-9f40-4d72-a946-4493ce0158e7) |![IMG_0059](https://github.com/microsoft/fluentui-apple/assets/20715435/e549cc5f-7f55-42d9-a892-2cc33aafa1c6)|



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2057)