### PR TITLE
Tab Bar View can hide separator and disable blur effect

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -73,7 +73,7 @@ class TabBarViewDemoController: DemoController {
         addRow(text: "Use gradient selection", items: [useGradientSelectionSwitch], textWidth: Constants.switchSettingTextWidth)
         useGradientSelectionSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
 
-        addRow(text: "Modify badge numbers", items: [incrementBadgeButton, decrementBadgeButton], textWidth: Constants.buttonSettingTextWidth)
+        addRow(text: "Modify badge numbers", items: [decrementBadgeButton, incrementBadgeButton], textWidth: Constants.buttonSettingTextWidth)
 
         setupTabBarView()
         updateBadgeButtons()

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TabBarViewDemoController.swift
@@ -20,11 +20,15 @@ class TabBarViewDemoController: DemoController {
     private var showBadgeNumbers: Bool { return showBadgeNumbersSwitch.isOn }
     private var useHigherBadgeNumbers: Bool { return useHigherBadgeNumbersSwitch.isOn }
     private var useGradientSelection: Bool { return useGradientSelectionSwitch.isOn }
+    private var blurBlackground: Bool { return blurBlackgroundSwitch.isOn }
+    private var hideSeparatorSelection: Bool { return hideSeparatorSelectionSwitch.isOn }
 
     private let itemTitleVisibilitySwitch = BrandedSwitch()
     private let showBadgeNumbersSwitch = BrandedSwitch()
     private let useHigherBadgeNumbersSwitch = BrandedSwitch()
     private let useGradientSelectionSwitch = BrandedSwitch()
+    private let blurBlackgroundSwitch = BrandedSwitch()
+    private let hideSeparatorSelectionSwitch = BrandedSwitch()
 
     private lazy var incrementBadgeButton: Button = {
         return createButton(title: "+", action: #selector(incrementBadgeNumbers))
@@ -73,6 +77,13 @@ class TabBarViewDemoController: DemoController {
         addRow(text: "Use gradient selection", items: [useGradientSelectionSwitch], textWidth: Constants.switchSettingTextWidth)
         useGradientSelectionSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
 
+        addRow(text: "Blur background", items: [blurBlackgroundSwitch], textWidth: Constants.switchSettingTextWidth)
+        blurBlackgroundSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
+        blurBlackgroundSwitch.isOn = true
+
+        addRow(text: "Hide Separator", items: [hideSeparatorSelectionSwitch], textWidth: Constants.switchSettingTextWidth)
+        hideSeparatorSelectionSwitch.addTarget(self, action: #selector(handleOnSwitchValueChanged), for: .valueChanged)
+
         addRow(text: "Modify badge numbers", items: [decrementBadgeButton, incrementBadgeButton], textWidth: Constants.buttonSettingTextWidth)
 
         setupTabBarView()
@@ -115,6 +126,9 @@ class TabBarViewDemoController: DemoController {
         if useGradientSelection {
             updatedTabBarView.selectedItemGradient = gradient
         }
+
+        updatedTabBarView.backgroundIsBlurred = blurBlackground
+        updatedTabBarView.separatorIsHidden = hideSeparatorSelection
 
         updatedTabBarView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(updatedTabBarView)

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
@@ -92,24 +92,11 @@ open class TabBarView: UIView, TokenizedControl {
             stackView.setCustomSpacing(spacing, after: view)
         }
     }
-    /// Initializes MSTabBarView
-    /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
-    @objc public convenience init(showsItemTitles: Bool = false) {
-        self.init(showsItemTitles: showsItemTitles, hideSeparator: false, disableBlur: false)
-    }
 
     /// Initializes MSTabBarView
     /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
-    /// - Parameter hideSeparator: Removes the top divider displayed above the tab bar.
-    /// - Parameter disableBlur: Disables the blur effect applied to the tab bar.
-    @objc public init(showsItemTitles: Bool = false, hideSeparator: Bool = false, disableBlur: Bool = false) {
+    @objc public init(showsItemTitles: Bool = false) {
         self.showsItemTitles = showsItemTitles
-
-        if disableBlur {
-            self.backgroundView = UIVisualEffectView()
-        } else {
-          self.backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemChromeMaterial))
-        }
 
         super.init(frame: .zero)
 
@@ -121,7 +108,6 @@ open class TabBarView: UIView, TokenizedControl {
         let stackViewInsets = Compatibility.isDeviceIdiomVision() ? UIEdgeInsets(top: 12.0, left: 0.0, bottom: 12.0, right: 0.0) : .zero
         contain(view: stackView, withInsets: stackViewInsets, respectingSafeAreaInsets: true)
 
-        topBorderLine.isHidden = hideSeparator
         topBorderLine.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topBorderLine)
 
@@ -170,11 +156,27 @@ open class TabBarView: UIView, TokenizedControl {
 
     @objc public static let tabBarPadHeight: CGFloat = TabBarTokenSet.padHeight
 
+    @objc public var backgroundIsBlurred: Bool = true {
+        didSet {
+            if backgroundIsBlurred != oldValue {
+                backgroundView.effect = backgroundIsBlurred ? UIBlurEffect(style: UIBlurEffect.Style.systemChromeMaterial) : nil
+            }
+        }
+    }
+
+    @objc public var separatorIsHidden: Bool = false {
+        didSet {
+            if separatorIsHidden != oldValue {
+                topBorderLine.isHidden = separatorIsHidden
+            }
+        }
+    }
+
     private struct Constants {
         static let maxTabCount: Int = 6
     }
 
-    private let backgroundView: UIVisualEffectView
+    private let backgroundView: UIVisualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemChromeMaterial))
 
     private lazy var heightConstraint: NSLayoutConstraint = stackView.heightAnchor.constraint(equalToConstant: traitCollection.userInterfaceIdiom == .phone ? TabBarTokenSet.phonePortraitHeight : TabBarTokenSet.padHeight)
 

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
@@ -102,7 +102,7 @@ open class TabBarView: UIView, TokenizedControl {
     /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
     /// - Parameter hideSeparator: Removes the top divider displayed with the Tab Bar
     /// - Parameter disableBlur: Disables the blur effect applied to the Tab Bar
-    @objc public init(showsItemTitles: Bool = false, hideSeparator: Bool = true, disableBlur: Bool = false) {
+    @objc public init(showsItemTitles: Bool = false, hideSeparator: Bool = false, disableBlur: Bool = false) {
         self.showsItemTitles = showsItemTitles
 
         if disableBlur {

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
@@ -95,8 +95,15 @@ open class TabBarView: UIView, TokenizedControl {
 
     /// Initializes MSTabBarView
     /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
-    @objc public init(showsItemTitles: Bool = false) {
+    @objc public init(showsItemTitles: Bool = false, hideSeparator: Bool = true, disableBlur: Bool = false) {
         self.showsItemTitles = showsItemTitles
+
+        if disableBlur {
+            self.backgroundView = UIVisualEffectView()
+        } else {
+          self.backgroundView = UIVisualEffectView(effect: UIBlurEffect(style: UIBlurEffect.Style.systemChromeMaterial))
+        }
+
         super.init(frame: .zero)
 
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
@@ -107,6 +114,7 @@ open class TabBarView: UIView, TokenizedControl {
         let stackViewInsets = Compatibility.isDeviceIdiomVision() ? UIEdgeInsets(top: 12.0, left: 0.0, bottom: 12.0, right: 0.0) : .zero
         contain(view: stackView, withInsets: stackViewInsets, respectingSafeAreaInsets: true)
 
+        topBorderLine.isHidden = hideSeparator
         topBorderLine.translatesAutoresizingMaskIntoConstraints = false
         addSubview(topBorderLine)
 
@@ -159,12 +167,7 @@ open class TabBarView: UIView, TokenizedControl {
         static let maxTabCount: Int = 6
     }
 
-    private let backgroundView: UIVisualEffectView = {
-        var style = UIBlurEffect.Style.regular
-        style = .systemChromeMaterial
-
-        return UIVisualEffectView(effect: UIBlurEffect(style: style))
-    }()
+    private let backgroundView: UIVisualEffectView
 
     private lazy var heightConstraint: NSLayoutConstraint = stackView.heightAnchor.constraint(equalToConstant: traitCollection.userInterfaceIdiom == .phone ? TabBarTokenSet.phonePortraitHeight : TabBarTokenSet.padHeight)
 

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
@@ -100,8 +100,8 @@ open class TabBarView: UIView, TokenizedControl {
 
     /// Initializes MSTabBarView
     /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
-    /// - Parameter hideSeparator: Removes the top divider displayed with the Tab Bar
-    /// - Parameter disableBlur: Disables the blur effect applied to the Tab Bar
+    /// - Parameter hideSeparator: Removes the top divider displayed above the tab bar.
+    /// - Parameter disableBlur: Disables the blur effect applied to the tab bar.
     @objc public init(showsItemTitles: Bool = false, hideSeparator: Bool = false, disableBlur: Bool = false) {
         self.showsItemTitles = showsItemTitles
 

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarView.swift
@@ -92,9 +92,16 @@ open class TabBarView: UIView, TokenizedControl {
             stackView.setCustomSpacing(spacing, after: view)
         }
     }
+    /// Initializes MSTabBarView
+    /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
+    @objc public convenience init(showsItemTitles: Bool = false) {
+        self.init(showsItemTitles: showsItemTitles, hideSeparator: false, disableBlur: false)
+    }
 
     /// Initializes MSTabBarView
     /// - Parameter showsItemTitles: Determines whether or not to show the titles of the tab bar items.
+    /// - Parameter hideSeparator: Removes the top divider displayed with the Tab Bar
+    /// - Parameter disableBlur: Disables the blur effect applied to the Tab Bar
     @objc public init(showsItemTitles: Bool = false, hideSeparator: Bool = true, disableBlur: Bool = false) {
         self.showsItemTitles = showsItemTitles
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
Consumers have no way currently to control the separator and blur effect created by the tab bar view. This PR adds the ability to specify in the init that you want to disable either/both the separator or the blur effect.  We do not apply any effect to the background view if the blur effect is disabled. If the separator is disabled we will set the hidden property on the separator view to true.

Tab Bar View demo app has the incrementor on the right and decrementor on the left to match LTR design patterns.
Additionally, it now has toggles for the control of the separator and blur effect.

### Binary change
(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
- [x] Built objective c projects that use Tab Bar View
- [x] Tab Bar View can be seen with no separator and blur effect in the demo controller.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="586" alt="TabBarViewDefault" src="https://github.com/user-attachments/assets/72147a46-efcb-4883-befa-946de1002546" /> | <img width="561" alt="TabBarViewNoBlurNoDivider" src="https://github.com/user-attachments/assets/89b94ebd-f06b-4b77-ad58-070cf37be915" /> |
| ![image](https://github.com/user-attachments/assets/bee46d81-3253-47c0-a2e1-abb6d6f8553d) | ![image](https://github.com/user-attachments/assets/579cb9a5-ed8f-4340-a25e-77e8518c121c) | 
</details>



### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2119)