### PR TITLE
Expand sheet string

### DIFF
--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -672,11 +672,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     private func updateResizingHandleViewAccessibility(for state: BottomSheetExpansionState) {
         if state == .expanded {
-            resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Collapse".localized
+            resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.CollapseSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
         } else if state == .collapsed {
-            resizingHandleView.accessibilityLabel = handleExpandCustomAccessibilityLabel ?? "Accessibility.Drawer.ResizingHandle.Label.Expand".localized
+            resizingHandleView.accessibilityLabel = handleExpandCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.ExpandSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Collapsed".localized
         }

--- a/Sources/FluentUI_iOS/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/FluentUI_iOS/Resources/Localization/en.lproj/Localizable.strings
@@ -15,9 +15,9 @@
 "Accessibility.AvatarGroup.AvatarListLast" = "and %@";
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
-/* Accessibility label for drawer's resizing handle when it has collapse action */
+/* Accessibility label for bottom sheet's resizing handle when it has collapse action */
 "Accessibility.BottomSheet.ResizingHandle.Label.CollapseSheet" = "Collapse Sheet";
-/* Accessibility label for drawer's resizing handle when it has expand action */
+/* Accessibility label for bottom sheet's resizing handle when it has expand action */
 "Accessibility.BottomSheet.ResizingHandle.Label.ExpandSheet" = "Expand Sheet";
 /* Accessibility hint for the upper calendar date picker view */
 "Accessibility.Calendar.Hint" = "Select a date";

--- a/Sources/FluentUI_iOS/Resources/Localization/en.lproj/Localizable.strings
+++ b/Sources/FluentUI_iOS/Resources/Localization/en.lproj/Localizable.strings
@@ -15,6 +15,10 @@
 "Accessibility.AvatarGroup.AvatarListLast" = "and %@";
 /* Accessibility label format string for avatar view. Format: "<Name>, <Presence>". Example: "Kat, Available" */
 "Accessibility.AvatarView.LabelFormat" = "%@, %@";
+/* Accessibility label for drawer's resizing handle when it has collapse action */
+"Accessibility.BottomSheet.ResizingHandle.Label.CollapseSheet" = "Collapse Sheet";
+/* Accessibility label for drawer's resizing handle when it has expand action */
+"Accessibility.BottomSheet.ResizingHandle.Label.ExpandSheet" = "Expand Sheet";
 /* Accessibility hint for the upper calendar date picker view */
 "Accessibility.Calendar.Hint" = "Select a date";
 /* Accessibility label for the upper calendar date picker view. */


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

We have an internal request to use a more verbose string for the bottom sheet controller resizing handle accessibility label so that the user knows what is being expanded or collapsed.

Previously, the accessibility label would just read "Expand" or "Collapse". Now the accessibility label will read "Expand Sheet" or "Collapse Sheet".

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

- On iPhone, validated that new strings are used when VoiceOver is ON.
- Using simulator and Accessibility Inspector, validated that the accessibility label is set as expected.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| 
<img width="1106" alt="Screenshot 2024-12-30 at 9 09 09 AM" src="https://github.com/user-attachments/assets/d1a5d693-fa13-4b26-b3b6-8dbe6a50aca4" />
 | 
<img width="1089" alt="Screenshot 2024-12-30 at 9 09 27 AM" src="https://github.com/user-attachments/assets/2c5cced7-3e7c-4e53-9f40-54fb1f123261" />
 |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2111)