### PR TITLE
Fix anchor and index path of ObjC popup demo

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuObjCDemoController.m
@@ -12,7 +12,7 @@
     self = [super init];
     if (self != nil)
     {
-        _selectedCityIndex = [[NSIndexPath alloc] initWithIndex:0];
+        _selectedCityIndex = [NSIndexPath indexPathForItem:2 inSection:1];
     }
     return self;
 }
@@ -21,7 +21,7 @@
     [super loadView];
     MSFButton *demoButton = [[MSFButton alloc] initWithStyle:MSFButtonStyleOutlineAccent];
     [demoButton setTitle:@"Show PopupMenu" forState:UIControlStateNormal];
-    [demoButton addTarget:self action:@selector(showPopupMenu) forControlEvents:UIControlEventTouchUpInside];
+    [demoButton addTarget:self action:@selector(showPopupMenu:) forControlEvents:UIControlEventTouchUpInside];
 
     UIStackView *stack = [[UIStackView alloc] initWithArrangedSubviews:@[demoButton]];
     [stack setAlignment:UIStackViewAlignmentTop];
@@ -41,7 +41,7 @@
     ]];
 }
 
-- (void)showPopupMenu {
+- (void)showPopupMenu:(id)sender {
     MSFPopupMenuItem *montreal = [[MSFPopupMenuItem alloc] initWithImageName:@"Montreal"
                                                        generateSelectedImage:NO
                                                                        title:@"Montréal"
@@ -112,9 +112,8 @@
                                                                        items:@[montreal, toronto, vancouver]];
     MSFPopupMenuSection *unitedStates = [[MSFPopupMenuSection alloc] initWithTitle:@"United States"
                                                                              items:@[lasVegas, phoenix, sanFrancisco, seattle]];
-    UIView *source = [self view];
-    MSFPopupMenuController *popupMenu = [[MSFPopupMenuController alloc] initWithSourceView:source
-                                                                                sourceRect:[source bounds]
+    MSFPopupMenuController *popupMenu = [[MSFPopupMenuController alloc] initWithSourceView:sender
+                                                                                sourceRect:[sender bounds]
                                                                         presentationOrigin:-1
                                                                      presentationDirection:MSFDrawerPresentationDirectionDown
                                                                     preferredMaximumHeight:-1];


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

The Objective-C demo for PopupMenu wasn't anchoring its popup correctly. Without this change, the popup won't appear due to constraint conflicts. No idea how long this has been broken, but let's fix it. 

While here, I'm also updating the starting selection index path to match the Swift demo.

### Binary change

n/a - demo only change

### Verification

| iPad | iPhone |
|-----|-----|
| ![PopupDemo-iPad](https://github.com/user-attachments/assets/4e8505b4-9b55-4f7a-9718-3a4946349d7c) | ![PopupDemo-iPhone](https://github.com/user-attachments/assets/bde3113a-d5e0-458e-a3a9-a8309d16a652) |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2078)