### PR TITLE
[iOS] Fix Dogfood `CODE_SIGN_IDENTITY`

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo.xcodeproj/project.pbxproj
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo.xcodeproj/project.pbxproj
@@ -1107,7 +1107,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				BUNDLE_NAME = FluentUI;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 9KBH5RKYEW;
 				INFOPLIST_FILE = FluentUI.Demo/Info.plist;


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Changing the `CODE_SIGN_IDENTITY` for Dogfood iOS demo builds to match the other build schemes. Not sure why it was using the Distribution profile 🤷

### Binary change

n/a, code signing for iOS demo app only

### Verification

Verified that I could Archive a Dogfood build with the correct profile set.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2100)