### PR TITLE
Handle deprecated API in DatePickerController

### DIFF
--- a/macos/FluentUI/DatePicker/DatePickerController.swift
+++ b/macos/FluentUI/DatePicker/DatePickerController.swift
@@ -262,10 +262,17 @@ open class DatePickerController: NSViewController {
 
 		// In this case, we want to use Chinese numerals instead of western
 		// Setting dateStyle to .long before setting the dateFormat will achieve this
-		if calendar.identifier == .chinese && calendar.locale?.languageCode == "zh" {
-			formatter.dateStyle = .long
+		if calendar.identifier == .chinese {
+			let languageCode: String?
+			if #available(macOS 13.0, *) {
+				languageCode = calendar.locale?.language.languageCode?.identifier
+			} else {
+				languageCode = calendar.locale?.languageCode
+			}
+			if languageCode == "zh" {
+				formatter.dateStyle = .long
+			}
 		}
-
 		formatter.dateFormat = "d"
 
 		return formatter


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

Working around a deprecated API in `DatePickerController` on macOS.

### Binary change

n/a - binary change only measures iOS, and this change is macOS-only.

### Verification

Verified the build with both macOS 12 and macOS 13 as deployment target.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2089)