### PR TITLE
Ensure TableViewHeaderFooterView has a themed default text color and font style

### DIFF
--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -454,7 +454,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     private func updateTitleViewFont() {
         if let window = window {
             let titleFont = tokenSet[.textFont].uiFont
-            if !isUsingAttributedTitle {
+            if !hasOverriddenAttributedFont {
                 titleView.font = titleFont
             }
 
@@ -479,8 +479,10 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
             backgroundView?.backgroundColor = .clear
         }
 
-        if !isUsingAttributedTitle {
+        if !hasOverriddenAttributedForegroundColor {
             titleView.textColor = tokenSet[.textColor].uiColor
+        }
+        if !hasOverriddenAttributedFont {
             titleView.font = tokenSet[.textFont].uiFont
         }
         titleView.linkColor = tokenSet[.linkTextColor].uiColor
@@ -522,13 +524,25 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         onHeaderViewTapped?()
     }
 
-    private var attributedTitle: NSAttributedString? {
-        didSet {
-            isUsingAttributedTitle = attributedTitle != nil
+    private var attributedTitle: NSAttributedString?
+
+    private var hasOverriddenAttributedForegroundColor: Bool {
+        if let attributes = attributedTitle?.attributes(at: 0, effectiveRange: nil) {
+            return attributes.contains(where: { attr in
+                attr.key == NSAttributedString.Key.foregroundColor
+            })
         }
+        return false
     }
 
-    private var isUsingAttributedTitle: Bool = false
+    private var hasOverriddenAttributedFont: Bool {
+        if let attributes = attributedTitle?.attributes(at: 0, effectiveRange: nil) {
+            return attributes.contains(where: { attr in
+                attr.key == NSAttributedString.Key.font
+            })
+        }
+        return false
+    }
 }
 
 // MARK: - TableViewHeaderFooterView: UITextViewDelegate

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -491,7 +491,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     }
 
     private func updateAttributedTitleWithDefaultFluentThemeAttributes() {
-        if let attributedTitle = self.attributedTitle as? NSMutableAttributedString {
+        if let attributedTitle = self.attributedTitle {
             /// Create an attributed string with the default fluent text color and font for the given style
             let attributedTitleWithFluentTheme = NSMutableAttributedString(string: attributedTitle.string, attributes: [NSAttributedString.Key.foregroundColor: tokenSet[.textColor].uiColor, NSAttributedString.Key.font: tokenSet[.textFont].uiFont])
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Issue: Attributed strings in the `TableViewHeaderFooterView` were showing as black if a foreground color attribute was not provided.

Root Cause: The attributed text color will default to the `textColor` of the `UITextView`. [According to the Apple documentation, the default text color for a `UITextView` is black](https://developer.apple.com/documentation/uikit/uitextview/1618601-textcolor), explaining why we were seeing the text show as black in both light and dark modes

Fix: Check if an attributed foreground color is provided with string. If not, apply the fluent theme text color. Also do the same thing for font.

### Binary change

Total increase: 19,560 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 30,900,560 bytes | 30,920,120 bytes | ⚠️ 19,560 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterView.o | 282,296 bytes | 297,712 bytes | ⚠️ 15,416 bytes |
| __.SYMDEF | 4,744,576 bytes | 4,746,832 bytes | ⚠️ 2,256 bytes |
| FocusRingView.o | 834,848 bytes | 836,576 bytes | ⚠️ 1,728 bytes |
| PopupMenuSectionHeaderView.o | 24,496 bytes | 24,656 bytes | ⚠️ 160 bytes |
</details>

### Verification

- In the demo controller, I validated that an attributed string with both foreground color and font attributes uses the attributes.
- In the demo controller, I validated that an attributed string without a foreground color and font attributes uses the fluent theme colors.
- Validated that the change fixes our internal use case.

<details>
<summary>Visual Verification</summary>

Before change, without attributes applied to string:
![Screenshot 2024-07-24 at 11 04 00 AM](https://github.com/user-attachments/assets/4b2ad671-dd96-4df8-b6d3-4e166b811795)
![Screenshot 2024-07-24 at 11 03 54 AM](https://github.com/user-attachments/assets/f217f29f-8cd3-4493-865c-5397a807cc94)

After change, without attributes applied to string:
![Screenshot 2024-07-24 at 11 05 38 AM](https://github.com/user-attachments/assets/121a77ec-c3ad-4b75-8d64-e5c223d97ab1)
![Screenshot 2024-07-24 at 11 05 42 AM](https://github.com/user-attachments/assets/3f8e51f9-3808-4503-b3fb-d2ad2570c5a5)

After change, with attributes applied to string:
![Screenshot 2024-07-24 at 11 01 04 AM](https://github.com/user-attachments/assets/3237170e-b13d-4b0b-a8fc-8a86b2596feb)
![Screenshot 2024-07-24 at 11 00 57 AM](https://github.com/user-attachments/assets/57b1d06d-7f7d-4432-8f36-0fee7addcbd4)


</details>

### Pull request checklist

This PR has considered:
- [X] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2076)