### PR TITLE
Tell BottomSheet delegate when user starts to pan the sheet

### DIFF
--- a/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
+++ b/ios/FluentUI/Bottom Sheet/BottomSheetController.swift
@@ -32,6 +32,13 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 
     /// Called when `collapsedHeightInSafeArea` changes.
     @objc optional func bottomSheetControllerCollapsedHeightInSafeAreaDidChange(_ bottomSheetController: BottomSheetController)
+
+    /// Called when the user initiates the pan gesture
+    ///
+    ///    - Parameters:
+    ///    - bottomSheetController: The caller object.
+    ///    - expansionState: The expansion state that the sheet moved from
+    @objc optional func bottomSheetStartedPan(_ bottomSheetController: BottomSheetController, from expansionState: BottomSheetExpansionState)
 }
 
 /// Interactions that can trigger a state change.
@@ -765,6 +772,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         switch sender.state {
         case .began:
             completeAnimationsIfNeeded()
+            delegate?.bottomSheetStartedPan?(self, from: currentExpansionState)
             currentExpansionState = .transitioning
             fallthrough
         case .changed:


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS

### Description of changes
Add the delegate method `bottomSheetStartedPan` to BottomSheetController.swift and invoke it when we begin panning the sheet from the users pan gesture.

### Binary change
Total increase: 1,312 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 32,302,600 bytes | 32,303,912 bytes | ⚠️ 1,312 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| BottomSheetController.o | 544,120 bytes | 544,904 bytes | ⚠️ 784 bytes |
| BottomCommandingController.o | 865,200 bytes | 865,464 bytes | ⚠️ 264 bytes |
| FocusRingView.o | 849,608 bytes | 849,872 bytes | ⚠️ 264 bytes |
</details>

### Verification

Tested by hiding the content of the sheet the sheet when the pan gesture starts. 

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2077)