### PR TITLE
Add disabled trait to tab bar item view

### DIFF
--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -19,13 +19,15 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
 
     override var isEnabled: Bool {
         didSet {
-            isUserInteractionEnabled = isEnabled
-            if isEnabled {
-                accessibilityTraits.remove(.notEnabled)
-            } else {
-                accessibilityTraits.insert(.notEnabled)
+            if isEnabled != oldValue {
+                isUserInteractionEnabled = isEnabled
+                if isEnabled {
+                    accessibilityTraits.remove(.notEnabled)
+                } else {
+                    accessibilityTraits.insert(.notEnabled)
+                }
+                updateColors()
             }
-            updateColors()
         }
     }
 

--- a/ios/FluentUI/Tab Bar/TabBarItemView.swift
+++ b/ios/FluentUI/Tab Bar/TabBarItemView.swift
@@ -20,6 +20,11 @@ class TabBarItemView: UIControl, TokenizedControlInternal {
     override var isEnabled: Bool {
         didSet {
             isUserInteractionEnabled = isEnabled
+            if isEnabled {
+                accessibilityTraits.remove(.notEnabled)
+            } else {
+                accessibilityTraits.insert(.notEnabled)
+            }
             updateColors()
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

When `TabBarItemView` is disabled, VoiceOver/the accessibility inspector do not accurately report that it is disabled. Update it so that we add/remove the `notEnabled` accessibility trait when `isEnabled` changes.

### Binary change

I no longer trust this at all. I triple checked this and somehow adding traits decreases our binary size??? I also confirmed that I wasn't doing the before/after comparison in the wrong direction.

Total increase: 48 bytes
Total decrease: -368 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 32,172,808 bytes | 32,172,488 bytes | 🎉 -320 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| __.SYMDEF | 4,887,416 bytes | 4,887,464 bytes | ⚠️ 48 bytes |
| TabBarItemView.o | 236,952 bytes | 236,584 bytes | 🎉 -368 bytes |
</details>

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1056" alt="before" src="https://github.com/user-attachments/assets/ab24f9b5-05b0-4d30-a353-d235d140e29b"> | <img width="1056" alt="after" src="https://github.com/user-attachments/assets/9d75fd13-2a4b-4544-87f9-7b6b8a5bc58a"> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2079)