### PR TITLE
[macOS] Fix ObjC export of MultilinePillPickerView

### DIFF
--- a/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
+++ b/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
@@ -42,7 +42,7 @@ public final class MultilinePillPickerView: ControlHostingView, ObservableObject
 	@MainActor @Published public var labels: [String]
 	@MainActor @Published public var action: (@MainActor (Int) -> Void)?
 
-	@MainActor private var viewModel: MultilinePillPickerViewModel = .init()
+	@MainActor private let viewModel: MultilinePillPickerViewModel = .init()
 }
 
 /// Maps properties from `MultilinePillPickerView` to `MultilinePillPickerViewWrapper`.

--- a/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
+++ b/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
@@ -56,8 +56,10 @@ fileprivate struct MultilinePillPickerWrapper: View {
 	@ObservedObject var viewModel: MultilinePillPickerViewModel
 
 	var body: some View {
-		MultilinePillPicker(labels: viewModel.labels,
-							action: viewModel.action)
+		MultilinePillPicker(
+			labels: viewModel.labels,
+			action: viewModel.action
+		)
 		.disabled(!viewModel.isEnabled)
 	}
 }

--- a/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
+++ b/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
@@ -49,6 +49,6 @@ public final class MultilinePillPickerView: ControlHostingView {
 	private func updatePicker() {
 		let picker = MultilinePillPicker(labels: labels, action: action)
 			.disabled(!isEnabled)
-		rootView = AnyView(picker)
+		hostingView.rootView = AnyView(picker)
 	}
 }

--- a/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
+++ b/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
@@ -4,7 +4,6 @@
 //
 
 import AppKit
-import Combine
 import SwiftUI
 
 /// This is a work-in-progress control for hosting multiple rows of pill buttons. At present, this control
@@ -25,22 +24,17 @@ public final class MultilinePillPickerView: ControlHostingView, ObservableObject
 		self.hostingView.rootView = AnyView(wrapper)
 
 		// Set up observation to keep the view model in sync.
-		viewModel.loadProperties(from: self)
-		cancellable = self.objectWillChange.sink { [weak self] in
-			DispatchQueue.main.async {
-				if let self {
-					self.viewModel.loadProperties(from: self)
-				}
-			}
-		}
+		bindProperty(from: self.$isEnabled, to: \.isEnabled, on: viewModel)
+		bindProperty(from: self.$labels, to: \.labels, on: viewModel)
+		bindProperty(from: self.$action, to: \.action, on: viewModel)
 	}
 
 	@MainActor required dynamic init?(coder aDecoder: NSCoder) {
-		fatalError("init(coder:) has not been implemented")
+		preconditionFailure("init(coder:) has not been implemented")
 	}
 
 	@MainActor required init(rootView: AnyView) {
-		fatalError("init(rootView:) has not been implemented")
+		preconditionFailure("init(rootView:) has not been implemented")
 	}
 
 	@MainActor @Published public var isEnabled: Bool = true
@@ -48,20 +42,13 @@ public final class MultilinePillPickerView: ControlHostingView, ObservableObject
 	@MainActor @Published public var action: (@MainActor (Int) -> Void)?
 
 	@MainActor private var viewModel: MultilinePillPickerViewModel = .init()
-	private var cancellable: AnyCancellable?
 }
 
 /// Maps properties from `MultilinePillPickerView` to `MultilinePillPickerViewWrapper`.
 fileprivate class MultilinePillPickerViewModel: ObservableObject {
 	@Published var isEnabled: Bool = true
 	@Published var labels: [String] = []
-	@Published var action: ((Int) -> Void)?
-
-	@MainActor func loadProperties(from host: MultilinePillPickerView) {
-		isEnabled = host.isEnabled
-		labels = host.labels
-		action = host.action
-	}
+	@Published var action: (@MainActor (Int) -> Void)?
 }
 
 /// Private wrapper `View` to map from view model to `MultilinePillPicker`.

--- a/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
+++ b/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
@@ -4,12 +4,13 @@
 //
 
 import AppKit
+import Combine
 import SwiftUI
 
 /// This is a work-in-progress control for hosting multiple rows of pill buttons. At present, this control
 /// only supports a hard-coded two rows of elements.
 @objc(MSFMultilinePillPickerView)
-public final class MultilinePillPickerView: ControlHostingView {
+public final class MultilinePillPickerView: ControlHostingView, ObservableObject {
 	/// Creates a multiline pill picker.
 	/// - Parameters:
 	///   - labels: An array of labels to show in the picker.
@@ -18,8 +19,10 @@ public final class MultilinePillPickerView: ControlHostingView {
 	@MainActor public init(labels: [String], action: (@MainActor (Int) -> Void)? = nil) {
 		self.labels = labels
 		self.action = action
-		let picker = MultilinePillPicker(labels: labels, action: action)
-		super.init(AnyView(picker))
+		super.init(AnyView(EmptyView()))
+
+		let wrapper = MultilinePillPickerWrapper(viewModel: self)
+		self.hostingView.rootView = AnyView(wrapper)
 	}
 
 	@MainActor required dynamic init?(coder aDecoder: NSCoder) {
@@ -30,25 +33,18 @@ public final class MultilinePillPickerView: ControlHostingView {
 		fatalError("init(rootView:) has not been implemented")
 	}
 
-	@MainActor public var isEnabled: Bool = true {
-		didSet {
-			updatePicker()
-		}
-	}
-	@MainActor public var labels: [String] {
-		didSet {
-			updatePicker()
-		}
-	}
-	@MainActor public var action: (@MainActor (Int) -> Void)? {
-		didSet {
-			updatePicker()
-		}
-	}
+	@MainActor @Published public var isEnabled: Bool = true
+	@MainActor @Published public var labels: [String]
+	@MainActor @Published public var action: (@MainActor (Int) -> Void)?
+}
 
-	private func updatePicker() {
-		let picker = MultilinePillPicker(labels: labels, action: action)
-			.disabled(!isEnabled)
-		hostingView.rootView = AnyView(picker)
+/// Private wrapper `View` to map from view model to `MultilinePillPicker`.
+fileprivate struct MultilinePillPickerWrapper: View {
+	@ObservedObject var viewModel: MultilinePillPickerView
+
+	var body: some View {
+		MultilinePillPicker(labels: viewModel.labels,
+							action: viewModel.action)
+		.disabled(!viewModel.isEnabled)
 	}
 }

--- a/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
+++ b/Sources/FluentUI_macOS/Components/MultilinePillPicker/MultilinePillPickerView.swift
@@ -4,6 +4,7 @@
 //
 
 import AppKit
+import Combine
 import SwiftUI
 
 /// This is a work-in-progress control for hosting multiple rows of pill buttons. At present, this control

--- a/Sources/FluentUI_macOS/Core/ControlHostingView.swift
+++ b/Sources/FluentUI_macOS/Core/ControlHostingView.swift
@@ -6,32 +6,54 @@
 import AppKit
 import SwiftUI
 
-/// Common wrapper for hosting and exposing SwiftUI components to AppKit-based clients.
-open class ControlHostingView: NSHostingView<AnyView> {
+/// Common wrapper for hosting and exposing SwiftUI components to UIKit-based clients.
+open class ControlHostingView: NSView {
+
+	/// The intrinsic content size of the wrapped SwiftUI view.
+	@objc public override var intrinsicContentSize: CGSize {
+		// Our desired size should always be the same as our hosted view.
+		return hostingView.intrinsicContentSize
+	}
+
 	/// Initializes and returns an instance of `ControlHostingContainer` that wraps `controlView`.
 	///
 	/// Unfortunately this class can't use Swift generics, which are incompatible with Objective-C interop. Instead we have to wrap
 	/// the control view in an `AnyView.`
 	///
 	/// - Parameter controlView: An `AnyView`-wrapped component to host.
-	/// - Parameter safeAreaRegions: Passthrough to the respective property on NSHostingView.
+	/// - Parameter safeAreaRegions: Passthrough to the respective property on UIHostingController.
 	/// Indicates which safe area regions the underlying hosting controller should add to its view.
 	public init(_ controlView: AnyView, safeAreaRegions: SafeAreaRegions = .all) {
-		super.init(rootView: controlView)
+		hostingView = NSHostingView.init(rootView: controlView)
 		if #available(macOS 13.3, *) {
-			self.sizingOptions = [.intrinsicContentSize]
-			self.safeAreaRegions = safeAreaRegions
+			hostingView.sizingOptions = [.intrinsicContentSize]
+			hostingView.safeAreaRegions = safeAreaRegions
 		}
 
-		layer?.backgroundColor = .clear
-		translatesAutoresizingMaskIntoConstraints = false
+		super.init(frame: .zero)
+
+		self.configureHostedView()
 	}
 
-	@MainActor @preconcurrency required public init?(coder: NSCoder) {
+	required public init?(coder: NSCoder) {
 		preconditionFailure("init(coder:) has not been implemented")
 	}
-	
-	@MainActor @preconcurrency required public init(rootView: AnyView) {
-		preconditionFailure("init(rootView:) has not been implemented")
+
+	let hostingView: NSHostingView<AnyView>
+
+	/// Adds `hostingController.view` to ourselves as a subview, and enables necessary constraints.
+	private func configureHostedView() {
+		hostingView.layer?.backgroundColor = NSColor.clear.cgColor
+
+		addSubview(hostingView)
+		hostingView.translatesAutoresizingMaskIntoConstraints = false
+
+		let requiredConstraints = [
+			hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+			hostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+			hostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+			hostingView.topAnchor.constraint(equalTo: topAnchor)
+		]
+		self.addConstraints(requiredConstraints)
 	}
 }

--- a/Sources/FluentUI_macOS/Core/ControlHostingView.swift
+++ b/Sources/FluentUI_macOS/Core/ControlHostingView.swift
@@ -22,7 +22,7 @@ open class ControlHostingView: NSView {
 	/// the control view in an `AnyView.`
 	///
 	/// - Parameter controlView: An `AnyView`-wrapped component to host.
-	/// - Parameter safeAreaRegions: Passthrough to the respective property on UIHostingController.
+	/// - Parameter safeAreaRegions: Passthrough to the respective property on NSHostingView.
 	/// Indicates which safe area regions the underlying hosting controller should add to its view.
 	public init(_ controlView: AnyView, safeAreaRegions: SafeAreaRegions = .all) {
 		hostingView = NSHostingView.init(rootView: controlView)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

My previous PR #2121 didn't work in ObjC as expected. Since we don't have a real ObjC demo in macOS yet, this was manually validated to quickly unblock the issue.

(The problem was inheriting from a generic class -- that silently fails to export to Objective-C, even though there's an `@objc` in the title.)

### Binary change

n/a, still can't measure macOS

### Verification

Verified MPP component still renders as expected.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2122)