### PR TITLE
Properly deprecate `UITextItemInteraction` for iOS 17

### DIFF
--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -133,11 +133,9 @@ extension TableViewHeaderFooterViewDemoController {
                 }
                 footer?.setup(style: .footer, attributedTitle: title)
 
-#if os(iOS)
                 if section.hasCustomLinkHandler {
                     footer?.delegate = self
                 }
-#endif
             }
             footer?.titleNumberOfLines = section.numberOfLines
             footer?.tokenSet.replaceAllOverrides(with: overrideTokens)
@@ -165,16 +163,15 @@ extension TableViewHeaderFooterViewDemoController {
 
 // MARK: - TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDelegate
 
-#if os(iOS)
 extension TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDelegate {
-    func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        let alertController = UIAlertController(title: "Link tapped", message: nil, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
-        present(alertController, animated: true, completion: nil)
-        return false
+    func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        return UIAction { [weak self] _ in
+            let alertController = UIAlertController(title: "Link tapped", message: nil, preferredStyle: .alert)
+            alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+            self?.present(alertController, animated: true, completion: nil)
+        }
     }
 }
-#endif
 
 extension TableViewHeaderFooterViewDemoController: DemoAppearanceDelegate {
     func themeWideOverrideDidChange(isOverrideEnabled: Bool) {

--- a/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -164,6 +164,15 @@ extension TableViewHeaderFooterViewDemoController {
 // MARK: - TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDelegate
 
 extension TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDelegate {
+    @available (visionOS, deprecated: 1.0)
+    func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
+        let alertController = UIAlertController(title: "Link tapped", message: nil, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        present(alertController, animated: true, completion: nil)
+        return false
+    }
+
+    @available(iOS, introduced: 17)
     func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
         return UIAction { [weak self] _ in
             let alertController = UIAlertController(title: "Link tapped", message: nil, preferredStyle: .alert)

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -22,6 +22,7 @@ public protocol TableViewHeaderFooterViewDelegate: AnyObject {
     /// @param defaultAction The default action for the text item. Return this to perform the default action.
     ///
     /// @return Return a UIAction to be performed when the text item is interacted with. Return @c nil to prevent the action from being performed.
+    @available(iOS, introduced: 17)
     @objc optional func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction?
 
     /// Asks the delegate for the menu configuration to be performed when interacting with a text item.
@@ -31,7 +32,8 @@ public protocol TableViewHeaderFooterViewDelegate: AnyObject {
     /// @param defaultMenu  The default menu for the specified text item.
     ///
     /// @return Return a menu configuration to be presented when the text item is interacted with. Return @c nil to prevent the menu from being presented.
-    @objc optional  func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration?
+    @available(iOS, introduced: 17)
+    @objc optional func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration?
 }
 
 // MARK: - TableViewHeaderFooterView
@@ -575,10 +577,12 @@ extension TableViewHeaderFooterView: UITextViewDelegate {
         return delegate?.headerFooterView?(self, shouldInteractWith: URL, in: characterRange, interaction: interaction) ?? true
     }
 
+    @available(iOS, introduced: 17)
     public func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
         return delegate?.headerFooterView?(self, primaryActionFor: textItem, defaultAction: defaultAction) ?? defaultAction
     }
 
+    @available(iOS, introduced: 17)
     public func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
         return delegate?.headerFooterView?(self, menuConfigurationFor: textItem, defaultMenu: defaultMenu) ?? .init(menu: defaultMenu)
     }

--- a/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
+++ b/ios/FluentUI/Table View/TableViewHeaderFooterView.swift
@@ -7,13 +7,32 @@ import UIKit
 
 // MARK: TableViewHeaderFooterViewDelegate
 
-#if os(iOS)
 @objc(MSFTableViewHeaderFooterViewDelegate)
 public protocol TableViewHeaderFooterViewDelegate: AnyObject {
     /// Returns: true if the interaction with the header view should be allowed; false if the interaction should not be allowed.
+    @available(iOS, deprecated: 17, message: "Replaced by primaryActionForTextItem: and menuConfigurationForTextItem: for additional customization options.")
+    @available(visionOS, deprecated: 1, message: "Replaced by primaryActionForTextItem: and menuConfigurationForTextItem: for additional customization options.")
     @objc optional func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool
+
+    /// Asks the delegate for the action to be performed when interacting with a text item. If a nil action is provided, the text view
+    /// will request a menu to be presented on primary action if possible.
+    ///
+    /// @param headerFooterView  The `TableViewHeaderFooterView` requesting the primary action.
+    /// @param textItem  The text item for performing said action.
+    /// @param defaultAction The default action for the text item. Return this to perform the default action.
+    ///
+    /// @return Return a UIAction to be performed when the text item is interacted with. Return @c nil to prevent the action from being performed.
+    @objc optional func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction?
+
+    /// Asks the delegate for the menu configuration to be performed when interacting with a text item.
+    ///
+    /// @param headerFooterView  The `TableViewHeaderFooterView` requesting the menu.
+    /// @param textItem  The text item for performing said action.
+    /// @param defaultMenu  The default menu for the specified text item.
+    ///
+    /// @return Return a menu configuration to be presented when the text item is interacted with. Return @c nil to prevent the menu from being presented.
+    @objc optional  func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration?
 }
-#endif // os(iOS)
 
 // MARK: - TableViewHeaderFooterView
 
@@ -125,9 +144,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
         }
     }
 
-#if os(iOS)
     @objc public weak var delegate: TableViewHeaderFooterViewDelegate?
-#endif // os(iOS)
 
     open override var intrinsicContentSize: CGSize {
         return CGSize(
@@ -407,9 +424,7 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
     open override func prepareForReuse() {
         super.prepareForReuse()
 
-#if os(iOS)
         delegate = nil
-#endif // os(iOS)
 
         accessoryButtonStyle = .regular
         titleNumberOfLines = 1
@@ -553,12 +568,20 @@ open class TableViewHeaderFooterView: UITableViewHeaderFooterView, TokenizedCont
 // MARK: - TableViewHeaderFooterView: UITextViewDelegate
 
 extension TableViewHeaderFooterView: UITextViewDelegate {
-#if os(iOS)
+    @available(iOS, deprecated: 17, message: "Replaced by primaryActionForTextItem: and menuConfigurationForTextItem: for additional customization options.")
+    @available(visionOS, deprecated: 1, message: "Replaced by primaryActionForTextItem: and menuConfigurationForTextItem: for additional customization options.")
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         // If the delegate function is not set, return `true` to let the default interaction handle this
         return delegate?.headerFooterView?(self, shouldInteractWith: URL, in: characterRange, interaction: interaction) ?? true
     }
-#endif // os(iOS)
+
+    public func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        return delegate?.headerFooterView?(self, primaryActionFor: textItem, defaultAction: defaultAction) ?? defaultAction
+    }
+
+    public func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+        return delegate?.headerFooterView?(self, menuConfigurationFor: textItem, defaultMenu: defaultMenu) ?? .init(menu: defaultMenu)
+    }
 }
 
 // MARK: - TableViewHeaderFooterTitleView


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Our public API on iOS includes `UITextItemInteraction`, which is deprecated in iOS 17. This PR marks it as deprecated as well, and provides an alternate implementation using Apple's recommended replacement.

Bonus: we now support this API on visionOS too! 🥳

### Binary change

Total increase: 13,040 bytes
Total decrease: 0 bytes
| File | Before | After | Delta |
|------|-------:|------:|------:|
| Total | 31,325,696 bytes | 31,338,736 bytes | ⚠️ 13,040 bytes |
<details>
<summary> Full breakdown </summary>

| File | Before | After | Delta |
|------|-------:|------:|------:|
| TableViewHeaderFooterView.o | 299,672 bytes | 309,216 bytes | ⚠️ 9,544 bytes |
| __.SYMDEF | 4,872,728 bytes | 4,875,448 bytes | ⚠️ 2,720 bytes |
| FocusRingView.o | 848,736 bytes | 849,512 bytes | ⚠️ 776 bytes |
</details>

### Verification

Tested that both default and custom links work as expected, on both iOS and visionOS.

<details>
<summary>Visual Verification</summary>

| iOS                                       | visionOS                                      |
|----------------------------------------------|--------------------------------------------|
| ![iOS](https://github.com/user-attachments/assets/898c698c-ed33-4cb7-881b-317248a8bfdc) | ![visionOS](https://github.com/user-attachments/assets/ee074a92-39d3-4248-af5d-fe4e8c8aa9fd) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2086)