### PR TITLE
[iOS] Add `sourceItem` option to Drawer as the popover presenting style anchor

### DIFF
--- a/ios/FluentUI/Drawer/DrawerController.swift
+++ b/ios/FluentUI/Drawer/DrawerController.swift
@@ -391,6 +391,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
     private let sourceView: UIView?
     private let sourceRect: CGRect?
     private let barButtonItem: UIBarButtonItem?
+    private let sourceItem: (any UIPopoverPresentationControllerSourceItem)?
 
     private var isPreferredContentSizeBeingChangedInternally: Bool = false
     private var normalDrawerHeight: CGFloat = 0
@@ -426,6 +427,7 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         self.sourceView = sourceView
         self.sourceRect = sourceRect
         self.barButtonItem = nil
+        self.sourceItem = nil
         self.presentationOrigin = presentationOrigin == -1 ? nil : presentationOrigin
         self.presentationDirection = presentationDirection
         self.preferredMaximumExpansionHeight = preferredMaximumHeight
@@ -446,6 +448,21 @@ open class DrawerController: UIViewController, TokenizedControlInternal {
         self.sourceView = nil
         self.sourceRect = nil
         self.barButtonItem = barButtonItem
+        self.sourceItem = nil
+        self.presentationOrigin = presentationOrigin == -1 ? nil : presentationOrigin
+        self.presentationDirection = presentationDirection
+        self.preferredMaximumExpansionHeight = preferredMaximumHeight
+
+        super.init(nibName: nil, bundle: nil)
+
+        initialize()
+    }
+
+    @objc public init(sourceItem: any UIPopoverPresentationControllerSourceItem, presentationOrigin: CGFloat = -1, presentationDirection: DrawerPresentationDirection, preferredMaximumHeight: CGFloat = -1) {
+        self.sourceView = nil
+        self.sourceRect = nil
+        self.barButtonItem = nil
+        self.sourceItem = sourceItem
         self.presentationOrigin = presentationOrigin == -1 ? nil : presentationOrigin
         self.presentationDirection = presentationDirection
         self.preferredMaximumExpansionHeight = preferredMaximumHeight
@@ -1016,6 +1033,8 @@ extension DrawerController: UIViewControllerTransitioningDelegate {
                 if let sourceRect = sourceRect {
                     presentationController.sourceRect = sourceRect
                 }
+            } else if let sourceItem = sourceItem {
+                presentationController.sourceItem = sourceItem
             } else if let barButtonItem = barButtonItem {
                 presentationController.barButtonItem = barButtonItem
             } else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Since iOS 16, [Apple introduced sourceItem](https://developer.apple.com/documentation/uikit/uipopoverpresentationcontroller/3930371-sourceitem) as anchor for the popover presenting style. This PR updates DrawerController to include the sourceItem option, enhancing its usages. This change is required by Microsoft Outlook to support using the tab bar item as the popover anchor.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)