### PR TITLE
[NavigationBar] Fixing NavBar style during willMove(toWindow:)

### DIFF
--- a/Sources/FluentUI_iOS/Components/Navigation/NavigationBar.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/NavigationBar.swift
@@ -540,7 +540,13 @@ open class NavigationBar: UINavigationBar, TokenizedControl, TwoLineTitleViewDel
         tokenSet.update(newWindow.fluentTheme)
 
         updateTitleViewTokenSets()
-        updateColors(for: topItem)
+
+        if let navigationItem = topItem {
+            let (_, actualItem) = actualStyleAndItem(for: navigationItem)
+            update(with: actualItem)
+        } else {
+            updateColors(for: topItem)
+        }
     }
 
     private func updateTitleViewTokenSets() {
@@ -756,7 +762,7 @@ open class NavigationBar: UINavigationBar, TokenizedControl, TwoLineTitleViewDel
     }
 
     /// Updates the bar button items.
-    /// 
+    ///
     /// In general, this should be called as late as possible when receiving a new navigation item
     /// because it will replace a client-provided left bar button item with a back button if needed.
     private func updateBarButtonItems(with navigationItem: UINavigationItem) {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

In `willMove(toWindow:)`, we call `updateColors(for:)` with the wrong NavigationItem. Let's make sure we get the correct one by calling `(actualStyleAndItem(for:)`

### Verification

Navigation bar style is applied correctly in `willMove(toWindow:)`

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2102)