### PR TITLE
[iOS] Update `LinearGradientInfo` to use SwiftUI `Color`

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -4,6 +4,7 @@
 //
 
 import FluentUI
+import SwiftUI
 import UIKit
 
 class NotificationViewDemoController: DemoController {
@@ -214,10 +215,10 @@ class NotificationViewDemoController: DemoController {
             notification.state.message = "The background of this notification has been customized with a gradient."
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             // It's a lovely blue-to-pink gradient
-            let colors: [UIColor] = [UIColor(light: GlobalTokens.sharedColor(.pink, .tint50),
-                                             dark: GlobalTokens.sharedColor(.pink, .shade40)),
-                                     UIColor(light: GlobalTokens.sharedColor(.cyan, .tint50),
-                                             dark: GlobalTokens.sharedColor(.cyan, .shade40))]
+            let colors: [Color] = [Color(light: GlobalTokens.sharedSwiftUIColor(.pink, .tint50),
+                                         dark: GlobalTokens.sharedSwiftUIColor(.pink, .shade40)),
+                                   Color(light: GlobalTokens.sharedSwiftUIColor(.cyan, .tint50),
+                                         dark: GlobalTokens.sharedSwiftUIColor(.cyan, .shade40))]
             notification.state.backgroundGradient = LinearGradientInfo(colors: colors,
                                                                        startPoint: .init(x: 0.0, y: 1.0),
                                                                        endPoint: .init(x: 1.0, y: 0.0))

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -292,10 +292,10 @@ struct NotificationDemoView: View {
 
     private var backgroundGradient: LinearGradientInfo {
         // It's a lovely blue-to-pink gradient
-        let colors: [UIColor] = [UIColor(light: GlobalTokens.sharedColor(.pink, .tint50),
-                                         dark: GlobalTokens.sharedColor(.pink, .shade40)),
-                                 UIColor(light: GlobalTokens.sharedColor(.cyan, .tint50),
-                                         dark: GlobalTokens.sharedColor(.cyan, .shade40))]
+        let colors: [Color] = [Color(light: GlobalTokens.sharedSwiftUIColor(.pink, .tint50),
+                                     dark: GlobalTokens.sharedSwiftUIColor(.pink, .shade40)),
+                               Color(light: GlobalTokens.sharedSwiftUIColor(.cyan, .tint50),
+                                     dark: GlobalTokens.sharedSwiftUIColor(.cyan, .shade40))]
         return LinearGradientInfo(colors: colors,
                                   startPoint: .init(x: 0.0, y: 1.0),
                                   endPoint: .init(x: 1.0, y: 0.0))

--- a/Sources/FluentUI_iOS/Core/Extensions/Color+Extensions.swift
+++ b/Sources/FluentUI_iOS/Core/Extensions/Color+Extensions.swift
@@ -14,7 +14,7 @@ extension Color {
     /// - Parameter hexValue: The color value to store, in 24-bit (three-channel, 8-bit) RGB.
     ///
     /// - Returns: A color object that stores the provided color information.
-    init(hexValue: UInt32) {
+	public init(hexValue: UInt32) {
         let red: CGFloat = CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0
         let green: CGFloat = CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0
         let blue: CGFloat = CGFloat(hexValue & 0x000000FF) / 255.0
@@ -28,7 +28,7 @@ extension Color {
     /// - Parameter light: The default `Color` for a light context. Required.
     /// - Parameter dark: The override `Color` for a dark context. Optional.
     /// - Parameter darkElevated: The override `Color` for a dark elevated context. Optional.
-    init(light: Color,
+    public init(light: Color,
          dark: Color? = nil,
          darkElevated: Color? = nil) {
 

--- a/Sources/FluentUI_iOS/Core/Extensions/Color+Extensions.swift
+++ b/Sources/FluentUI_iOS/Core/Extensions/Color+Extensions.swift
@@ -14,7 +14,7 @@ extension Color {
     /// - Parameter hexValue: The color value to store, in 24-bit (three-channel, 8-bit) RGB.
     ///
     /// - Returns: A color object that stores the provided color information.
-	public init(hexValue: UInt32) {
+    public init(hexValue: UInt32) {
         let red: CGFloat = CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0
         let green: CGFloat = CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0
         let blue: CGFloat = CGFloat(hexValue & 0x000000FF) / 255.0
@@ -29,13 +29,13 @@ extension Color {
     /// - Parameter dark: The override `Color` for a dark context. Optional.
     /// - Parameter darkElevated: The override `Color` for a dark elevated context. Optional.
     public init(light: Color,
-         dark: Color? = nil,
-         darkElevated: Color? = nil) {
+                dark: Color? = nil,
+                darkElevated: Color? = nil) {
 
         let dynamicColor = DynamicColor(light: light, dark: dark, darkElevated: darkElevated)
         self.init(dynamicColor: dynamicColor)
     }
-    
+
     /// Creates a custom `Color` from a prebuilt `DynamicColor` structure.
     ///
     /// - Parameter dynamicColor: A dynmic color structure that describes the `Color` to be created.

--- a/Sources/FluentUI_iOS/Core/Theme/Tokens/LinearGradientInfo.swift
+++ b/Sources/FluentUI_iOS/Core/Theme/Tokens/LinearGradientInfo.swift
@@ -7,7 +7,7 @@ import Foundation
 import SwiftUI
 
 /// Represents a linear gradient as used by FluentUI.
-@objc public class LinearGradientInfo: NSObject {
+public class LinearGradientInfo: NSObject {
     /// Initializes a linear gradient to be used in Fluent.
     ///
     /// - Parameters:

--- a/Sources/FluentUI_iOS/Core/Theme/Tokens/LinearGradientInfo.swift
+++ b/Sources/FluentUI_iOS/Core/Theme/Tokens/LinearGradientInfo.swift
@@ -3,7 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import CoreGraphics
 import Foundation
 import SwiftUI
 
@@ -16,7 +15,7 @@ import SwiftUI
     ///   - locations: An optional array of values defining the location of each gradient stop. Must be in the range `[0, 1]`.
     ///   - startPoint: The starting point for this gradient. Values should range from 0.0 to 1.0.
     ///   - endPoint: The ending point for this gradient. Values should range from 0.0 to 1.0.
-    public init(colors: [UIColor],
+    public init(colors: [Color],
                 locations: [CGFloat]? = nil,
                 startPoint: CGPoint,
                 endPoint: CGPoint) {
@@ -27,7 +26,7 @@ import SwiftUI
     }
 
     /// The array of colors to apply to this linear gradient.
-    public let colors: [UIColor]
+    public let colors: [Color]
 
     /// An optional array of values defining the location of each gradient stop.
     ///
@@ -49,14 +48,14 @@ extension LinearGradient {
         if let locations = gradientInfo.locations {
             // Map the colors and locations together.
             let stops: [Gradient.Stop] = zip(gradientInfo.colors, locations).map({ (color, location) in
-                return Gradient.Stop(color: Color(color),
+                return Gradient.Stop(color: color,
                                      location: location)
             })
             self.init(stops: stops,
                       startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
                       endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
         } else {
-            self.init(colors: gradientInfo.colors.map({ Color($0) }),
+            self.init(colors: gradientInfo.colors,
                       startPoint: UnitPoint(x: gradientInfo.startPoint.x, y: gradientInfo.startPoint.y),
                       endPoint: UnitPoint(x: gradientInfo.endPoint.x, y: gradientInfo.endPoint.y))
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Updating `LinearGradientInfo` to use SwiftUI `Color` instead of `UIColor` to make it available cross-platform.

### Verification

Only used in `Notification` -- verified both UIKit and SwiftUI in both light and dark.

<details>
<summary>Visual Verification</summary>

| Dark                                       | Light                                      |
|----------------------------------------------|--------------------------------------------|
| ![SwiftUI_dark](https://github.com/user-attachments/assets/9cb4831a-5264-4c03-a2e5-db089f118f7c) | ![SwiftUI_light](https://github.com/user-attachments/assets/52389635-d4b9-44fa-99f2-0d8cc63735a6) |
| ![UIKit_dark](https://github.com/user-attachments/assets/014a0250-d323-45fe-a948-2de1c18be9df) | ![UIKit_light](https://github.com/user-attachments/assets/b62e6717-242d-4683-ad5a-8eb3aece0534) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2137)