### PR TITLE
[main_0.29] Cherry-pick: New method for separator hiding (#2068)

### DIFF
--- a/ios/FluentUI/Other Cells/ActionsCell.swift
+++ b/ios/FluentUI/Other Cells/ActionsCell.swift
@@ -186,6 +186,14 @@ open class ActionsCell: UITableViewCell, TokenizedControlInternal {
             verticalSeparator.frame = CGRect(x: left, y: 0, width: verticalSeparator.frame.width, height: frame.height)
         }
 
+        // A hacky way to hide the system separator by squeezing it just enough to have zero width.
+        // This is the only known way to hide the separator without making the UITableView do it for us.
+        let boundsWidth = bounds.width
+        let targetSystemSeparatorInset = UIEdgeInsets(top: 0, left: boundsWidth, bottom: 0, right: 0)
+        if separatorInset.left < boundsWidth {
+            separatorInset = targetSystemSeparatorInset
+        }
+
         layoutHorizontalSeparator(topSeparator, with: topSeparatorType, at: 0)
         layoutHorizontalSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)
     }

--- a/ios/FluentUI/Table View/TableViewCell.swift
+++ b/ios/FluentUI/Table View/TableViewCell.swift
@@ -1437,6 +1437,14 @@ open class TableViewCell: UITableViewCell, TokenizedControlInternal {
         layoutContentSubviews()
         contentView.flipSubviewsForRTL()
 
+        // A hacky way to hide the system separator by squeezing it just enough to have zero width.
+        // This is the only known way to hide the separator without making the UITableView do it for us.
+        let boundsWidth = bounds.width
+        let targetSystemSeparatorInset = UIEdgeInsets(top: 0, left: boundsWidth, bottom: 0, right: 0)
+        if separatorInset.left < boundsWidth {
+            separatorInset = targetSystemSeparatorInset
+        }
+
         layoutSeparator(topSeparator, with: topSeparatorType, at: 0)
         layoutSeparator(bottomSeparator, with: bottomSeparatorType, at: frame.height - bottomSeparator.frame.height)
     }


### PR DESCRIPTION
(cherry picked from commit 30b8885f5d563b3a0b32f0c42a203900c2065340)

### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

- #2068 

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2070)