### PR TITLE
[iOS] Support gradient colors for selected item in `TabBarView`

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -19,10 +19,12 @@ class TabBarViewDemoController: DemoController {
     private var showsItemTitles: Bool { return itemTitleVisibilitySwitch.isOn }
     private var showBadgeNumbers: Bool { return showBadgeNumbersSwitch.isOn }
     private var useHigherBadgeNumbers: Bool { return useHigherBadgeNumbersSwitch.isOn }
+    private var useGradientSelection: Bool { return useGradientSelectionSwitch.isOn }
 
     private let itemTitleVisibilitySwitch = BrandedSwitch()
     private let showBadgeNumbersSwitch = BrandedSwitch()
     private let useHigherBadgeNumbersSwitch = BrandedSwitch()
+    private let useGradientSelectionSwitch = BrandedSwitch()
 
     private lazy var incrementBadgeButton: Button = {
         return createButton(title: "+", action: #selector(incrementBadgeNumbers))
@@ -36,6 +38,35 @@ class TabBarViewDemoController: DemoController {
 
     private var badgeNumbers: [UInt] = Constants.initialBadgeNumbers
     private var higherBadgeNumbers: [UInt] = Constants.initialHigherBadgeNumbers
+
+    private lazy var gradient: CAGradientLayer = {
+//        let gradientColors = [
+//            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor,
+//            UIColor(red: 0.18, green: 0.45, blue: 0.96, alpha: 1).cgColor,
+//            UIColor(red: 0.36, green: 0.80, blue: 0.98, alpha: 1).cgColor,
+//            UIColor(red: 0.45, green: 0.72, blue: 0.22, alpha: 1).cgColor,
+//            UIColor(red: 0.97, green: 0.78, blue: 0.27, alpha: 1).cgColor,
+//            UIColor(red: 0.94, green: 0.52, blue: 0.20, alpha: 1).cgColor,
+//            UIColor(red: 0.92, green: 0.26, blue: 0.16, alpha: 1).cgColor,
+//            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor]
+//
+//        let colorfulGradient = CAGradientLayer()
+//        colorfulGradient.colors = gradientColors
+//        colorfulGradient.startPoint = CGPoint(x: 0.5, y: 0.5)
+//        colorfulGradient.endPoint = CGPoint(x: 0.5, y: 0)
+//        colorfulGradient.type = .conic
+//        return colorfulGradient
+        let gradientColors = [
+            UIColor.red.cgColor,
+            UIColor.green.cgColor
+        ]
+        let colorfulGradient = CAGradientLayer()
+        colorfulGradient.colors = gradientColors
+        colorfulGradient.startPoint = CGPoint(x: 0.0, y: 0.0)
+        colorfulGradient.endPoint = CGPoint(x: 1.0, y: 1.0)
+        colorfulGradient.type = .axial
+        return colorfulGradient
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -54,6 +85,9 @@ class TabBarViewDemoController: DemoController {
 
         addRow(text: "Use higher badge numbers", items: [useHigherBadgeNumbersSwitch], textWidth: Constants.switchSettingTextWidth)
         useHigherBadgeNumbersSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
+
+        addRow(text: "Use gradient selection", items: [useGradientSelectionSwitch], textWidth: Constants.switchSettingTextWidth)
+        useGradientSelectionSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
 
         addRow(text: "Modify badge numbers", items: [incrementBadgeButton, decrementBadgeButton], textWidth: Constants.buttonSettingTextWidth)
 
@@ -93,6 +127,10 @@ class TabBarViewDemoController: DemoController {
 
         // If the open file item has been clicked, maintain that state through to the new item
         updatedTabBarView.items[2].isUnreadDotVisible = isOpenFileUnread
+
+        if useGradientSelection {
+            updatedTabBarView.selectedItemGradient = gradient
+        }
 
         updatedTabBarView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(updatedTabBarView)

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -40,22 +40,6 @@ class TabBarViewDemoController: DemoController {
     private var higherBadgeNumbers: [UInt] = Constants.initialHigherBadgeNumbers
 
     private lazy var gradient: CAGradientLayer = {
-//        let gradientColors = [
-//            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor,
-//            UIColor(red: 0.18, green: 0.45, blue: 0.96, alpha: 1).cgColor,
-//            UIColor(red: 0.36, green: 0.80, blue: 0.98, alpha: 1).cgColor,
-//            UIColor(red: 0.45, green: 0.72, blue: 0.22, alpha: 1).cgColor,
-//            UIColor(red: 0.97, green: 0.78, blue: 0.27, alpha: 1).cgColor,
-//            UIColor(red: 0.94, green: 0.52, blue: 0.20, alpha: 1).cgColor,
-//            UIColor(red: 0.92, green: 0.26, blue: 0.16, alpha: 1).cgColor,
-//            UIColor(red: 0.45, green: 0.29, blue: 0.79, alpha: 1).cgColor]
-//
-//        let colorfulGradient = CAGradientLayer()
-//        colorfulGradient.colors = gradientColors
-//        colorfulGradient.startPoint = CGPoint(x: 0.5, y: 0.5)
-//        colorfulGradient.endPoint = CGPoint(x: 0.5, y: 0)
-//        colorfulGradient.type = .conic
-//        return colorfulGradient
         let gradientColors = [
             UIColor.red.cgColor,
             UIColor.green.cgColor

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItemView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItemView.swift
@@ -283,6 +283,7 @@ class TabBarItemView: UIControl, TokenizedControl {
             return selectedImage
         }
 
+        // This is necessary because imageView.tintColor does not work with UIColor(patternImage:).
         let mask = CALayer()
         mask.contents = selectedImage?.cgImage
         mask.frame = imageView.bounds
@@ -297,6 +298,8 @@ class TabBarItemView: UIControl, TokenizedControl {
 
     private func updateColors() {
         if isEnabled {
+            // We cannot use UIColor(patternImage:) for the tintColor of a UIView. Instead, we have to
+            // fully replace the image, so we should not re-tint it here when we have a gradient.
             let shouldTint = isSelected && gradient == nil
             let tintColor = tokenSet[.selectedColor].uiColor
             titleLabel.textColor = shouldTint ? tintColor : tokenSet[.unselectedTextColor].uiColor

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
@@ -64,6 +64,13 @@ open class TabBarView: UIView, TokenizedControl {
             }
         }
     }
+    
+    /// An optional gradient to display for the selected item.
+    @objc public var selectedItemGradient: CAGradientLayer? {
+        didSet {
+            updateAppearance()
+        }
+    }
 
     @objc public weak var delegate: TabBarViewDelegate?
 
@@ -210,6 +217,10 @@ open class TabBarView: UIView, TokenizedControl {
                                                     forToken: .titleLabelFontPortrait)
                 tabBarItemTokenSet.setOverrideValue(tokenSet.overrideValue(forToken: .tabBarItemTitleLabelFontLandscape),
                                                     forToken: .titleLabelFontLandscape)
+
+                if let selectedItemGradient {
+                    tabBarItemView.gradient = selectedItemGradient
+                }
             }
         }
         topBorderLine.tokenSet[.color] = tokenSet[.separatorColor]


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Added a new API to `TabBarView`, `selectedItemGradient`. This is an optional property of type `CAGradientLayer?` that, when set, will override the tab bar view's tint color. Instead, this gradient will be resized and used as a mask, giving the selected item a gradient fill.

Additionally, when this is set, the selected item's `titleLabel` will not receive any tinting.

### Binary change

TBD

### Verification

Verified the tint on iPhone and iPad, dark and light modes.

<details>
<summary>Visual Verification</summary>

![GradientTabBar](https://github.com/user-attachments/assets/ec862913-e25a-4e94-ac1d-d967890d48bc)

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2107)