### PR TITLE
PROTOTYPE voice over focus bug for people picker persona suggestions

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift
@@ -79,6 +79,12 @@ extension TableViewHeaderFooterViewDemoController {
         let section = groupedSections[section]
         if let header = header, section.hasHandler {
             header.onHeaderViewTapped = { [weak self] in self?.forHeaderTapped(header: header, section: index) }
+//            let state = collapsedSections[index] ? "Expand" : "Collapse"
+            
+            // header.accessibilityLabel isn't assigned here yet. Currently I suspect it's being read out from the private
+//            `titleView` property which is a `TableViewHeaderFooterTitleView`. The trait on that is set as
+            // `titleView.accessibilityTraits.insert(.header)`
+            header.accessibilityLabel = "\(header.accessibilityLabel ?? ""), \(collapsedSections[index] ? "Collapse" : "Expand")"
         }
 
         if section.hasCustomAccessoryView {

--- a/Sources/FluentUI_iOS/Components/People Picker/PeoplePicker.swift
+++ b/Sources/FluentUI_iOS/Components/People Picker/PeoplePicker.swift
@@ -355,7 +355,7 @@ open class PeoplePicker: BadgeField {
         personaSuggestionsView.removeFromSuperview()
         containingViewBoundsObservation = nil
 		
-		personaSuggestionsView.accessibilityViewIsModal = true
+		personaSuggestionsView.accessibilityViewIsModal = false
 		
         delegate?.peoplePickerDidHidePersonaSuggestions?(self)
 				

--- a/Sources/FluentUI_iOS/Components/People Picker/PeoplePicker.swift
+++ b/Sources/FluentUI_iOS/Components/People Picker/PeoplePicker.swift
@@ -247,11 +247,11 @@ open class PeoplePicker: BadgeField {
         delegate?.peoplePickerDidShowPersonaSuggestions?(self)
 		
 //		DEBUG: this makes it so that the elements of the entire peoplePicker view behind are not VO accessible.
-		personaSuggestionsView.accessibilityViewIsModal = true
+//		personaSuggestionsView.accessibilityViewIsModal = true
 		
 		// layoutChanged - because if the focus is on the personaBadge text field, it doesn't automaticaly move to window
 //		UIAccessibility.post(notification: .layoutChanged, argument: nil)
-		UIAccessibility.post(notification: .layoutChanged, argument: personaSuggestionsView)
+//		UIAccessibility.post(notification: .layoutChanged, argument: personaSuggestionsView)
 		
 		// DEBUG: I can't do the below with totally hiding the containingViewController's ccessibilityElements
 		// because it's similar to doing `personaSuggestionsView.accessibilityViewIsModal=true` which don't let me
@@ -355,7 +355,7 @@ open class PeoplePicker: BadgeField {
         personaSuggestionsView.removeFromSuperview()
         containingViewBoundsObservation = nil
 		
-		personaSuggestionsView.accessibilityViewIsModal = false
+//		personaSuggestionsView.accessibilityViewIsModal = false
 		
         delegate?.peoplePickerDidHidePersonaSuggestions?(self)
 				

--- a/Sources/FluentUI_iOS/Components/People Picker/PeoplePicker.swift
+++ b/Sources/FluentUI_iOS/Components/People Picker/PeoplePicker.swift
@@ -234,7 +234,7 @@ open class PeoplePicker: BadgeField {
 //		personaSuggestionsView.isAccessibilityElement = false
 
 		// DEBUG: The subView is added to `window` and not the PeoplePickerView, which might cause the weird FocusOrder
-        window?.addSubview(personaSuggestionsView)
+        self.addSubview(personaSuggestionsView)
 //		self.addSubview(personaSuggestionsView) // Can't do this. There's probably some benefits to adding it to the window. ie. Layouting wrt. the entire window's contents like keyboard.
 
         containingViewBoundsObservation = window?.observe(\.bounds) { [unowned self] (_, _) in


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2135)