### PR TITLE
Fix SPM support for visionOS

### DIFF
--- a/Sources/FluentUI/FluentUI.swift
+++ b/Sources/FluentUI/FluentUI.swift
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 @_exported import FluentUI_ios
 #elseif os(macOS)
 @_exported import FluentUI_macos


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Importing FluentUI via SPM on visionOS does not work as expected. The Fluent classes are not exposed and the package has no public interfaces. iOS and Mac both export their internal targets, but nothing is exported on visionOS. This changes the package to also export the `FluentUI_ios` target for visionOS.

As a workaround, clients can directly import the `FluentUI_ios` target on visionOS:
```
#if os(visionOS)
import FluentUI_ios
#else
import FluentUI
#endif
```

### Binary change

N/A

### Verification

A test app was created which adds FluentUI as a Swift package. Within the module, I was able to import FluentUI and build properly for iOS; building for visionOS was unsuccessful due to missing definitions unless I used the workaround mentioned above. With this change, that workaround is not needed and the test app builds with a standard import of FluentUI.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2098)