### PR TITLE
New Avatar API: `hasBackgroundOutline`

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController.swift
@@ -54,7 +54,7 @@ class AvatarDemoController: DemoTableViewController {
              .presence,
              .activity,
              .ringInnerGap,
-             .transparency,
+             .backgroundOutline,
              .defaultImage:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
@@ -277,11 +277,11 @@ class AvatarDemoController: DemoTableViewController {
         }
     }
 
-    private var isTransparent: Bool = true {
+    private var hasBackgroundOutline: Bool = false {
         didSet {
-            if oldValue != isTransparent {
+            if oldValue != hasBackgroundOutline {
                 allDemoAvatarsCombined.forEach { avatar in
-                    avatar.state.isTransparent = isTransparent
+                    avatar.state.hasBackgroundOutline = hasBackgroundOutline
                 }
             }
         }
@@ -406,8 +406,8 @@ class AvatarDemoController: DemoTableViewController {
             return self.isShowingRings
         case .ringInnerGap:
             return self.isShowingRingInnerGap
-        case .transparency:
-            return self.isTransparent
+        case .backgroundOutline:
+            return self.hasBackgroundOutline
         case .defaultImage:
             return self.useCustomDefaultImage
         }
@@ -444,8 +444,8 @@ class AvatarDemoController: DemoTableViewController {
             self.isShowingRings = isOn
         case .ringInnerGap:
             self.isShowingRingInnerGap = isOn
-        case .transparency:
-            self.isTransparent = isOn
+        case .backgroundOutline:
+            self.hasBackgroundOutline = isOn
         case .defaultImage:
             self.useCustomDefaultImage = isOn
         }
@@ -518,7 +518,7 @@ class AvatarDemoController: DemoTableViewController {
                 return [.animating,
                         .alternateBackground,
                         .pointerInteraction,
-                        .transparency,
+                        .backgroundOutline,
                         .presence,
                         .activity,
                         .outOfOffice,
@@ -566,7 +566,7 @@ class AvatarDemoController: DemoTableViewController {
         case ring
         case ringInnerGap
         case swiftUIDemo
-        case transparency
+        case backgroundOutline
         case defaultImage
 
         var isDemoRow: Bool {
@@ -591,7 +591,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency,
+                 .backgroundOutline,
                  .defaultImage:
                 return false
             }
@@ -620,7 +620,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency,
+                 .backgroundOutline,
                  .defaultImage:
                 return nil
             }
@@ -651,7 +651,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency,
+                 .backgroundOutline,
                  .defaultImage:
                 return nil
             }
@@ -684,7 +684,7 @@ class AvatarDemoController: DemoTableViewController {
                  .ring,
                  .ringInnerGap,
                  .swiftUIDemo,
-                 .transparency,
+                 .backgroundOutline,
                  .defaultImage:
                 preconditionFailure("Row does not have an associated avatar style")
             }
@@ -730,8 +730,8 @@ class AvatarDemoController: DemoTableViewController {
                 return "Set ring inner gap"
             case .swiftUIDemo:
                 return "SwiftUI Demo"
-            case .transparency:
-                return "Use transparency"
+            case .backgroundOutline:
+                return "Use background outline"
             case .defaultImage:
                 return "Use custom default image"
             }

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarDemoController_SwiftUI.swift
@@ -36,7 +36,7 @@ struct AvatarDemoView: View {
     @State var isAnimated: Bool = true
     @State var isOutOfOffice: Bool = false
     @State var isRingVisible: Bool = true
-    @State var isTransparent: Bool = true
+    @State var hasBackgroundOutline: Bool = false
     @State var hasPointerInteraction: Bool = false
     @State var hasRingInnerGap: Bool = true
     @State var primaryText: String = "Kat Larsson"
@@ -66,11 +66,11 @@ struct AvatarDemoView: View {
                    image: showImage ? UIImage(named: "avatar_kat_larsson") : nil,
                    primaryText: primaryText,
                    secondaryText: secondaryText)
-                .isRingVisible(showImageBasedRingColor || isRingVisible)
+                .isRingVisible(isRingVisible)
                 .hasRingInnerGap(hasRingInnerGap)
                 .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
                 .defaultImage(defaultImage)
-                .isTransparent(isTransparent)
+                .hasBackgroundOutline(hasBackgroundOutline)
                 .presence(presence)
                 .activity(activityStyle, showActivityImage ? (activityStyle == .circle ? UIImage(named: "thumbs_up_3d_default") : UIImage(named: "excelIcon")) : nil)
                 .isOutOfOffice(isOutOfOffice)
@@ -101,7 +101,7 @@ struct AvatarDemoView: View {
 
                         FluentUIDemoToggle(titleKey: "Set image", isOn: $showImage)
                         FluentUIDemoToggle(titleKey: "Set alternate background", isOn: $useAlternateBackground)
-                        FluentUIDemoToggle(titleKey: "Transparency", isOn: $isTransparent)
+                        FluentUIDemoToggle(titleKey: "Has background border", isOn: $hasBackgroundOutline)
                         FluentUIDemoToggle(titleKey: "iPad Pointer interaction", isOn: $hasPointerInteraction)
                         FluentUIDemoToggle(titleKey: "Animate transitions", isOn: $isAnimated)
                         FluentUIDemoToggle(titleKey: "Use custom default image", isOn: $useCustomDefaultImage)

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController.swift
@@ -71,28 +71,15 @@ class AvatarGroupDemoController: DemoTableViewController {
 
             return cell
 
-        case .alternateBackground:
+        case .alternateBackground, .customRingColor, .hasBackgroundOutline:
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
                 return UITableViewCell()
             }
 
-            cell.setup(title: row.title, isOn: self.isUsingAlternateBackgroundColor)
+            cell.setup(title: row.title, isOn: row.booleanValue(self))
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
-                self?.isUsingAlternateBackgroundColor = cell?.isOn ?? true
-            }
-
-            return cell
-
-        case .customRingColor:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier) as? BooleanCell else {
-                return UITableViewCell()
-            }
-
-            cell.setup(title: row.title, isOn: self.isUsingImageBasedCustomColor)
-            cell.titleNumberOfLines = 0
-            cell.onValueChanged = { [weak self, weak cell] in
-                self?.isUsingImageBasedCustomColor = cell?.isOn ?? true
+                row.setBooleanValue(self, cell?.isOn ?? true)
             }
 
             return cell
@@ -168,7 +155,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 cell.contentView.trailingAnchor.constraint(equalTo: avatarGroupView.trailingAnchor, constant: 20)
             ])
 
-            cell.backgroundConfiguration?.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor : TableViewCell.tableCellBackgroundColor
+            cell.backgroundColor = self.isUsingAlternateBackgroundColor ? TableViewCell.tableCellBackgroundSelectedColor : TableViewCell.tableCellBackgroundColor
 
             return cell
         }
@@ -272,6 +259,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                 return [.avatarCount,
                         .alternateBackground,
                         .customRingColor,
+                        .hasBackgroundOutline,
                         .maxDisplayedAvatars,
                         .overflow]
             case .avatarStackNoActivityRing,
@@ -303,6 +291,7 @@ class AvatarGroupDemoController: DemoTableViewController {
         case avatarCount
         case alternateBackground
         case customRingColor
+        case hasBackgroundOutline
         case maxDisplayedAvatars
         case overflow
         case titleSize72
@@ -340,6 +329,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .avatarCount,
                  .alternateBackground,
                  .customRingColor,
+                 .hasBackgroundOutline,
                  .maxDisplayedAvatars,
                  .overflow,
                  .swiftUIDemo:
@@ -373,6 +363,7 @@ class AvatarGroupDemoController: DemoTableViewController {
                  .avatarCount,
                  .alternateBackground,
                  .customRingColor,
+                 .hasBackgroundOutline,
                  .maxDisplayedAvatars,
                  .overflow,
                  .swiftUIDemo:
@@ -390,7 +381,9 @@ class AvatarGroupDemoController: DemoTableViewController {
                 return "Use alternate background color"
             case .customRingColor:
                 return "Use image based custom ring color"
-            case.maxDisplayedAvatars:
+            case .hasBackgroundOutline:
+                return "Has background outline"
+            case .maxDisplayedAvatars:
                 return "Max displayed avatars"
             case .overflow:
                 return "Overflow count"
@@ -418,6 +411,38 @@ class AvatarGroupDemoController: DemoTableViewController {
                 preconditionFailure("Row should not have title")
             }
         }
+
+        func booleanValue(_ controller: AvatarGroupDemoController?) -> Bool {
+            guard let controller else {
+                return false
+            }
+            switch self {
+            case .alternateBackground:
+                return controller.isUsingAlternateBackgroundColor
+            case .customRingColor:
+                return controller.isUsingImageBasedCustomColor
+            case .hasBackgroundOutline:
+                return controller.isUsingBackgroundOutline
+            default:
+                assertionFailure("Cannot get boolean value for non-boolean row")
+                return false
+            }
+        }
+
+        func setBooleanValue(_ controller: AvatarGroupDemoController?, _ value: Bool) {
+            switch self {
+            case .alternateBackground:
+                controller?.isUsingAlternateBackgroundColor = value
+            case .customRingColor:
+                controller?.isUsingImageBasedCustomColor = value
+            case .hasBackgroundOutline:
+                controller?.isUsingBackgroundOutline = value
+            default:
+                assertionFailure("Cannot set boolean value for non-boolean row")
+                return
+            }
+        }
+
     }
 
     private var maxDisplayedAvatars: Int = 3 {
@@ -578,6 +603,14 @@ class AvatarGroupDemoController: DemoTableViewController {
     private var isUsingImageBasedCustomColor: Bool = false {
         didSet {
             updateAvatarsCustomRingColor(for: 0..<avatarCount)
+        }
+    }
+
+    private var isUsingBackgroundOutline: Bool = false {
+        didSet {
+            for group in allDemoAvatarGroupsCombined {
+                group.state.hasBackgroundOutline = isUsingBackgroundOutline
+            }
         }
     }
 

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarGroupDemoController_SwiftUI.swift
@@ -29,16 +29,18 @@ struct AvatarGroupDemoView: View {
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
 
-    @State var useAlternateBackground: Bool = false
+    @State var useAlternateBackground: Bool = true
 
     // Avatar settings
     @State var isRingVisible: Bool = false
     @State var showImage: Bool = true
     @State var showImageBasedRingColor: Bool = false
+    @State var hasRingInnerGap: Bool = true
 
     // AvatarGroup settings
     @State var maxDisplayedAvatars: Int = startingMaxDisplayedAvatars
     @State var overflowCount: Int = 0
+    @State var hasBackgroundOutline: Bool = false
     @State var isUnread: Bool = false
     @State var size: MSFAvatarSize = AvatarGroupDemoView.defaultSize
     @State var style: MSFAvatarGroupStyle = .stack
@@ -53,6 +55,7 @@ struct AvatarGroupDemoView: View {
                primaryText: samplePersona.name,
                secondaryText: samplePersona.email)
         .isRingVisible(isRingVisible)
+        .hasRingInnerGap(hasRingInnerGap)
         .imageBasedRingColor(showImageBasedRingColor ? AvatarDemoController.colorfulCustomImage : nil)
     }
 
@@ -65,6 +68,7 @@ struct AvatarGroupDemoView: View {
                             avatarCount: avatarCount,
                             maxDisplayedAvatars: maxDisplayedAvatars,
                             overflowCount: overflowCount,
+                            hasBackgroundOutline: hasBackgroundOutline,
                             isUnread: isUnread) { index in
                     avatarFromSamplePersona(index)
                 }.fixedSize()
@@ -76,6 +80,7 @@ struct AvatarGroupDemoView: View {
                     Stepper("Avatar Count: \(avatarCount)", value: $avatarCount, in: (0...Int.max))
                     Stepper("Max Displayed Avatars: \(maxDisplayedAvatars)", value: $maxDisplayedAvatars)
                     Stepper("Overflow Count: \(overflowCount)", value: $overflowCount)
+                    Toggle("Has Background Outline", isOn: $hasBackgroundOutline)
                     Toggle("Show Avatar Images", isOn: $showImage)
                     Toggle("Unread Dot", isOn: $isUnread)
                     Toggle("Alternate Background", isOn: $useAlternateBackground)
@@ -84,6 +89,7 @@ struct AvatarGroupDemoView: View {
                 FluentListSection("Ring") {
                     Toggle("Ring Visible", isOn: $isRingVisible)
                     Toggle("Image Based Ring Color", isOn: $showImageBasedRingColor)
+                    Toggle("Has Ring Inner Gap", isOn: $hasRingInnerGap)
                 }
 
                 FluentListSection("Style") {

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -49,7 +49,12 @@ import SwiftUI
 
     /// Sets the transparency of the avatar elements (inner and outer ring gaps, presence, and activity icon outline).
     /// Uses the solid default background color if set to false.
+    @available(iOS, deprecated, message: "Transparency is deprecated, and will default to `false`. This property will be removed in a future version of Fluent.")
     var isTransparent: Bool { get set }
+
+    /// Whether a background-colored outline should be drawn behind the avatar.
+    /// Uses the solid default background color if set to true.
+    var hasBackgroundOutline: Bool { get set }
 
     /// Defines the presence displayed by the Avatar.
     /// Image displayed depends on the value of the isOutOfOffice property.
@@ -134,6 +139,7 @@ public struct Avatar: View, TokenizedControlView, Equatable {
         let cornerRadius = shouldDisplayActivity ? (activityStyle == .square ? AvatarTokenSet.activityIconRadius(size) : .infinity) : .infinity
         let isRingVisible = state.isRingVisible
         let hasRingInnerGap = state.hasRingInnerGap
+        let hasBackgroundOutline = state.hasBackgroundOutline
         let ringThicknessToken: CGFloat = tokenSet[.ringThickness].float
         let accessoryBorderThicknessToken: CGFloat = tokenSet[.borderThickness].float
         let accessoryBorderColorToken: UIColor = tokenSet[.borderColor].uiColor
@@ -143,7 +149,7 @@ public struct Avatar: View, TokenizedControlView, Equatable {
         // Adding ringInnerGapOffset to ringInnerGap & ringThickness to accommodate for a small space between
         // the ring and avatar when the ring is visible and there is no inner ring gap
         let ringInnerGapOffset = 0.5
-        let ringInnerGap: CGFloat = isRingVisible ? (hasRingInnerGap ? tokenSet[.ringInnerGap].float : -ringInnerGapOffset) : 0
+        let ringInnerGap: CGFloat = (isRingVisible || hasBackgroundOutline) ? ((hasRingInnerGap || hasBackgroundOutline) ? tokenSet[.ringInnerGap].float : -ringInnerGapOffset) : 0
         let ringThickness: CGFloat = isRingVisible ? (hasRingInnerGap ? ringThicknessToken : ringThicknessToken + ringInnerGapOffset) : 0
         let ringOuterGap: CGFloat = isRingVisible ? tokenSet[.ringOuterGap].float : 0
         let totalRingGap: CGFloat = ringInnerGap + ringThickness + ringOuterGap
@@ -161,10 +167,14 @@ public struct Avatar: View, TokenizedControlView, Equatable {
             !shouldUseCalculatedColors ? tokenSet[.backgroundDefaultColor].uiColor :
                 CalculatedColors.backgroundColor(hashCode: colorHashCode))
         let ringGapColor = Color(tokenSet[.ringGapColor].uiColor).opacity(isTransparent ? 0 : 1)
-        let ringColor = !isRingVisible ? Color.clear :
-        Color(state.ringColor ?? ( !shouldUseCalculatedColors ?
-                                       tokenSet[.ringDefaultColor].uiColor :
-                                       CalculatedColors.ringColor(hashCode: colorHashCode)))
+        let ringColor = ( !isRingVisible ?
+                          Color.clear :
+                            Color(state.ringColor ?? ( !shouldUseCalculatedColors ?
+                                                       tokenSet[.ringDefaultColor].uiColor :
+                                                        CalculatedColors.ringColor(hashCode: colorHashCode)
+                                                     )
+                            )
+        )
 
         let avatarImageInfo: (image: UIImage?, renderingMode: Image.TemplateRenderingMode) = {
             if shouldUseDefaultImage {
@@ -567,7 +577,8 @@ class MSFAvatarStateImpl: ControlState, MSFAvatarState {
     @Published var isAnimated: Bool = true
     @Published var isOutOfOffice: Bool = false
     @Published var isRingVisible: Bool = false
-    @Published var isTransparent: Bool = true
+    @Published var isTransparent: Bool = false
+    @Published var hasBackgroundOutline: Bool = false
     @Published var presence: MSFAvatarPresence = .none
     @Published var activityStyle: MSFAvatarActivityStyle = .none
     @Published var activityImage: UIImage?

--- a/ios/FluentUI/Avatar/Avatar.swift
+++ b/ios/FluentUI/Avatar/Avatar.swift
@@ -149,9 +149,9 @@ public struct Avatar: View, TokenizedControlView, Equatable {
         // Adding ringInnerGapOffset to ringInnerGap & ringThickness to accommodate for a small space between
         // the ring and avatar when the ring is visible and there is no inner ring gap
         let ringInnerGapOffset = 0.5
-        let ringInnerGap: CGFloat = (isRingVisible || hasBackgroundOutline) ? ((hasRingInnerGap || hasBackgroundOutline) ? tokenSet[.ringInnerGap].float : -ringInnerGapOffset) : 0
+        let ringInnerGap: CGFloat = isRingVisible ? (hasRingInnerGap ? tokenSet[.ringInnerGap].float : -ringInnerGapOffset) : 0
         let ringThickness: CGFloat = isRingVisible ? (hasRingInnerGap ? ringThicknessToken : ringThicknessToken + ringInnerGapOffset) : 0
-        let ringOuterGap: CGFloat = isRingVisible ? tokenSet[.ringOuterGap].float : 0
+        let ringOuterGap: CGFloat = (isRingVisible || hasBackgroundOutline) ? tokenSet[.ringOuterGap].float : 0
         let totalRingGap: CGFloat = ringInnerGap + ringThickness + ringOuterGap
         let avatarImageSize: CGFloat = contentSize
         let ringInnerGapSize: CGFloat = avatarImageSize + (ringInnerGap * 2)

--- a/ios/FluentUI/Avatar/AvatarModifiers.swift
+++ b/ios/FluentUI/Avatar/AvatarModifiers.swift
@@ -50,6 +50,14 @@ public extension Avatar {
         return self
     }
 
+    /// Whether the avatar should draw an outline using a background color.
+    /// - Parameter hasBackgroundOutline: Boolean value to set the property.
+    /// - Returns: The modified Avatar with the property set.
+    func hasBackgroundOutline(_ hasBackgroundOutline: Bool) -> Avatar {
+        state.hasBackgroundOutline = hasBackgroundOutline
+        return self
+    }
+
     /// An override for the template icon to use when there is no set image or name.
     /// - Parameter defaultImage: Image to be used as the Avatar's default image.
     /// - Returns: The modified Avatar with the property set.

--- a/ios/FluentUI/AvatarGroup/AvatarGroup.swift
+++ b/ios/FluentUI/AvatarGroup/AvatarGroup.swift
@@ -16,6 +16,9 @@ import SwiftUI
     /// items than just the remainder of the avatars that could not be displayed due to the maxDisplayedAvatars property.
     var overflowCount: Int { get set }
 
+    /// Whether a background-colored outline should be drawn behind all Avatars, including the overflow.
+    var hasBackgroundOutline: Bool { get set }
+
     /// Show a top-trailing aligned unread dot when set to true.
     var isUnread: Bool { get set }
 
@@ -103,6 +106,7 @@ public struct AvatarGroup: View, TokenizedControlView {
     ///   - maxDisplayedAvatars: Caps the number of displayed avatars and shows the remaining not displayed in the overflow avatar.
     ///   - overflowCount: Adds to the overflow count in case the calling code did not provide all the avatars, but still wants to convey more
     ///                    items than just the remainder of the avatars that could not be displayed due to the maxDisplayedAvatars property.
+    ///   - hasBackgroundOutline: Whether a background-colored outline should be drawn behind all Avatars, including the overflow.
     ///   - isUnread: Show a top-trailing aligned unread dot when set to true.
     ///   - avatarBuilder: A ViewBuilder that creates an `Avatar` for a given index.
     public init(style: MSFAvatarGroupStyle,
@@ -110,6 +114,7 @@ public struct AvatarGroup: View, TokenizedControlView {
                 avatarCount: Int = 0,
                 maxDisplayedAvatars: Int = Int.max,
                 overflowCount: Int = 0,
+                hasBackgroundOutline: Bool = false,
                 isUnread: Bool = false,
                 @ViewBuilder avatarBuilder: @escaping (_ index: Int) -> Avatar) {
         // Configure the avatars
@@ -117,7 +122,7 @@ public struct AvatarGroup: View, TokenizedControlView {
             let avatar = avatarBuilder(index)
             avatar.state.size = size
             avatar.state.style = .default
-            avatar.state.isTransparent = false
+            avatar.state.hasBackgroundOutline = hasBackgroundOutline
             return avatar
         }
 
@@ -126,6 +131,7 @@ public struct AvatarGroup: View, TokenizedControlView {
         state.avatars = avatars
         state.maxDisplayedAvatars = maxDisplayedAvatars
         state.overflowCount = overflowCount
+        state.hasBackgroundOutline = hasBackgroundOutline
         state.isUnread = isUnread
 
         self.state = state
@@ -323,6 +329,7 @@ public struct AvatarGroup: View, TokenizedControlView {
         let state = MSFAvatarStateImpl(style: .overflow, size: state.size)
         state.primaryText = "\(count)"
         state.image = nil
+        state.hasBackgroundOutline = self.state.hasBackgroundOutline
         return Avatar(state)
     }
 }
@@ -359,6 +366,11 @@ class MSFAvatarGroupStateImpl: ControlState, MSFAvatarGroupState {
     @Published var avatars: [Avatar] = []
     @Published var maxDisplayedAvatars: Int = Int.max
     @Published var overflowCount: Int = 0
+    @Published var hasBackgroundOutline: Bool = false {
+        didSet {
+            avatars.forEach { $0.state.hasBackgroundOutline = hasBackgroundOutline }
+        }
+    }
     @Published var isUnread: Bool = false
 
     @Published var style: MSFAvatarGroupStyle


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Adding a new API for `Avatar` and `AvatarGroup` that optionally renders an outline around the `Avatar` instances with the Fluent background color.

This is the same color (and the same logic) that is used when drawing a ring around the `Avatar`. Useful for when the control is being rendered atop a dark or complicated background, such as a photo.

As an addendum, this change also brings formal deprecation to the `isTransparent` property of `Avatar`. This is from a very old version of the Fluent spec, and should not be used anymore. The default value has been changed to `false`, and will be fully removed in a future version of Fluent.

### Binary change

Total increase: 31,000 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,248,472 bytes | 31,279,472 bytes | ⚠️ 31,000 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| AvatarGroup.o | 383,488 bytes | 399,688 bytes | ⚠️ 16,200 bytes |
| Avatar.o | 601,344 bytes | 609,088 bytes | ⚠️ 7,744 bytes |
| __.SYMDEF | 4,860,560 bytes | 4,865,256 bytes | ⚠️ 4,696 bytes |
| AvatarModifiers.o | 45,952 bytes | 47,760 bytes | ⚠️ 1,808 bytes |
| FocusRingView.o | 846,992 bytes | 847,520 bytes | ⚠️ 528 bytes |
| MSFAvatarGroup.o | 30,352 bytes | 30,376 bytes | ⚠️ 24 bytes |
</details>

### Verification

Verified enabling and disabling the value in both UIKit and SwiftUI.

<details>
<summary>Visual Verification</summary>

| UIKit                                       | SwiftUI                                      |
|----------------------------------------------|--------------------------------------------|
| ![UIKit](https://github.com/user-attachments/assets/01eeddb4-f811-4321-814e-8765b9336f68) | ![SwiftUI](https://github.com/user-attachments/assets/e13485e7-947b-4694-930a-6046e821f056) |
| ![UIKit_Dark](https://github.com/user-attachments/assets/873fa801-a249-4093-be00-f759e5a5fa63) | ![SwiftUI_Dark](https://github.com/user-attachments/assets/ac551a44-7d32-4b6f-ad03-dc9406cd90b0) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2081)