### PR TITLE
Support CommandBarButton with icon and label

### DIFF
--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButton.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButton.swift
@@ -48,7 +48,9 @@ class CommandBarButton: UIButton {
             isAccessibilityElement = false
         } else {
             var buttonConfiguration = UIButton.Configuration.plain()
+            buttonConfiguration.title = item.title
             buttonConfiguration.image = item.iconImage
+            buttonConfiguration.imagePadding = CommandBarTokenSet.buttonImagePadding
             buttonConfiguration.contentInsets = CommandBarTokenSet.buttonContentInsets
             buttonConfiguration.background.cornerRadius = 0
             configuration = buttonConfiguration
@@ -87,14 +89,6 @@ class CommandBarButton: UIButton {
             return
         }
 
-        // always update icon and title as we only display one; we may alterenate between them, and the icon may also change
-        let iconImage = item.iconImage
-        let title = item.title
-        let accessibilityDescription = item.accessibilityLabel
-
-        configuration?.image = iconImage
-        configuration?.title = iconImage != nil ? nil : title
-
         if let font = item.titleFont {
             let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])
             configuration?.attributedTitle?.setAttributes(attributeContainer)
@@ -105,7 +99,8 @@ class CommandBarButton: UIButton {
 
         titleLabel?.isEnabled = isEnabled
 
-        accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : title
+        let accessibilityDescription = item.accessibilityLabel
+        accessibilityLabel = (accessibilityDescription != nil) ? accessibilityDescription : item.title
         accessibilityHint = item.accessibilityHint
         accessibilityValue = item.accessibilityValue
         accessibilityIdentifier = item.accessibilityIdentifier

--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarItem.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarItem.swift
@@ -88,7 +88,7 @@ open class CommandBarItem: NSObject {
         }
     }
 
-    /// Title for the item. Only valid when `iconImage` is `nil`.
+    /// Title for the item.
     @objc public var title: String? {
         didSet {
             if title != oldValue {

--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarTokenSet.swift
@@ -117,4 +117,7 @@ extension CommandBarTokenSet {
                                                        leading: 10.0,
                                                        bottom: 8.0,
                                                        trailing: 10.0)
+
+    /// The padding between the Command Bar Button image and title.
+    static let buttonImagePadding: CGFloat = GlobalTokens.spacing(.size60)
 }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Currently, our `CommandBarButton` only supports icon-only or label-only buttons. Add the ability to have an icon and label button.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/user-attachments/assets/35502cc4-b840-4172-be0f-cda7c1912fbd) | ![after](https://github.com/user-attachments/assets/c51f74e4-1647-4704-8a4a-d67299f4c88d) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2117)