### PR TITLE
[BottomSheetController] Use view.bounds instead of view.frame when calculating sheet offset

### DIFF
--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -1038,16 +1038,16 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         switch expansionState {
         case .collapsed:
             if !isHeightRestricted || !isExpandable {
-                offset = view.frame.maxY - collapsedSheetHeight
+                offset = view.bounds.maxY - collapsedSheetHeight
             } else {
                 // When we're height restricted a distinct collapsed offset doesn't make sense,
                 // so we go straight to expanded.
                 fallthrough
             }
         case .expanded:
-            offset = view.frame.maxY - expandedSheetHeight
+            offset = view.bounds.maxY - expandedSheetHeight
         case .hidden:
-            offset = view.frame.maxY
+            offset = view.bounds.maxY
         case .transitioning:
             offset = bottomSheetView.frame.minY
         }


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

If the root view of the bottom sheet had a non-zero frame origin, the offset of the sheet would be miscalculated because the offset function was using the view frame and not the view bounds. When calculating the offset, we should use the view bounds so that the offset is calculated relative to the bottom sheet's root view's own space.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

In the `BottomSheetControllerDemo`, I validated that the bottom sheet is correctly laid out when the bottom sheet view has an offset applied to its top anchor.

<details>
<summary>Visual Verification</summary>
In the first row of images, you can see in the before that the sheet in the collapsed state is not visible and in the after it is. In the second row, you can see in the before that the sheet is push way off the screen due to the calculation using the frame and not the bounds, and in the after you can see that it is correctly positioned.

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="931" alt="Screenshot 2025-01-13 at 12 03 18 PM" src="https://github.com/user-attachments/assets/95306c50-911e-454f-919a-9876a74a0e06" /> | <img width="932" alt="Screenshot 2025-01-13 at 12 02 37 PM" src="https://github.com/user-attachments/assets/50adb1bf-e3e1-4158-8222-e426b75aed1e" /> |
| <img width="470" alt="Screenshot 2025-01-13 at 11 27 14 AM" src="https://github.com/user-attachments/assets/72e088b6-0097-4cd7-a4ae-331014b1b715" /> | <img width="861" alt="Screenshot 2025-01-13 at 12 02 25 PM" src="https://github.com/user-attachments/assets/2611d79b-df2a-49f3-bbe6-864713e2f52d" /> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2115)