### PR TITLE
Don't recreate pill buttons when the pill button bar's bounds change

### DIFF
--- a/Sources/FluentUI_iOS/Components/Pill Button Bar/PillButtonBar.swift
+++ b/Sources/FluentUI_iOS/Components/Pill Button Bar/PillButtonBar.swift
@@ -81,20 +81,6 @@ open class PillButtonBar: UIScrollView {
         }
     }
 
-    public override var bounds: CGRect {
-        didSet {
-            if bounds.width > 0, lastKnownScrollFrameWidth > 0, bounds.width != lastKnownScrollFrameWidth {
-                // Frame changes can happen because of rotation, split view or adding the view for the first
-                // time into a superview. First time layout already has buttons in default sizes, recreate
-                // them so that the next time we layout subviews we'll recalculate their optimal sizes.
-                recreateButtons()
-                stackView.spacing = Constants.minButtonsSpacing
-            }
-
-            lastKnownScrollFrameWidth = bounds.width
-        }
-    }
-
     /// Initializes the PillButtonBar using the provided style.
     ///
     /// - Parameters:
@@ -206,8 +192,6 @@ open class PillButtonBar: UIScrollView {
     private var buttonExtraSidePadding: CGFloat = 0.0
 
     private var buttons = [PillButton]()
-
-    private var lastKnownScrollFrameWidth: CGFloat = 0.0
 
     private var needsButtonSizeReconfiguration: Bool = false
 
@@ -392,19 +376,6 @@ open class PillButtonBar: UIScrollView {
         }
 
         return nil
-    }
-
-    private func recreateButtons() {
-        let selectedItem = selectedButton?.pillBarItem
-        selectedButton = nil
-
-        let currentItems = items
-        items = nil
-        items = currentItems
-
-        if let selectedItem = selectedItem {
-            selectItem(selectedItem)
-        }
     }
 
     private func setupScrollView() {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Recreating the pill buttons when the bounds property of the bar changes can lead to inconsistent frame calculations during layout passes. For instance, there's a use case where accessing the width of the bar's `contentSize` in `viewDidLayoutSubviews` or `viewWillTransitionToSize` returns 0 because the buttons are removed and being re-added during the layout pass. From the comment it's still unclear why this logic exists. With the help of #mischreiber, we think it's best to remove this logic altogether and find a less fragile fix if it breaks edge cases we're not aware of.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Tested the Pill Button Bar on the demo app and on the client app use case. No regressions were observed even though large text  mode support on the control is broken independent of this change.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before_iphone_portrait](https://github.com/user-attachments/assets/1dd63a50-9304-4296-8948-a59138252273) | ![after_iphone_portrait](https://github.com/user-attachments/assets/0212f63a-8eb0-4f80-91d0-7a28c2656adb) |
| ![before_iphone_landscape](https://github.com/user-attachments/assets/40c7b110-cdc1-4f25-a233-83296a9278fc) | ![after_iphone_landscape](https://github.com/user-attachments/assets/880b1bd1-e795-4c21-ad74-8cc30512ac95) |
| ![before_iphone_large_text](https://github.com/user-attachments/assets/f46f67dc-85c3-4d20-b1c5-d79540645d79) | ![after_iphone_large_text](https://github.com/user-attachments/assets/5c732fff-7367-4e3d-a498-91db597c8994) |
| ![before_ipda_portrait](https://github.com/user-attachments/assets/a0e679bd-d569-4177-bf89-4408df633de3) | ![after_ipad_portrait](https://github.com/user-attachments/assets/efea7955-9a78-4ebd-9af0-35306c39fc1a) |
| ![before_ipad_landscape](https://github.com/user-attachments/assets/a52f60a3-e040-4e69-9dd3-aa794b122d1d) | ![after_ipad_landscape](https://github.com/user-attachments/assets/b83a0337-5f5d-43c9-a97f-a5044344e77d) |
| ![before_ipad_large_text](https://github.com/user-attachments/assets/deb1a826-5abc-47bd-b160-2a59bf011b28) | ![after_ipad_large_text](https://github.com/user-attachments/assets/8738e8cf-77e3-4a32-857a-9cdc799f153a) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2108)