### PR TITLE
Fix swift 6 error

### DIFF
--- a/Sources/FluentUI_iOS/Core/Theme/Tokens/TokenizedControlView.swift
+++ b/Sources/FluentUI_iOS/Core/Theme/Tokens/TokenizedControlView.swift
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License.
 //
 
+import Combine
 import SwiftUI
 
 /// SwiftUI-specific extension to `TokenizedControl`.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

In swift 6, it's an error to use `Combine.ObservableObject` and not import `Combine`. Explicitly import it.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2103)