### PR TITLE
[NavigationBar] Fixing function call in willMove(toWindow:)

### DIFF
--- a/Sources/FluentUI_iOS/Components/Navigation/NavigationBar.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/NavigationBar.swift
@@ -543,7 +543,7 @@ open class NavigationBar: UINavigationBar, TokenizedControl, TwoLineTitleViewDel
 
         if let navigationItem = topItem {
             let (_, actualItem) = actualStyleAndItem(for: navigationItem)
-            update(with: actualItem)
+            updateColors(for: actualItem)
         } else {
             updateColors(for: topItem)
         }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
#2102 Introduced a fix that is calling the wrong API. 

update(with:) => updateColors(for:)

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2104)