### PR TITLE
[iOS Demo App] Fix retain cycles in bottom sheet demo  

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -118,16 +118,16 @@ class BottomSheetDemoController: DemoController {
         secondarySheetController.isFlexibleHeight = true
         secondarySheetController.allowsSwipeToHide = true
 
-        let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { _ in
-            secondarySheetController.setIsHidden(true, animated: true)
+        let dismissButton = Button(primaryAction: UIAction(title: "Dismiss", handler: { [weak secondarySheetController] _ in
+            secondarySheetController?.setIsHidden(true, animated: true)
         }))
 
         dismissButton.style = .accent
         dismissButton.translatesAutoresizingMaskIntoConstraints = false
         sheetContentView.addSubview(dismissButton)
 
-        let anotherOneButton = Button(primaryAction: UIAction(title: "Show another sheet", handler: { _ in
-            self.showTransientSheet()
+        let anotherOneButton = Button(primaryAction: UIAction(title: "Show another sheet", handler: { [weak self] _ in
+            self?.showTransientSheet()
         }))
         anotherOneButton.translatesAutoresizingMaskIntoConstraints = false
         sheetContentView.addSubview(anotherOneButton)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

We have a few retain cycles (noted by #2106), one where a strong reference to self is sent to a block stored by a strong var of self, the other where a strong reference to a view controller is sent to a block stored by a view in that view controller's hierarchy. Fix both using weak references in these blocks.

### Binary change

N/A - No product change

### Verification

Sanity in the test app by temporarily adding a deinit to the view controller and a breakpoint confirmed that it is now called when the view controller is dismissed.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2116)