### PR TITLE
Add accessibility for MultilineCommandBarDemo

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/MultilineCommandBarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/MultilineCommandBarDemoController.swift
@@ -37,7 +37,8 @@ class MultilineCommandBarDemoController: DemoController {
                 return CommandBarItem(iconImage: nil, title: command.title, titleFont: command.titleFont)
             default:
                 return CommandBarItem(
-                    iconImage: command.iconImage
+                    iconImage: command.iconImage,
+                    accessibilityLabel: command.rawValue
                 )
             }
         }
@@ -66,7 +67,7 @@ class MultilineCommandBarDemoController: DemoController {
         return MultilineCommandBar(compactRows: compactRows, regularRows: regularRows)
     }()
 
-    enum Command: CaseIterable {
+    enum Command: String, CaseIterable {
         case heading1
         case heading2
         case heading3


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

n/a, demo app only

### Verification

Verified that VoiceOver reads appropriate values in Demo app.


https://github.com/microsoft/fluentui-apple/assets/4934719/91845938-fbe3-4ac9-b689-ad1a1ee7c970



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)