### PR TITLE
[main_0.28] Cherry-pick: Fix Xcode crash by not creating infinitely large views (#2056)

### DIFF
--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -125,8 +125,6 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         addSubview(topSeparator)
         addSubview(bottomSeparator)
 
-        // hide system separator so we can draw our own. We prefer the container UITableView to set separatorStyle = .none
-        separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
         updateHorizontalSeparator(topSeparator, with: topSeparatorType)
         updateHorizontalSeparator(bottomSeparator, with: bottomSeparatorType)
         setupBackgroundColors()
@@ -184,6 +182,14 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         if actionCount > 1 {
             action2Button.frame = CGRect(x: left, y: 0, width: frame.width - left, height: frame.height)
             verticalSeparator.frame = CGRect(x: left, y: 0, width: verticalSeparator.frame.width, height: frame.height)
+        }
+
+        // A hacky way to hide the system separator by squeezing it just enough to have zero width.
+        // This is the only known way to hide the separator without making the UITableView do it for us.
+        let boundsWidth = bounds.width
+        if separatorInset.left != boundsWidth || separatorInset.right != 0 {
+            separatorInset.left = boundsWidth
+            separatorInset.right = 0
         }
 
         layoutHorizontalSeparator(topSeparator, with: topSeparatorType, at: 0)

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1307,8 +1307,6 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         setupBackgroundColors()
 
-        // hide system separator so we can draw our own. We prefer the container UITableView to set separatorStyle = .none
-        separatorInset = UIEdgeInsets(top: 0, left: CGFloat.greatestFiniteMagnitude, bottom: 0, right: 0)
         updateSeparator(topSeparator, with: topSeparatorType)
         updateSeparator(bottomSeparator, with: bottomSeparatorType)
 
@@ -1515,6 +1513,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
 
         layoutContentSubviews()
         contentView.flipSubviewsForRTL()
+
+        // A hacky way to hide the system separator by squeezing it just enough to have zero width.
+        // This is the only known way to hide the separator without making the UITableView do it for us.
+        let boundsWidth = bounds.width
+        if separatorInset.left != boundsWidth || separatorInset.right != 0 {
+            separatorInset.left = boundsWidth
+            separatorInset.right = 0
+        }
 
         layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
         layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)


### PR DESCRIPTION
(cherry picked from commit 0b1431c6dbf9a9ac2b2b200a8221b0a073c63087)

### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2063)