### PR TITLE
[a11y] Extend DemoController's alert auto-dismiss delay when vo is on

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/DemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/DemoController.swift
@@ -96,7 +96,8 @@ class DemoController: UIViewController {
         present(alert, animated: true)
 
         if autoDismiss {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            let delay: TimeInterval = UIAccessibility.isVoiceOverRunning ? 3 : 1
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
                 self.dismiss(animated: true)
             }
         } else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

`DemoController`'s `showMessage` has an auto dismiss option of 1 second. When voice over is running, this is too fast and ends up dismissing the alert before the alert message can be read. Update it to be 3 seconds when vo is on.

### Verification

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| https://github.com/user-attachments/assets/1edbf183-88e5-4ed9-a377-5e29244929dc | https://github.com/user-attachments/assets/cba02757-3d3d-4325-9a65-ebaafcc042a2 |

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2123)