### PR TITLE
add objc initialization support for dynamic color

### DIFF
--- a/macos/FluentUI/DynamicColor/DynamicColor.swift
+++ b/macos/FluentUI/DynamicColor/DynamicColor.swift
@@ -22,7 +22,7 @@ public class DynamicColor: NSObject {
 	@objc public let light: NSColor
 	@objc public let dark: NSColor
 
-	public init(light: NSColor, dark: NSColor) {
+	@objc public init(light: NSColor, dark: NSColor) {
 		self.light = light
 		self.dark = dark
 	}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

I want to create customized color badge in objective C but I can't do that because I can't create new dynamic color in objective C. add objc support for Dynamiccolor initialization.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

no impact on test app. Generated Fluentui-swift.h include
```
SWIFT_CLASS_NAMED("DynamicColor")
@interface MSFDynamicColor : NSObject
- (nonnull instancetype)initWithLight:(NSColor * _Nonnull)light dark:(NSColor * _Nonnull)dark OBJC_DESIGNATED_INITIALIZER;
@end

```

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2083)