### PR TITLE
Bottom Sheet Animation Crash Fix

### DIFF
--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -871,13 +871,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         let availableWidth: CGFloat = view.bounds.width
         let maxWidth = min(Constants.maxSheetWidth, availableWidth)
         let determinedWidth: CGFloat
+
         if shouldAlwaysFillWidth {
             determinedWidth = availableWidth
-        } else if Constants.minSheetWidth...maxWidth ~= preferredWidth {
-            determinedWidth = preferredWidth
+        } else if maxWidth > Constants.minSheetWidth {
+            determinedWidth = Constants.minSheetWidth...maxWidth ~= preferredWidth ? preferredWidth : maxWidth
         } else {
             determinedWidth = maxWidth
         }
+
         return determinedWidth
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
When the bottom sheet is animating the views width can become 0 and thus results in our available width being able to be less than the minimum width resulting in a crash if the animation is interupted at the right time.

To fix this we add a guard to make sure that out available width is less than the minWidth before doing a range operation.

### Binary change
Not currently measurable with new infra.


### Verification
Tested in bottom sheet demo with a button to allow closing/opening of the sheet while animating.
<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
|  Sheet could cause crash when animating | Sheet will preform a check to make sure we are creating a valid range |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2110)