### PR TITLE
Prototype changes to preserve VoiceOver Focus on SheetGrabber button …

### DIFF
--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -622,8 +622,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         stackView.addArrangedSubview(expandedContentView)
         bottomSheetContentView.accessibilityElements?.append(expandedContentView)
         bottomSheetContentView.addSubview(stackView)
-		
-//		bottomSheetContentView.accessibilityViewIsModal = true;
 
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: bottomSheetContentView.topAnchor),

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -622,6 +622,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         stackView.addArrangedSubview(expandedContentView)
         bottomSheetContentView.accessibilityElements?.append(expandedContentView)
         bottomSheetContentView.addSubview(stackView)
+		
+//		bottomSheetContentView.accessibilityViewIsModal = true;
 
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: bottomSheetContentView.topAnchor),
@@ -941,6 +943,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         completeAnimationsIfNeeded()
 
         updateResizingHandleViewAccessibility(for: targetExpansionState)
+		UIAccessibility.post(notification: .layoutChanged, argument: resizingHandleView) // Works!
 
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
             delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)


### PR DESCRIPTION
…after collapse

### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2133)