### PR TITLE
[iOS] Updating `Version.plist` keys to match other plists

### DIFF
--- a/Sources/FluentUI_iOS/Core/FluentUIFramework.swift
+++ b/Sources/FluentUI_iOS/Core/FluentUIFramework.swift
@@ -26,7 +26,7 @@ public class FluentUIFramework: NSObject {
     @objc public static var fluentVersion: String? = {
         struct VersionConfig: Decodable {
             // swiftlint:disable identifier_name
-            let FluentVersion: String
+            let CFBundleVersion: String
             // swiftlint:enable identifier_name
         }
 
@@ -35,7 +35,7 @@ public class FluentUIFramework: NSObject {
               let versionConfig = try? PropertyListDecoder().decode(VersionConfig.self, from: data) else {
             return nil
         }
-        return versionConfig.FluentVersion
+        return versionConfig.CFBundleVersion
     }()
 
     @available(*, deprecated, message: "Non-fluent icons no longer supported. Setting this var no longer has any effect and it will be removed in a future update.")

--- a/Sources/FluentUI_iOS/Resources/Version.plist
+++ b/Sources/FluentUI_iOS/Resources/Version.plist
@@ -2,7 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>FluentVersion</key>
+	<key>CFBundleShortVersionString</key>
+	<string>0.30.0</string>
+	<key>CFBundleVersion</key>
 	<string>0.30.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

The FluentUI_iOS library was using different keys to store its version info compared to every other plist in the repo. Let's just consolidate onto the same standard `CFBundleVersion`/`CFBundleShortVersionString` naming pattern, to make version increases easier. 

### Binary change

| Before | After | Delta |
|---|---|---|
| 16,525,060 | 16,525,126 | 62 bytes |

### Verification

Ran the `BumpVersion.swift` script to confirm that the new plist is correctly updated.

<details>
<summary>Visual Verification</summary>

![Simulator Screenshot - iPhone 16 Pro - 2024-10-16 at 16 09 31](https://github.com/user-attachments/assets/54155c5d-73a6-4188-8ee3-e6c8b96a65c5)

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2096)