### PR TITLE
Cleanup code

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -57,9 +57,6 @@ class NavigationControllerDemoController: DemoController {
         addTitle(text: "Top Accessory View")
         container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width", action: #selector(showWithTopSearchBar)))
 
-        addTitle(text: "Top Accessory View with shy wide accessory view")
-        container.addArrangedSubview(createButton(title: "Show with top search bar for large screen width with a shy pill segment control", action: #selector(showWithTopSearchBarWithShySecondaryAccessoryView)))
-
         addTitle(text: "Change Style Periodically")
         container.addArrangedSubview(createButton(title: "Change the style every second", action: #selector(showSearchChangingStyleEverySecond)))
     }
@@ -131,24 +128,24 @@ class NavigationControllerDemoController: DemoController {
         presentController(withTitleStyle: .leading, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true, leadingItem: .customButton)
     }
 
-    @objc func showSystemTitleWithShyAccessory() {
-        presentController(withTitleStyle: .system, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true)
-    }
-
     @objc func showRegularTitleWithShyAccessoryAndSubtitle() {
         presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(), contractNavigationBarOnScroll: true)
     }
 
     @objc func showRegularTitleWithFixedAccessory() {
-        presentController(withTitleStyle: .system, accessoryView: createAccessoryView())
-    }
-
-    @objc func showSystemTitleWithFixedAccessoryAndSubtitle() {
-        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: false)
+        presentController(withTitleStyle: .system, accessoryView: createAccessoryView(), contractNavigationBarOnScroll: false)
     }
 
     @objc func showSystemTitle() {
         presentController(withTitleStyle: .system, style: .system)
+    }
+
+    @objc func showSystemTitleWithShyAccessory() {
+        presentController(withTitleStyle: .system, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true)
+    }
+
+    @objc func showSystemTitleWithFixedAccessoryAndSubtitle() {
+        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: false)
     }
 
     @objc func showRegularTitleWithSubtitle() {
@@ -156,7 +153,7 @@ class NavigationControllerDemoController: DemoController {
     }
 
     @objc func showRegularTitleWithSubtitleAndCustomLeadingButton() {
-        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true, leadingItem: .customButton)
+        presentController(withTitleStyle: .system, subtitle: "Subtitle goes here", accessoryView: createAccessoryView(with: .onSystemNavigationBar), contractNavigationBarOnScroll: true, leadingItem: .customButton)
     }
 
     @objc func showLargeTitleWithGradientStyle() {
@@ -195,10 +192,6 @@ class NavigationControllerDemoController: DemoController {
 
     @objc func showWithTopSearchBar() {
         presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), showsTopAccessory: true, contractNavigationBarOnScroll: false)
-    }
-
-    @objc func showWithTopSearchBarWithShySecondaryAccessoryView() {
-        presentController(withTitleStyle: .largeLeading, style: .system, accessoryView: createAccessoryView(with: .onSystemNavigationBar), secondaryAccessoryView: createSecondaryAccessoryView(), showsTopAccessory: true, contractNavigationBarOnScroll: true)
     }
 
     @objc func showSearchChangingStyleEverySecond() {

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -164,7 +164,7 @@ extension TableViewHeaderFooterViewDemoController {
 // MARK: - TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDelegate
 
 extension TableViewHeaderFooterViewDemoController: TableViewHeaderFooterViewDelegate {
-    @available (visionOS, deprecated: 1.0)
+    @available(visionOS, deprecated: 1.0)
     func headerFooterView(_ headerFooterView: TableViewHeaderFooterView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         let alertController = UIAlertController(title: "Link tapped", message: nil, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))

--- a/Sources/FluentUI_iOS/Components/Navigation/NavigationBar.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/NavigationBar.swift
@@ -329,7 +329,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
                 return
             }
             updateAccessibilityElements()
-            updateViewsForLargeTitlePresentation(for: topItem)
+            updateViewsForNavigationItem(topItem)
         }
     }
 
@@ -425,7 +425,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         systemShadowColor = standardAppearance.shadowColor
 
         updateColors(for: topItem)
-        updateViewsForLargeTitlePresentation(for: topItem)
+        updateViewsForNavigationItem(topItem)
         updateAccessibilityElements()
 
         tokenSet.registerOnUpdate(for: self) { [weak self] in
@@ -574,7 +574,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
         if traitCollection.verticalSizeClass != previousTraitCollection?.verticalSizeClass {
             updateElementSizes()
             updateContentStackViewMargins(forExpandedContent: contentIsExpanded)
-            updateViewsForLargeTitlePresentation(for: topItem)
+            updateViewsForNavigationItem(topItem)
             updateTitleViewConstraints()
 
             // change bar button image size and title inset depending on device rotation
@@ -844,7 +844,7 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
     /// Cache for the system shadow color, since the default value is private.
     private var systemShadowColor: UIColor?
 
-    private func updateViewsForLargeTitlePresentation(for navigationItem: UINavigationItem?) {
+    private func updateViewsForNavigationItem(_ navigationItem: UINavigationItem?) {
         // UIView.isHidden has a bug where a series of repeated calls with the same parameter can "glitch" the view into a permanent shown/hidden state
         // i.e. repeatedly trying to hide a UIView that is already in the hidden state
         // by adding a check to the isHidden property prior to setting, we avoid such problematic scenarios
@@ -856,7 +856,8 @@ open class NavigationBar: UINavigationBar, TokenizedControlInternal, TwoLineTitl
 
         // We also want to hide the backgroundView and the contentStackView for gradient style regular title to
         // avoid displaying duplicated navigation bar items.
-        if usesLeadingTitle || (style != .gradient && systemWantsCompactNavigationBar && navigationItem?.titleView == nil) {
+        let shouldHideSystemNavigationItems =  usesLeadingTitle || (style != .gradient && systemWantsCompactNavigationBar && navigationItem?.titleView == nil)
+        if shouldHideSystemNavigationItems {
             if backgroundView.isHidden {
                 backgroundView.isHidden = false
             }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Cleaning up code
- Fix bugs in `NavigationControllerDemoController`: wrong styles, duplicate style
- Lint error
- `updateViewsForLargeTitlePresentation` has evolved quite a bit over time, rename it

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2095)