### PR TITLE
Fixing swiftlint for new folder config

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -168,8 +168,9 @@ only_rules:
 
 included: # paths to include during linting. `--path` is ignored if present.
   - ${LINTPATH}
-  - ios
-  - macos
+  - Demos
+  - Sources
+  - Tests
 
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods

--- a/Sources/FluentUI_iOS/Core/FluentUIFramework.swift
+++ b/Sources/FluentUI_iOS/Core/FluentUIFramework.swift
@@ -25,7 +25,9 @@ public class FluentUIFramework: NSObject {
 
     @objc public static var fluentVersion: String? = {
         struct VersionConfig: Decodable {
+            // swiftlint:disable identifier_name
             let FluentVersion: String
+            // swiftlint:enable identifier_name
         }
 
         guard let url = resourceBundle.url(forResource: "Version", withExtension: "plist"),


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Updating `.swiftlint.yml` to reference new directory paths, and suppressing one warning that was added while it was broken.

### Binary change

n/a -- only changing how the linter is run, no code changes.

### Verification

Ran the linter locally:
```
Done linting! Found 0 violations, 0 serious in 402 files.
```

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2093)