### PR TITLE
Fix bottom commanding bug where dimming view is still accessible when collapsed 

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -46,8 +46,7 @@ class BottomCommandingDemoController: DemoController {
 
     private lazy var heroItems: [CommandingItem] = {
         return Array(1...25).map {
-            let title = ($0 == 4) ? "Two line item" : "Item"
-            let item = CommandingItem(title: title + String($0), image: homeImage, action: commandAction)
+            let item = CommandingItem(title: "Item " + String($0), image: homeImage, action: commandAction)
             item.selectedImage = homeSelectedImage
             item.isOn = ($0 % 3 == 1)
             item.isEnabled = ($0 % 2 == 1)

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -920,7 +920,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         bottomSheetController.isExpandable = isExpandable
 
         let maxHeroItemHeight = heroCommandStack.arrangedSubviews.map { $0.intrinsicContentSize.height }.max() ?? Constants.defaultHeroButtonHeight
-        let headerHeightWithoutBottomWhitespace = BottomCommandingTokenSet.handleHeaderHeight + maxHeroItemHeight
+        let headerHeightWithoutBottomWhitespace = BottomCommandingTokenSet.headerTopMargin + maxHeroItemHeight
 
         // How much more whitespace is required at the bottom of the sheet header
         let requiredBottomWhitespace = max(0, Constants.BottomSheet.headerHeight - headerHeightWithoutBottomWhitespace)
@@ -933,7 +933,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         let addedHeaderTopMargin = !isExpandable
             ? BottomSheetController.resizingHandleHeight
             : 0
-        bottomSheetHeroStackTopConstraint?.constant = BottomCommandingTokenSet.handleHeaderHeight + addedHeaderTopMargin
+        bottomSheetHeroStackTopConstraint?.constant = BottomCommandingTokenSet.headerTopMargin + addedHeaderTopMargin
 
         let oldCollapsedContentHeight = bottomSheetController.collapsedContentHeight
         let newCollapsedContentHeight = headerHeightWithoutBottomWhitespace + reducedBottomWhitespace + addedHeaderTopMargin

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingController.swift
@@ -402,6 +402,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         headerView.addSubview(heroCommandStack)
 
         let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
+        sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden
         sheetController.shouldAlwaysFillWidth = sheetShouldAlwaysFillWidth
@@ -533,7 +534,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         } else {
             tableView.tableHeaderView = nil
         }
-        calculateHeaderHeight()
     }
 
     private func reloadHeroCommandOverflowStack() {
@@ -561,13 +561,6 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         if isInSheetMode {
             view.setNeedsLayout()
         }
-    }
-
-    @discardableResult
-    private func calculateHeaderHeight() -> CGFloat {
-        let headerHeight = heroCommandStack.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height + BottomSheetController.resizingHandleHeight
-        bottomSheetController?.headerContentHeight = headerHeight
-        return headerHeight
     }
 
     private func updateAppearance() {
@@ -930,7 +923,7 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
         let headerHeightWithoutBottomWhitespace = BottomCommandingTokenSet.handleHeaderHeight + maxHeroItemHeight
 
         // How much more whitespace is required at the bottom of the sheet header
-        let requiredBottomWhitespace = max(0, calculateHeaderHeight() - headerHeightWithoutBottomWhitespace)
+        let requiredBottomWhitespace = max(0, Constants.BottomSheet.headerHeight - headerHeightWithoutBottomWhitespace)
 
         // The safe area inset can fulfill some or all of our bottom whitespace requirement.
         // This is how much more we need, taking the inset into account.
@@ -1124,6 +1117,10 @@ open class BottomCommandingController: UIViewController, TokenizedControlInterna
 
             static let moreButtonIcon: UIImage? = UIImage.staticImageNamed("more-24x24")
             static let moreButtonTitle: String = "CommandingBottomBar.More".localized
+        }
+
+        struct BottomSheet {
+            static let headerHeight: CGFloat = 66
         }
     }
 }

--- a/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
+++ b/ios/FluentUI/Bottom Commanding/BottomCommandingTokenSet.swift
@@ -97,5 +97,5 @@ extension BottomCommandingTokenSet {
     static let tabVerticalPadding: CGFloat = GlobalTokens.spacing(.size80)
     static let tabHorizontalPadding: CGFloat = GlobalTokens.spacing(.size160)
     static let strokeWidth: CGFloat = GlobalTokens.stroke(.width05)
-    static let handleHeaderHeight: CGFloat = GlobalTokens.spacing(.size120)
+    static let headerTopMargin: CGFloat = GlobalTokens.spacing(.size60)
 }

--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -740,6 +740,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 targetAlpha = abs(currentOffset - lowestUndimmedOffset) / (lowestUndimmedOffset - highestDimmedOffset)
             }
         }
+
+        if currentExpansionState != .transitioning {
+            // In the case that there has been a floating point precision error and
+            // targetAlpha is a value very close to 0 or 1, set it explicitly
+            if targetAlpha != 0 || targetAlpha != 1 {
+                targetAlpha = currentExpansionState == .expanded ? 1 : 0
+            }
+        }
+
         dimmingView.alpha = targetAlpha
     }
 
@@ -1050,6 +1059,9 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
 
         bottomSheetView.isHidden = targetExpansionState == .hidden
+
+        updateDimmingViewAlpha()
+        updateDimmingViewAccessibility()
 
         // UIKit doesn't properly handle interrupted constraint animations, so we need to
         // detect and fix a possible desync here


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

We've gotten a bug from clients that even when collapsed, `BottomCommandingController`'s dimming view (which dismisses the sheet when tapped) is still accessible. 

There are some dependent changes in this pr (otherwise I would have opened separate prs) so I've broken it down by commit
- #2041 attempted to fix an issue where two line hero items in `BottomCommandingController` did not have enough padding. This ended up subtly hiding a pre-exisiting bug (the one this pr is solving). Revert this change.
- Actually solve the padding issue.
  - Given our fixed `headerHeight` of 66, the padding between the resizing handle and the hero items should be small enough to allow for two-line titles. This was the original design and somewhere along the shuffle with tokenization, this got lost. See screenshots for the original design.
  - Update the padding to `.size60`. Revert the name back to `headerTopMargin` since it gets confusing with `resizingHandleHeight`
- Fix the accessible dimming view bug. This requires a long explanation:
  - In `BottomCommandingController`, we calculate `collapsedContentHeight` by starting from the height of the `heroCommandStack` and working our way up to the header height. In `BottomSheetController`. we then use `collapsedSheetHeight` to calculate the offset, which we use to calculate the alpha of the dimming view, which we use to determine whether or not the dimming view should be accessible.
  - When `collapsedContentHeight` is a whole number, this is fine. However when it's a decimal, specifically one that can not be precisely represented in binary, we run into issues.
  - Take for example the one line case in bottom commanding.
    - In `updateDimmingViewAlpha`, `currentOffset = 750.6666666666665` and `lowestUndimmedOffset = 750.6666666666666`
    - The `0.0000000000001` difference causes `currentOffset >= lowestUndimmedOffset` to fail
    - `dimmingView.alpha` is set to be a number very close to 0
    - `dimmingView.alpha == 0` fails and our dimming view is left as accessible when it should not
  - The fix?
    - In `updateDimmingViewAlpha`, when `targetAlpha` is expected to be 0 or 1 (all states except `.transitioning`), set it explicitly if that is not the case.
    - When `handleCompletedStateChange` is hit, it was previously assumed that `dimmingView.alpha` would already be 0 or 1. Call `updateDimmingViewAlpha/updateDimmingViewAccessibility` to ensure that is the case.

### Binary change

Total increase: 0 bytes
Total decrease: -1,848 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,087,520 bytes | 31,085,672 bytes | 🎉 -1,848 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomCommandingTokenSet.o | 71,944 bytes | 71,928 bytes | 🎉 -16 bytes |
| BottomSheetController.o | 523,880 bytes | 523,848 bytes | 🎉 -32 bytes |
| __.SYMDEF | 4,805,640 bytes | 4,805,360 bytes | 🎉 -280 bytes |
| BottomCommandingController.o | 837,912 bytes | 836,392 bytes | 🎉 -1,520 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/a46d2966-1e7b-4648-aab7-751579a13382"> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/d21dac14-faa7-4e9f-8e6a-2928ff68a3bf"> |
| <img width="549" alt="two line before" src="https://github.com/user-attachments/assets/89810318-394a-4dc3-84fd-e04551c86183"> | <img width="549" alt="two line after" src="https://github.com/user-attachments/assets/681ceb0d-125c-483f-a8e4-b2944ed0dc8e"> |
| <img width="549" alt="collapsed before" src="https://github.com/user-attachments/assets/8c05a3f4-2287-4769-af4d-7ae009e546bf"> | <img width="549" alt="collapsed after" src="https://github.com/user-attachments/assets/bd9ca177-6cd9-45e7-a4f4-66fd6db7b5ec"> |
| <img width="549" alt="expanded before" src="https://github.com/user-attachments/assets/5a61f685-e817-4350-bbf4-948ba609bfde"> | <img width="549" alt="expanded after" src="https://github.com/user-attachments/assets/35e79f42-8019-4da2-a989-6dbeaf858192"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2072)