### PR TITLE
Fixing floating button style horizontal padding

### DIFF
--- a/Sources/FluentUI_iOS/Components/Button/FluentButtonStyle.swift
+++ b/Sources/FluentUI_iOS/Components/Button/FluentButtonStyle.swift
@@ -97,12 +97,11 @@ public struct FluentButtonStyle: SwiftUI.ButtonStyle {
     private var edgeInsets: EdgeInsets {
         let size = size
         let horizontalPadding = ButtonTokenSet.horizontalPadding(style: style, size: size)
-        let fabAlternativePadding = ButtonTokenSet.fabAlternativePadding(size)
         return EdgeInsets(
             top: .zero,
             leading: horizontalPadding,
             bottom: .zero,
-            trailing: style.isFloating ? fabAlternativePadding : horizontalPadding
+            trailing: horizontalPadding
         )
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Fixing UI bugs in `FluentButtonStyle(style: .floatingSubtle)` style from the fluent library.

###Actual behavior:
The icon in the Floating fluent button style is not centered because of some padding added to the icon. Icon must be centered. The fluent icon shape is an oval, but it must be a circle.

###Expected behavior:
Icon must be centered, and button frame should be a circle.

<img width="584" alt="Screenshot 2024-12-18 at 4 55 43 PM" src="https://github.com/user-attachments/assets/afd6bef6-6aa4-4360-97f0-b750403a17a5" />

### Verification

The floating button horizontal margin from icon to frame must be symmetric.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)