### PR TITLE
[A11y][VoiceOver] Set accessibility value for the sheet expansion state

### DIFF
--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -174,7 +174,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     /// The message should convey the "Expand" action and will be used when the bottom sheet is collapsed.
     @objc public var handleExpandCustomAccessibilityLabel: String? {
         didSet {
-            updateResizingHandleViewAccessibility()
+            updateResizingHandleViewAccessibility(for: currentExpansionState)
         }
     }
 
@@ -182,7 +182,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     /// The message should convey the "Collapse" action and will be used when the bottom sheet is expanded.
     @objc public var handleCollapseCustomAccessibilityLabel: String? {
         didSet {
-            updateResizingHandleViewAccessibility()
+            updateResizingHandleViewAccessibility(for: currentExpansionState)
         }
     }
 
@@ -496,6 +496,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         super.viewDidAppear(animated)
 
         tokenSet.update(fluentTheme)
+
+        updateResizingHandleViewAccessibility(for: currentExpansionState)
     }
 
     public override func viewDidLayoutSubviews() {
@@ -523,6 +525,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
 
         updateAppearance()
+
         super.viewDidLayoutSubviews()
     }
 
@@ -667,27 +670,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         move(to: isExpanded ? .collapsed : .expanded, interaction: .resizingHandleTap)
     }
 
-    private func updateResizingHandleViewAccessibility() {
-        if currentExpansionState == .expanded {
+    private func updateResizingHandleViewAccessibility(for state: BottomSheetExpansionState) {
+        if state == .expanded {
             resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Collapse".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
-        } else {
+            resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
+        } else if state == .collapsed {
             resizingHandleView.accessibilityLabel = handleExpandCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Expand".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
-        }
-    }
-
-    private func updateResizingHandleViewAccessibilityValue(for state: BottomSheetExpansionState) {
-        switch state {
-        case .collapsed:
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Collapsed".localized
-            break
-        case .expanded:
-            resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
-            break
-        default:
-            resizingHandleView.accessibilityValue = nil
-            break
         }
     }
 
@@ -947,7 +938,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
         completeAnimationsIfNeeded()
 
-        updateResizingHandleViewAccessibilityValue(for: targetExpansionState)
+        updateResizingHandleViewAccessibility(for: targetExpansionState)
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
             delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)
@@ -1189,11 +1180,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     private var currentStateChangeAnimator: UIViewPropertyAnimator?
 
-    private var currentExpansionState: BottomSheetExpansionState = .collapsed {
-        didSet {
-            updateResizingHandleViewAccessibility()
-        }
-    }
+    private var currentExpansionState: BottomSheetExpansionState = .collapsed
 
     private var targetExpansionState: BottomSheetExpansionState?
 

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -677,6 +677,20 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
     }
 
+    private func updateResizingHandleViewAccessibilityValue(for state: BottomSheetExpansionState) {
+        switch state {
+        case .collapsed:
+            resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Collapsed".localized
+            break
+        case .expanded:
+            resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
+            break
+        default:
+            resizingHandleView.accessibilityValue = nil
+            break
+        }
+    }
+
     private func updateExpandedContentAlpha() {
         let currentOffset = currentSheetVerticalOffset
         let collapsedOffset = offset(for: .collapsed)
@@ -932,6 +946,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
 
         completeAnimationsIfNeeded()
+
+        updateResizingHandleViewAccessibilityValue(for: targetExpansionState)
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
             delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)

--- a/Sources/FluentUI_iOS/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/FluentUI_iOS/Resources/Localization/en.lproj/Localizable.strings
@@ -82,10 +82,14 @@
 "Accessibility.Drawer.ResizingHandle.Label.Expand" = "Expand";
 /* Accessibility hint for drawer's resizing handle when it has expand action */
 "Accessibility.Drawer.ResizingHandle.Hint.Expand" = "Double tap to expand";
+/* Accessibility value for drawer's resizing handle when the sheet is in a collapsed state */
+"Accessibility.Drawer.ResizingHandle.Value.Collapsed" = "Collapsed";
 /* Accessibility label for drawer's resizing handle when it has collapse action */
 "Accessibility.Drawer.ResizingHandle.Label.Collapse" = "Collapse";
 /* Accessibility hint for drawer's resizing handle when it has collapse action */
 "Accessibility.Drawer.ResizingHandle.Hint.Collapse" = "Double tap to collapse";
+/* Accessibility value for drawer's resizing handle when the sheet is in a expanded state */
+"Accessibility.Drawer.ResizingHandle.Value.Expanded" = "Expanded";
 
 /* Accessibility label for when a task under progress has finished */
 "Accessibility.HUD.Done" = "Done";


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Currently, the resizing handle of the bottom sheet does not read its current state (i.e. "Collapsed" or "Expanded"). This change adds that functionality to align with Apple system sheets and improve the VoiceOver experience.

I `updateResizingHandleViewAccessibility` to set the `accessibilityValue` on the `resizingHandle` based on the provided expansion state. Updated where `updateResizingHandleViewAccessibility` is called to ensure that the accessibility values are updated before the voiceover reads the new state.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

On iPhone, in the Fluent Test app, I validated that the "Expanded" value is read when the sheet is in an expanded state and that the "Collapsed" value is read when the sheet is in a collapsed state.

<details>
After:

https://github.com/user-attachments/assets/812cb6cc-fecd-4a74-a7ca-f99b353d2183

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2101)