### PR TITLE
Show large content viewer instead of scaling pill buttons in large text mode

### DIFF
--- a/Sources/FluentUI_iOS/Components/Pill Button Bar/PillButton.swift
+++ b/Sources/FluentUI_iOS/Components/Pill Button Bar/PillButton.swift
@@ -134,6 +134,7 @@ open class PillButton: UIButton, TokenizedControl {
         layer.cornerCurve = .continuous
         largeContentTitle = titleLabel?.text
         showsLargeContentViewer = true
+        addInteraction(UILargeContentViewerInteraction())
     }
 
     private func updateAccessibilityTraits() {

--- a/Sources/FluentUI_iOS/Components/Pill Button Bar/PillButtonTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Pill Button Bar/PillButtonTokenSet.swift
@@ -121,7 +121,7 @@ public class PillButtonTokenSet: ControlTokenSet<PillButtonToken> {
                 }
 
             case .font:
-                return .uiFont { theme.typography(.body2) }
+                return .uiFont { theme.typography(.body2, adjustsForContentSizeCategory: false) }
 
             case .titleColor:
                 return .uiColor {


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Currently, PillButtonBar is broken on large text mode and should be relying on its `UILargeContentViewerInteraction` instead. This change changes the font of the PillButton to not scale with size category changes and use a `UILargeContentViewerInteraction`.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Pill buttons no longer scale and show a large content viewer instead.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/user-attachments/assets/8af4305a-e44c-4ea3-a70a-725ad172a92f) | ![after](https://github.com/user-attachments/assets/22c3bfa3-76a7-4ab2-b554-21a1b63968c6) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2127)