### PR TITLE
Added large custom view size to MSFTableViewCell

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -226,10 +226,7 @@ extension TableViewCellDemoController {
             cell.bottomSeparatorType = .inset
         }
 
-        if let customViewSize = section.customViewSize {
-            cell.customViewSize = customViewSize
-        }
-
+        cell.customViewSize = section.customViewSize
         cell.isInSelectionMode = section.allowsMultipleSelection ? isInSelectionMode : false
 
         cell.tokenSet.replaceAllOverrides(with: overrideTokens)

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewCellDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewCellDemoController.swift
@@ -226,6 +226,10 @@ extension TableViewCellDemoController {
             cell.bottomSeparatorType = .inset
         }
 
+        if let customViewSize = section.customViewSize {
+            cell.customViewSize = customViewSize
+        }
+
         cell.isInSelectionMode = section.allowsMultipleSelection ? isInSelectionMode : false
 
         cell.tokenSet.replaceAllOverrides(with: overrideTokens)

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/TableViewCellSampleData.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/TableViewCellSampleData.swift
@@ -52,6 +52,17 @@ class TableViewCellSampleData: TableViewSampleData {
             hasFullLengthLabelAccessoryView: true
         ),
         Section(
+            title: "Cell with large custom view",
+            items: [
+                Item(text1: "Contoso Survey",
+                     text2: "Research Notes",
+                     image: "excelIcon",
+                     text2LeadingAccessoryView: { createIconsAccessoryView(images: ["ic_fluent_share_20_regular", "ic_fluent_lock_closed_20_regular"]) })
+            ],
+            isUnreadDotVisible: true,
+            customViewSize: .large
+        ),
+        Section(
             title: "Cell without custom view",
             items: [
                 Item(text1: "Contoso Survey",

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/TableViewSampleData.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/TableViewSampleData.swift
@@ -25,6 +25,7 @@ class TableViewSampleData {
         let hasCustomAccessoryView: Bool
         let hasCustomLeadingView: Bool
         let hasHandler: Bool
+        let customViewSize: MSFTableViewCellCustomViewSize?
 
         init(title: String,
              items: [Item] = [],
@@ -41,7 +42,8 @@ class TableViewSampleData {
              hasCustomLinkHandler: Bool = false,
              hasCustomAccessoryView: Bool = false,
              hasCustomLeadingView: Bool = false,
-             hasHandler: Bool = false) {
+             hasHandler: Bool = false,
+             customViewSize: MSFTableViewCellCustomViewSize? = nil) {
             self.title = title
             self.items = items
             self.isUnreadDotVisible = isUnreadDotVisible
@@ -58,6 +60,7 @@ class TableViewSampleData {
             self.hasCustomAccessoryView = hasCustomAccessoryView
             self.hasCustomLeadingView = hasCustomLeadingView
             self.hasHandler = hasHandler
+            self.customViewSize = customViewSize
         }
     }
 

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/TableViewSampleData.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/TableViewSampleData.swift
@@ -24,8 +24,8 @@ class TableViewSampleData {
         let hasCustomLinkHandler: Bool
         let hasCustomAccessoryView: Bool
         let hasCustomLeadingView: Bool
+        let customViewSize: MSFTableViewCellCustomViewSize
         let hasHandler: Bool
-        let customViewSize: MSFTableViewCellCustomViewSize?
 
         init(title: String,
              items: [Item] = [],
@@ -42,8 +42,8 @@ class TableViewSampleData {
              hasCustomLinkHandler: Bool = false,
              hasCustomAccessoryView: Bool = false,
              hasCustomLeadingView: Bool = false,
-             hasHandler: Bool = false,
-             customViewSize: MSFTableViewCellCustomViewSize? = nil) {
+             customViewSize: MSFTableViewCellCustomViewSize = .default,
+             hasHandler: Bool = false) {
             self.title = title
             self.items = items
             self.isUnreadDotVisible = isUnreadDotVisible
@@ -59,8 +59,8 @@ class TableViewSampleData {
             self.hasCustomLinkHandler = hasCustomLinkHandler
             self.hasCustomAccessoryView = hasCustomAccessoryView
             self.hasCustomLeadingView = hasCustomLeadingView
-            self.hasHandler = hasHandler
             self.customViewSize = customViewSize
+            self.hasHandler = hasHandler
         }
     }
 

--- a/Sources/FluentUI_iOS/Components/Table View/TableViewCell.swift
+++ b/Sources/FluentUI_iOS/Components/Table View/TableViewCell.swift
@@ -233,7 +233,7 @@ open class TableViewCell: UITableViewCell, TokenizedControl {
                                          footerLeadingAccessoryView: footerLeadingAccessoryView,
                                          footerTrailingAccessoryView: footerTrailingAccessoryView)
         // Layout type should accommodate for the customViewSize, even if it is only one line.
-        if customViewSize == .medium && layoutType == .oneLine {
+        if (customViewSize == .medium || customViewSize == .large) && layoutType == .oneLine {
             layoutType = .twoLines
         }
         let customViewSize = Self.customViewSize(from: customViewSize, layoutType: layoutType)

--- a/Sources/FluentUI_iOS/Components/TableViewListShared/TableViewCellTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/TableViewListShared/TableViewCellTokenSet.swift
@@ -113,6 +113,8 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellToken> {
                         return GlobalTokens.icon(.size240)
                     case .medium, .default:
                         return GlobalTokens.icon(.size400)
+                    case .large:
+                        return GlobalTokens.icon(.size480)
                     }
                 }
 
@@ -125,6 +127,8 @@ public class TableViewCellTokenSet: ControlTokenSet<TableViewCellToken> {
                         return GlobalTokens.spacing(.size160)
                     case .medium, .default:
                         return GlobalTokens.spacing(.size120)
+                    case .large:
+                        return GlobalTokens.spacing(.size80)
                     }
                 }
 
@@ -283,6 +287,7 @@ extension TableViewCellTokenSet {
     case zero
     case small
     case medium
+    case large
 }
 
 // MARK: TableViewCellAccessoryType


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
- Added a large custom view size option MSFTableViewCell to accommodate larger custom views. 
- TableViewCell.swift
  - Forcing two line layout when using the new large size if the layout type was trying to be one line.
- Added the large custom view size example to the demo app
### Binary change

N/A

### Verification
When using a fluent avatar with size 40 and then setting an activity, for example:
```
let avatar = MSFAvatar(style: .default, size: .size40)
avatar.state.activityStyle = .circle
avatar.state.activityImage = UIImage(systemName: "star")
avatar.state.image = UIImage(systemName: "person")
```
The avatar view will actually go from having 40x40 dimensions, to having 46x46 dimensions. When using the fluent table view cell which can only accommodate 40x40, this causes the unread status to make contact with the custom view. However, when using the new large custom view, that is no longer the case.

| Before (Using medium custom view size) | After (using new large custom view size)     |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/3114cb66-4d3b-4418-92bf-a4efd34df49e) | ![image](https://github.com/user-attachments/assets/a169f3f9-bd92-4272-960b-e4834ed40eca) |
</details>

| Before (Not forcing two line layout for large custom view size) | After (forcing two line layout for large custom view size) |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/153ca9fc-708d-404a-b441-9544f77af26f)  | ![image](https://github.com/user-attachments/assets/e2beb689-10d3-456a-8572-fc977690b917) |
</details>

Large custom view size added to testapp:
![image](https://github.com/user-attachments/assets/7b9e3f6e-8f03-4b83-a728-2de860917a2e)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2114)