### PR TITLE
Add wide accessory view to ShyHeaderView

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -92,7 +92,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithShyAccessoryAndWideAccessory() {
-        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), wideAccessoryView: createWideAccessoryView(), wideAccessoryViewHeight: 50.0, contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), wideAccessoryView: createWideAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithFixedAccessory() {
@@ -198,7 +198,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showWithTopSearchBarWithShyWideAccessoryView() {
-        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), wideAccessoryView: createWideAccessoryView(), wideAccessoryViewHeight: 50.0, showsTopAccessory: true, contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), wideAccessoryView: createWideAccessoryView(), showsTopAccessory: true, contractNavigationBarOnScroll: true)
     }
 
     @objc func showSearchChangingStyleEverySecond() {
@@ -220,7 +220,6 @@ class NavigationControllerDemoController: DemoController {
                                    style: NavigationBar.Style = .primary,
                                    accessoryView: UIView? = nil,
                                    wideAccessoryView: UIView? = nil,
-                                   wideAccessoryViewHeight: CGFloat = 0.0,
                                    showsTopAccessory: Bool = false,
                                    contractNavigationBarOnScroll: Bool = true,
                                    showShadow: Bool = true,
@@ -234,7 +233,6 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
         content.navigationItem.wideAccessoryView = wideAccessoryView
-        content.navigationItem.wideAccessoryViewHeight = wideAccessoryViewHeight
         content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTopAccessoryView = showsTopAccessory
@@ -315,7 +313,7 @@ class NavigationControllerDemoController: DemoController {
         let segmentControl = createSegmentedControl(compatibleWith: .system)
         let stackView = UIStackView()
         stackView.addArrangedSubview(segmentControl)
-        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        stackView.layoutMargins = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
         stackView.isLayoutMarginsRelativeArrangement = true
         stackView.backgroundColor = view.fluentTheme.color(.background1)
         return stackView
@@ -507,6 +505,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     var showsTopAccessoryView: Bool = false
+    var wideAccessoryView: UIView?
 
     var personaData: PersonaData = {
         let personaData = PersonaData(name: "Kat Larsson", image: UIImage(named: "avatar_kat_larsson"))
@@ -862,7 +861,8 @@ extension RootViewController: SearchBarDelegate {
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
         if navigationItem.wideAccessoryView != nil && !showsTopAccessoryView {
-            navigationItem.wideAccessoryViewHeight = 0.0
+            wideAccessoryView = navigationItem.wideAccessoryView
+            navigationItem.wideAccessoryView = nil
         }
     }
 
@@ -871,8 +871,8 @@ extension RootViewController: SearchBarDelegate {
 
     func searchBarDidCancel(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
-        if navigationItem.wideAccessoryView != nil && !showsTopAccessoryView {
-            navigationItem.wideAccessoryViewHeight = 50.0
+        if wideAccessoryView != nil && !showsTopAccessoryView {
+            navigationItem.wideAccessoryView = wideAccessoryView
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -58,7 +58,7 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
 
         addTitle(text: "Top Accessory View with shy wide accessory view")
-        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width with a shy pill segment control", action: #selector(showWithTopSearchBarWithShyWideAccessoryView)))
+        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width with a shy pill segment control", action: #selector(showWithTopSearchBarWithShySecondaryAccessoryView)))
 
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))
@@ -92,7 +92,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showLargeTitleWithShyAccessoryAndWideAccessory() {
-        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), wideAccessoryView: createWideAccessoryView(), contractNavigationBarOnScroll: true)
+        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), secondaryAccessoryView: createSecondaryAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithFixedAccessory() {
@@ -197,8 +197,8 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), showsTopAccessory: true, contractNavigationBarOnScroll: false)
     }
 
-    @objc func showWithTopSearchBarWithShyWideAccessoryView() {
-        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), wideAccessoryView: createWideAccessoryView(), showsTopAccessory: true, contractNavigationBarOnScroll: true)
+    @objc func showWithTopSearchBarWithShySecondaryAccessoryView() {
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), secondaryAccessoryView: createSecondaryAccessoryView(), showsTopAccessory: true, contractNavigationBarOnScroll: true)
     }
 
     @objc func showSearchChangingStyleEverySecond() {
@@ -219,7 +219,7 @@ class NavigationControllerDemoController: DemoController {
                                    subtitle: String? = nil,
                                    style: NavigationBar.Style = .primary,
                                    accessoryView: UIView? = nil,
-                                   wideAccessoryView: UIView? = nil,
+                                   secondaryAccessoryView: UIView? = nil,
                                    showsTopAccessory: Bool = false,
                                    contractNavigationBarOnScroll: Bool = true,
                                    showShadow: Bool = true,
@@ -232,7 +232,7 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.navigationBarStyle = style
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
-        content.navigationItem.wideAccessoryView = wideAccessoryView
+        content.navigationItem.secondaryAccessoryView = secondaryAccessoryView
         content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTopAccessoryView = showsTopAccessory
@@ -309,7 +309,7 @@ class NavigationControllerDemoController: DemoController {
         return searchBar
     }
 
-    private func createWideAccessoryView() -> UIView {
+    private func createSecondaryAccessoryView() -> UIView {
         let segmentControl = createSegmentedControl(compatibleWith: .system)
         let stackView = UIStackView()
         stackView.addArrangedSubview(segmentControl)
@@ -505,7 +505,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
 
     var showsTopAccessoryView: Bool = false
-    var wideAccessoryView: UIView?
+    var secondaryAccessoryView: UIView?
 
     var personaData: PersonaData = {
         let personaData = PersonaData(name: "Kat Larsson", image: UIImage(named: "avatar_kat_larsson"))
@@ -860,9 +860,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 extension RootViewController: SearchBarDelegate {
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
-        if navigationItem.wideAccessoryView != nil && !showsTopAccessoryView {
-            wideAccessoryView = navigationItem.wideAccessoryView
-            navigationItem.wideAccessoryView = nil
+        if navigationItem.secondaryAccessoryView != nil && !showsTopAccessoryView {
+            secondaryAccessoryView = navigationItem.secondaryAccessoryView
+            navigationItem.secondaryAccessoryView = nil
         }
     }
 
@@ -871,8 +871,8 @@ extension RootViewController: SearchBarDelegate {
 
     func searchBarDidCancel(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
-        if wideAccessoryView != nil && !showsTopAccessoryView {
-            navigationItem.wideAccessoryView = wideAccessoryView
+        if secondaryAccessoryView != nil && !showsTopAccessoryView {
+            navigationItem.secondaryAccessoryView = secondaryAccessoryView
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -15,7 +15,7 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Large Title with Primary style")
         container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitle)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithShyAccessory)))
-        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and pill segmented control", action: #selector(showLargeTitleWithShyAccessoryAndWideAccessory)))
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and pill segmented control", action: #selector(showLargeTitleWithShyAccessoryAndSecondaryAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show without an avatar", action: #selector(showLargeTitleWithoutAvatar)))
         container.addArrangedSubview(createButton(title: "Show with a custom leading button", action: #selector(showLargeTitleWithCustomLeadingButton)))
@@ -91,7 +91,7 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
-    @objc func showLargeTitleWithShyAccessoryAndWideAccessory() {
+    @objc func showLargeTitleWithShyAccessoryAndSecondaryAccessory() {
         presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), secondaryAccessoryView: createSecondaryAccessoryView(), contractNavigationBarOnScroll: true)
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -15,6 +15,7 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Large Title with Primary style")
         container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitle)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithShyAccessory)))
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and wide accessory view", action: #selector(showLargeTitleWithShyAccessoryAndWideAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show without an avatar", action: #selector(showLargeTitleWithoutAvatar)))
         container.addArrangedSubview(createButton(title: "Show with a custom leading button", action: #selector(showLargeTitleWithCustomLeadingButton)))
@@ -56,6 +57,9 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Top Accessory View")
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
 
+        addTitle(text: "Top Accessory View with shy wide accessory view")
+        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width with a wide accessory view", action: #selector(showWithTopSearchBarWithShyWideAccessoryView)))
+
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))
     }
@@ -85,6 +89,10 @@ class NavigationControllerDemoController: DemoController {
 
     @objc func showLargeTitleWithShyAccessory() {
         presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
+    }
+
+    @objc func showLargeTitleWithShyAccessoryAndWideAccessory() {
+        presentController(withTitleStyle: .largeLeading, accessoryView: createAccessoryView(), wideAccessoryView: createWideAccessoryView(), wideAccessoryViewHeight: 50.0, contractNavigationBarOnScroll: true)
     }
 
     @objc func showLargeTitleWithFixedAccessory() {
@@ -189,6 +197,10 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), showsTopAccessory: true, contractNavigationBarOnScroll: false)
     }
 
+    @objc func showWithTopSearchBarWithShyWideAccessoryView() {
+        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), wideAccessoryView: createWideAccessoryView(), wideAccessoryViewHeight: 50.0, showsTopAccessory: true, contractNavigationBarOnScroll: true)
+    }
+
     @objc func showSearchChangingStyleEverySecond() {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), showsTopAccessory: true, contractNavigationBarOnScroll: false, updateStylePeriodically: true)
     }
@@ -207,6 +219,8 @@ class NavigationControllerDemoController: DemoController {
                                    subtitle: String? = nil,
                                    style: NavigationBar.Style = .primary,
                                    accessoryView: UIView? = nil,
+                                   wideAccessoryView: UIView? = nil,
+                                   wideAccessoryViewHeight: CGFloat = 0.0,
                                    showsTopAccessory: Bool = false,
                                    contractNavigationBarOnScroll: Bool = true,
                                    showShadow: Bool = true,
@@ -219,6 +233,8 @@ class NavigationControllerDemoController: DemoController {
         content.navigationItem.navigationBarStyle = style
         content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
         content.navigationItem.accessoryView = accessoryView
+        content.navigationItem.wideAccessoryView = wideAccessoryView
+        content.navigationItem.wideAccessoryViewHeight = wideAccessoryViewHeight
         content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
         content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTopAccessoryView = showsTopAccessory
@@ -293,6 +309,16 @@ class NavigationControllerDemoController: DemoController {
         searchBar.style = style
         searchBar.placeholderText = "Search"
         return searchBar
+    }
+
+    private func createWideAccessoryView() -> UIView {
+        let segmentControl = createSegmentedControl(compatibleWith: .system)
+        let stackView = UIStackView()
+        stackView.addArrangedSubview(segmentControl)
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+        stackView.isLayoutMarginsRelativeArrangement = true
+        stackView.backgroundColor = .white
+        return stackView
     }
 
     private func createSegmentedControl(compatibleWith style: NavigationBar.Style) -> UIView {
@@ -835,6 +861,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 extension RootViewController: SearchBarDelegate {
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
+        if navigationItem.wideAccessoryView != nil && !showsTopAccessoryView {
+            navigationItem.wideAccessoryViewHeight = 0.0
+        }
     }
 
     func searchBar(_ searchBar: SearchBar, didUpdateSearchText newSearchText: String?) {
@@ -842,6 +871,9 @@ extension RootViewController: SearchBarDelegate {
 
     func searchBarDidCancel(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
+        if navigationItem.wideAccessoryView != nil && !showsTopAccessoryView {
+            navigationItem.wideAccessoryViewHeight = 50.0
+        }
     }
 
     func searchBarDidRequestSearch(_ searchBar: SearchBar) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -15,7 +15,7 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Large Title with Primary style")
         container.addArrangedSubview(createButton(title: "Show without accessory", action: #selector(showLargeTitle)))
         container.addArrangedSubview(createButton(title: "Show with collapsible search bar", action: #selector(showLargeTitleWithShyAccessory)))
-        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and wide accessory view", action: #selector(showLargeTitleWithShyAccessoryAndWideAccessory)))
+        container.addArrangedSubview(createButton(title: "Show with collapsible search bar and pill segmented control", action: #selector(showLargeTitleWithShyAccessoryAndWideAccessory)))
         container.addArrangedSubview(createButton(title: "Show with fixed search bar", action: #selector(showLargeTitleWithFixedAccessory)))
         container.addArrangedSubview(createButton(title: "Show without an avatar", action: #selector(showLargeTitleWithoutAvatar)))
         container.addArrangedSubview(createButton(title: "Show with a custom leading button", action: #selector(showLargeTitleWithCustomLeadingButton)))
@@ -58,7 +58,7 @@ class NavigationControllerDemoController: DemoController {
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
 
         addTitle(text: "Top Accessory View with shy wide accessory view")
-        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width with a wide accessory view", action: #selector(showWithTopSearchBarWithShyWideAccessoryView)))
+        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width with a shy pill segment control", action: #selector(showWithTopSearchBarWithShyWideAccessoryView)))
 
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -315,9 +315,9 @@ class NavigationControllerDemoController: DemoController {
         let segmentControl = createSegmentedControl(compatibleWith: .system)
         let stackView = UIStackView()
         stackView.addArrangedSubview(segmentControl)
-        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+        stackView.layoutMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.backgroundColor = .white
+        stackView.backgroundColor = view.fluentTheme.color(.background1)
         return stackView
     }
 

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -46,7 +46,6 @@ class ShyHeaderController: UIViewController {
 
     private var accessoryViewObservation: NSKeyValueObservation?
     private var wideAccessoryViewObservation: NSKeyValueObservation?
-    private var wideAccessoryViewHeightObservation: NSKeyValueObservation?
 
     private var navigationBarCenterObservation: NSKeyValueObservation?
     private var navigationBarStyleObservation: NSKeyValueObservation?
@@ -106,10 +105,6 @@ class ShyHeaderController: UIViewController {
 
         wideAccessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.wideAccessoryView) { [weak self] item, _ in
             self?.shyHeaderView.wideAccessoryView = item.wideAccessoryView
-        }
-
-        wideAccessoryViewHeightObservation = contentViewController.navigationItem.observe(\UINavigationItem.wideAccessoryViewHeight) { [weak self] item, _ in
-            self?.shyHeaderView.wideAccessoryViewHeight = item.wideAccessoryViewHeight
         }
     }
 
@@ -221,10 +216,10 @@ class ShyHeaderController: UIViewController {
     }
 
     private func setupShyHeaderView() {
-        shyHeaderView.accessoryView = contentViewController.navigationItem.accessoryView
-        shyHeaderView.wideAccessoryView = contentViewController.navigationItem.wideAccessoryView
-        shyHeaderView.wideAccessoryViewHeight = contentViewController.navigationItem.wideAccessoryViewHeight
-        shyHeaderView.navigationBarShadow = contentViewController.navigationItem.navigationBarShadow
+        let navigationItem = contentViewController.navigationItem
+        shyHeaderView.accessoryView = navigationItem.accessoryView
+        shyHeaderView.wideAccessoryView = navigationItem.wideAccessoryView
+        shyHeaderView.navigationBarShadow = navigationItem.navigationBarShadow
         shyHeaderView.paddingView = paddingView
         shyHeaderView.parentController = self
         shyHeaderView.maxHeightChanged = { [weak self] in

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -45,6 +45,8 @@ class ShyHeaderController: UIViewController {
     }
 
     private var accessoryViewObservation: NSKeyValueObservation?
+    private var wideAccessoryViewObservation: NSKeyValueObservation?
+    private var wideAccessoryViewHeightObservation: NSKeyValueObservation?
 
     private var navigationBarCenterObservation: NSKeyValueObservation?
     private var navigationBarStyleObservation: NSKeyValueObservation?
@@ -100,6 +102,14 @@ class ShyHeaderController: UIViewController {
 
         accessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.accessoryView) { [weak self] item, _ in
             self?.shyHeaderView.accessoryView = item.accessoryView
+        }
+
+        wideAccessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.wideAccessoryView) { [weak self] item, _ in
+            self?.shyHeaderView.wideAccessoryView = item.wideAccessoryView
+        }
+
+        wideAccessoryViewHeightObservation = contentViewController.navigationItem.observe(\UINavigationItem.wideAccessoryViewHeight) { [weak self] item, _ in
+            self?.shyHeaderView.wideAccessoryViewHeight = item.wideAccessoryViewHeight
         }
     }
 
@@ -212,6 +222,8 @@ class ShyHeaderController: UIViewController {
 
     private func setupShyHeaderView() {
         shyHeaderView.accessoryView = contentViewController.navigationItem.accessoryView
+        shyHeaderView.wideAccessoryView = contentViewController.navigationItem.wideAccessoryView
+        shyHeaderView.wideAccessoryViewHeight = contentViewController.navigationItem.wideAccessoryViewHeight
         shyHeaderView.navigationBarShadow = contentViewController.navigationItem.navigationBarShadow
         shyHeaderView.paddingView = paddingView
         shyHeaderView.parentController = self

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderController.swift
@@ -45,7 +45,7 @@ class ShyHeaderController: UIViewController {
     }
 
     private var accessoryViewObservation: NSKeyValueObservation?
-    private var wideAccessoryViewObservation: NSKeyValueObservation?
+    private var secondaryAccessoryViewObservation: NSKeyValueObservation?
 
     private var navigationBarCenterObservation: NSKeyValueObservation?
     private var navigationBarStyleObservation: NSKeyValueObservation?
@@ -103,8 +103,8 @@ class ShyHeaderController: UIViewController {
             self?.shyHeaderView.accessoryView = item.accessoryView
         }
 
-        wideAccessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.wideAccessoryView) { [weak self] item, _ in
-            self?.shyHeaderView.wideAccessoryView = item.wideAccessoryView
+        secondaryAccessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.secondaryAccessoryView) { [weak self] item, _ in
+            self?.shyHeaderView.secondaryAccessoryView = item.secondaryAccessoryView
         }
     }
 
@@ -218,7 +218,7 @@ class ShyHeaderController: UIViewController {
     private func setupShyHeaderView() {
         let navigationItem = contentViewController.navigationItem
         shyHeaderView.accessoryView = navigationItem.accessoryView
-        shyHeaderView.wideAccessoryView = navigationItem.wideAccessoryView
+        shyHeaderView.secondaryAccessoryView = navigationItem.secondaryAccessoryView
         shyHeaderView.navigationBarShadow = navigationItem.navigationBarShadow
         shyHeaderView.paddingView = paddingView
         shyHeaderView.parentController = self

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -143,12 +143,12 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         }
     }
 
-    var wideAccessoryView: UIView? {
+    var secondaryAccessoryView: UIView? {
         willSet {
-            wideAccessoryView?.removeFromSuperview()
+            secondaryAccessoryView?.removeFromSuperview()
         }
         didSet {
-            if let newContentView = wideAccessoryView {
+            if let newContentView = secondaryAccessoryView {
                 wideContentStackView.addArrangedSubview(newContentView)
             }
             maxHeightChanged?()
@@ -163,17 +163,17 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         }
     }
 
-    var wideAccessoryViewHeight: CGFloat {
-        guard let wideAccessoryView else {
+    var secondaryAccessoryViewHeight: CGFloat {
+        guard let secondaryAccessoryView else {
             return 0.0
         }
 
-        let wideAccessoryViewSize = wideAccessoryView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
-        return wideAccessoryViewSize.height
+        let secondaryAccessoryViewSize = secondaryAccessoryView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        return secondaryAccessoryViewSize.height
     }
 
     var maxHeight: CGFloat {
-        return accessoryViewHeight + wideAccessoryViewHeight
+        return accessoryViewHeight + secondaryAccessoryViewHeight
     }
 
     private var maxHeightNoAccessory: CGFloat {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -72,7 +72,7 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         tokenSet.registerOnUpdate(for: self) { [weak self] in
             self?.updateColors()
         }
-        self.initWideContentStackView()
+        self.initSecondaryContentStackView()
     }
 
     override func willMove(toWindow newWindow: UIWindow?) {
@@ -126,11 +126,11 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         willSet {
             accessoryView?.removeFromSuperview()
             contentStackView.removeFromSuperview()
-            // When there is no accessoryView, the top anchor of the wideContentStackView should be equal to
+            // When there is no accessoryView, the top anchor of the secondaryContentStackView should be equal to
             // the top anchor of the parent view.
-            if let wideContentStackViewTopAnchorConstraint {
+            if let secondaryContentStackViewTopAnchorConstraint {
                 NSLayoutConstraint.activate([
-                    wideContentStackViewTopAnchorConstraint
+                    secondaryContentStackViewTopAnchorConstraint
                 ])
             }
         }
@@ -149,7 +149,7 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         }
         didSet {
             if let newContentView = secondaryAccessoryView {
-                wideContentStackView.addArrangedSubview(newContentView)
+                secondaryContentStackView.addArrangedSubview(newContentView)
             }
             maxHeightChanged?()
         }
@@ -221,8 +221,8 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
 
     private let contentStackView = UIStackView()
     private var contentStackViewHeightConstraint: NSLayoutConstraint?
-    private let wideContentStackView = UIStackView()
-    private var wideContentStackViewTopAnchorConstraint: NSLayoutConstraint?
+    private let secondaryContentStackView = UIStackView()
+    private var secondaryContentStackViewTopAnchorConstraint: NSLayoutConstraint?
     private let shadow = Separator()
 
     private var needsShadow: Bool {
@@ -262,11 +262,11 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentStackView)
 
-        // When there is a accessoryView, the top anchor of the wideContentStackView should be equal to
+        // When there is a accessoryView, the top anchor of the secondaryContentStackView should be equal to
         // the bottom anchor of contentStackView.
-        if let wideContentStackViewTopAnchorConstraint {
+        if let secondaryContentStackViewTopAnchorConstraint {
             NSLayoutConstraint.deactivate([
-                wideContentStackViewTopAnchorConstraint
+                secondaryContentStackViewTopAnchorConstraint
             ])
         }
 
@@ -276,26 +276,26 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
             contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             contentStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             contentStackView.topAnchor.constraint(equalTo: topAnchor),
-            contentStackView.bottomAnchor.constraint(equalTo: wideContentStackView.topAnchor),
+            contentStackView.bottomAnchor.constraint(equalTo: secondaryContentStackView.topAnchor),
             heightConstraint
         ])
         updateContentInsets()
         contentStackView.addInteraction(UILargeContentViewerInteraction())
     }
 
-    private func initWideContentStackView() {
-        wideContentStackView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(wideContentStackView)
-        let topAnchorConstraint = wideContentStackView.topAnchor.constraint(equalTo: topAnchor)
-        wideContentStackViewTopAnchorConstraint = topAnchorConstraint
+    private func initSecondaryContentStackView() {
+        secondaryContentStackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(secondaryContentStackView)
+        let topAnchorConstraint = secondaryContentStackView.topAnchor.constraint(equalTo: topAnchor)
+        secondaryContentStackViewTopAnchorConstraint = topAnchorConstraint
         NSLayoutConstraint.activate([
-            wideContentStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            wideContentStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            secondaryContentStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            secondaryContentStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             topAnchorConstraint,
-            wideContentStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            secondaryContentStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
 
-        wideContentStackView.addInteraction(UILargeContentViewerInteraction())
+        secondaryContentStackView.addInteraction(UILargeContentViewerInteraction())
     }
 
     private func initShadow() {

--- a/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
+++ b/ios/FluentUI/Navigation/Shy Header/ShyHeaderView.swift
@@ -126,6 +126,8 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         willSet {
             accessoryView?.removeFromSuperview()
             contentStackView.removeFromSuperview()
+            // When there is no accessoryView, the top anchor of the wideContentStackView should be equal to
+            // the top anchor of the parent view.
             if let wideContentStackViewTopAnchorConstraint {
                 NSLayoutConstraint.activate([
                     wideContentStackViewTopAnchorConstraint
@@ -149,6 +151,7 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
             if let newContentView = wideAccessoryView {
                 wideContentStackView.addArrangedSubview(newContentView)
             }
+            maxHeightChanged?()
         }
     }
 
@@ -160,10 +163,13 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         }
     }
 
-    var wideAccessoryViewHeight: CGFloat = 0.0 {
-        didSet {
-            maxHeightChanged?()
+    var wideAccessoryViewHeight: CGFloat {
+        guard let wideAccessoryView else {
+            return 0.0
         }
+
+        let wideAccessoryViewSize = wideAccessoryView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        return wideAccessoryViewSize.height
     }
 
     var maxHeight: CGFloat {
@@ -256,6 +262,8 @@ class ShyHeaderView: UIView, TokenizedControlInternal {
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentStackView)
 
+        // When there is a accessoryView, the top anchor of the wideContentStackView should be equal to
+        // the bottom anchor of contentStackView.
         if let wideContentStackViewTopAnchorConstraint {
             NSLayoutConstraint.deactivate([
                 wideContentStackViewTopAnchorConstraint

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -8,6 +8,7 @@ import UIKit
 @objc public extension UINavigationItem {
     private struct AssociatedKeys {
         static var accessoryView: UInt8 = 0
+        static var secondaryAccessoryView: UInt8 = 0
         static var titleAccessory: UInt8 = 0
         static var titleImage: UInt8 = 0
         static var topAccessoryView: UInt8 = 0
@@ -20,7 +21,6 @@ import UIKit
         static var customNavigationBarColor: UInt8 = 0
         static var customSubtitleTrailingImage: UInt8 = 0
         static var isTitleImageLeadingForTitleAndSubtitle: UInt8 = 0
-        static var wideAccessoryView: UInt8 = 0
     }
 
     var accessoryView: UIView? {
@@ -35,12 +35,12 @@ import UIKit
     /// An wide accessory view that can be shown as a subview of ShyHeaderView but doesn't have leading, trailing
     /// and bottom insets. So it can appear as being part of the content view but still contract and expand as part of
     /// the shy header.
-    var wideAccessoryView: UIView? {
+    var secondaryAccessoryView: UIView? {
         get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.wideAccessoryView) as? UIView
+            return objc_getAssociatedObject(self, &AssociatedKeys.secondaryAccessoryView) as? UIView
         }
         set {
-            objc_setAssociatedObject(self, &AssociatedKeys.wideAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+            objc_setAssociatedObject(self, &AssociatedKeys.secondaryAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -21,7 +21,6 @@ import UIKit
         static var customSubtitleTrailingImage: UInt8 = 0
         static var isTitleImageLeadingForTitleAndSubtitle: UInt8 = 0
         static var wideAccessoryView: UInt8 = 0
-        static var wideAccessoryViewHeight: CGFloat = 0.0
     }
 
     var accessoryView: UIView? {
@@ -42,16 +41,6 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.wideAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-
-    /// The height of the wideAccessoryView.
-    var wideAccessoryViewHeight: CGFloat {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.wideAccessoryViewHeight) as? CGFloat ?? 0.0
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.wideAccessoryViewHeight, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 

--- a/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
+++ b/ios/FluentUI/Navigation/UINavigationItem+Navigation.swift
@@ -20,6 +20,8 @@ import UIKit
         static var customNavigationBarColor: UInt8 = 0
         static var customSubtitleTrailingImage: UInt8 = 0
         static var isTitleImageLeadingForTitleAndSubtitle: UInt8 = 0
+        static var wideAccessoryView: UInt8 = 0
+        static var wideAccessoryViewHeight: CGFloat = 0.0
     }
 
     var accessoryView: UIView? {
@@ -28,6 +30,28 @@ import UIKit
         }
         set {
             objc_setAssociatedObject(self, &AssociatedKeys.accessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    /// An wide accessory view that can be shown as a subview of ShyHeaderView but doesn't have leading, trailing
+    /// and bottom insets. So it can appear as being part of the content view but still contract and expand as part of
+    /// the shy header.
+    var wideAccessoryView: UIView? {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.wideAccessoryView) as? UIView
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.wideAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
+    /// The height of the wideAccessoryView.
+    var wideAccessoryViewHeight: CGFloat {
+        get {
+            return objc_getAssociatedObject(self, &AssociatedKeys.wideAccessoryViewHeight) as? CGFloat ?? 0.0
+        }
+        set {
+            objc_setAssociatedObject(self, &AssociatedKeys.wideAccessoryViewHeight, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Based on my understanding, the current shy header behavior has 2 limitations:
(1) The accessory view is expected to be a SearchBar
(2) The accessory view has an inset on 4 edges so that the accessory view will always looks like it's part of the shy header. This is very obvious when the shy header has a background color.
Now the issue is sometimes we want to make other views to hide and appear when users scroll as well, but we don't want them to have the header background color. 

So to solve this problem, in `ShyHeaderView` I added a `wideAccessoryView`, which sits at the bottom of the `ShyHeaderView`. It can be set with or without an accessory view. As a result, on iPhone where there is an `accessoryView`(`SearchBar`), both the `SearchBar` and the `wideAccessoryView` will shy; and on iPad where there is a `topAccessoryView`(`SearchBar`) then only `wideAccessoryView` will shy. So as to matching the design.

Also I make the `wideAccessoryView` such that it doesn't have leading, trailing, and bottom inset. As a result, the client code can set the background color of it to match the content view controller so that it doesn't look like a part of header(otherwise the header could look too massive).

### Binary change

Small code change, no assets, no SwiftUI added. So I don't think there will be a binary change concern.

### Verification

- Added two buttons in `NavigationControllerDemoController`:
"Show with collapsible search bar and pill segmented control", 
https://github.com/user-attachments/assets/832e4714-c820-474c-b274-23447e809797
Note that now both the search bar and the pill segment control will shy when user scrolls. And when user taps on the search bar, the pill segment control will contract as well.

"Show with top search bar for large screen width with a shy pill segment control"
https://github.com/user-attachments/assets/148ad5f0-a2a5-43b3-a696-57323149c00f
Note that the search bar doesn't shy because it's a `topAccessoryView` not `accessoryView`, and only the pill segment control will shy. And when user taps on the search bar, the pill segment control doesn't appear.

- Also verified that switching between iPad regular and compact mode works well, i.e. handling adding and removing `accessoryView` is working as expected:
https://github.com/user-attachments/assets/202d4cee-36da-40f6-bfed-ac1f5ddf3c2a

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)