### PR TITLE
Adjust the method for UITableViewCell separator hiding to prevent hangs

### DIFF
--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -187,9 +187,9 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
         // A hacky way to hide the system separator by squeezing it just enough to have zero width.
         // This is the only known way to hide the separator without making the UITableView do it for us.
         let boundsWidth = bounds.width
-        if separatorInset.left != boundsWidth || separatorInset.right != 0 {
-            separatorInset.left = boundsWidth
-            separatorInset.right = 0
+        let targetSystemSeparatorInset = UIEdgeInsets(top: 0, left: boundsWidth, bottom: 0, right: 0)
+        if separatorInset.left < boundsWidth {
+            separatorInset = targetSystemSeparatorInset
         }
 
         layoutHorizontalSeparator(topSeparator, with: topSeparatorType, at: 0)

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1444,9 +1444,9 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         // A hacky way to hide the system separator by squeezing it just enough to have zero width.
         // This is the only known way to hide the separator without making the UITableView do it for us.
         let boundsWidth = bounds.width
-        if separatorInset.left != boundsWidth || separatorInset.right != 0 {
-            separatorInset.left = boundsWidth
-            separatorInset.right = 0
+        let targetSystemSeparatorInset = UIEdgeInsets(top: 0, left: boundsWidth, bottom: 0, right: 0)
+        if separatorInset.left < boundsWidth {
+            separatorInset = targetSystemSeparatorInset
         }
 
         layoutSeparator(topSeparator, with: topSeparatorType, at: 0)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Turns out that the method I previously implemented to keep separator insets at zero frame actually may not work, and can cause a hang because the system sometimes adds its own inset to whatever inset the client sets.

Let's change the logic to:
1. Only set the inset once, not piece-meal
2. Loosen up the condition to cover cases where after setting, the inset may actually be bigger than intended (which is still fine for our purposes).

### Binary change

N/A

### Verification

Sanity in test app that insets are still gone and view debugger still doesn't crash.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2068)