### PR TITLE
[main_0.29] Bumping version to 0.29.2

### DIFF
--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUI'
-  s.version          = '0.29.1'
+  s.version          = '0.29.2'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.29.1</string>
+	<string>1.29.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>137.29.1</string>
+	<string>137.29.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/ios/FluentUI.Resources/Info.plist
+++ b/ios/FluentUI.Resources/Info.plist
@@ -13,8 +13,8 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.29.1</string>
+	<string>0.29.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.29.1</string>
+	<string>0.29.2</string>
 </dict>
 </plist>

--- a/macos/FluentUI/FluentUI-Info.plist
+++ b/macos/FluentUI/FluentUI-Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.29.1</string>
+	<string>0.29.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.29.1</string>
+	<string>0.29.2</string>
 </dict>
 </plist>

--- a/macos/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/macos/FluentUITestApp/FluentUITestApp-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.29.1</string>
+	<string>0.29.2</string>
 	<key>CFBundleVersion</key>
-	<string>62.29.1</string>
+	<string>62.29.2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

- #2070 

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2071)