### PR TITLE
Ensure MSFNotification doesn't internally handle safe areas

### DIFF
--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -25,7 +25,7 @@ import UIKit
         self.isFlexibleWidthToast = isFlexibleWidthToast && style.isToast
         notification = FluentNotification(style: style,
                                           shouldSelfPresent: false)
-        super.init(AnyView(notification))
+        super.init(AnyView(notification), safeAreaRegions: [])
         let defaultDismissAction = { [weak self] in
             guard let strongSelf = self else {
                 return

--- a/Sources/FluentUI_iOS/Core/ControlHostingView.swift
+++ b/Sources/FluentUI_iOS/Core/ControlHostingView.swift
@@ -35,9 +35,16 @@ open class ControlHostingView: UIView {
     /// the control view in an `AnyView.`
     ///
     /// - Parameter controlView: An `AnyView`-wrapped component to host.
-    public init(_ controlView: AnyView) {
+    /// - Parameter safeAreaRegions: Passthrough to the respective property on UIHostingController.
+    /// Indicates which safe area regions the underlying hosting controller should add to its view.
+    public init(_ controlView: AnyView, safeAreaRegions: SafeAreaRegions = .all) {
         hostingController = FluentThemedHostingController.init(rootView: controlView)
         hostingController.sizingOptions = [.intrinsicContentSize]
+
+        if #available(iOS 16.4, *) {
+            hostingController.safeAreaRegions = safeAreaRegions
+        }
+
         super.init(frame: .zero)
 
         self.configureHostedView()


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes
By default, `UIHostingController` will [internally handle safe areas](https://developer.apple.com/documentation/swiftui/uihostingcontroller/safearearegions) by growing the hosting view correspondingly (to allow the content to clear the unsafe area).

This sometimes caused a layout feedback loop (and a hang) in `MSFNotification`.
To hide, we slide the notification beyond the host view edge to which it was constrained. This can cause it to be in the unsafe area, which causes the hosting view to grow (because of the safe area region handling behavior). This triggers a synchronous layout pass to shift the view even further away to satisfy the new constraints, which causes it to grow again. This repeats indefinitely and the app hangs.

This doesn't always repro - we need a special combo of soft keyboard (which causes a safe area mismatch between SwiftUI and UIKit) and specific notification positioning. Regardless, this view (and probably most other leaf node views) should *not* internally handle safe areas. So I'm exposing the safeAreaRegions API, and setting it to an empty array for the notification view.

### Verification

Reproduced hang in product and in a small test app.
Verified hang is fixed, and did sanity checks in fluent test app to make sure nothing else regressed.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2099)