### PR TITLE
[macOS] Add dynamic color support directly to NSColor

### DIFF
--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestColorViewController.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestColorViewController.swift
@@ -21,7 +21,7 @@ class TestColorViewController: NSViewController {
 
 		let colorsStackView = NSStackView()
 
-		[colorsStackView, dynamicColorsStackView, primaryColorsStackView].forEach { stackView in
+		for stackView in [colorsStackView, dynamicColorsStackView, primaryColorsStackView] {
 			stackView.translatesAutoresizingMaskIntoConstraints = false
 			stackView.orientation = .vertical
 			stackView.alignment = .leading

--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestColorViewController.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestColorViewController.swift
@@ -8,6 +8,7 @@ import FluentUI
 
 class TestColorViewController: NSViewController {
 	var primaryColorsStackView = NSStackView()
+	var dynamicColorsStackView = NSStackView()
 	var subviewConstraints = [NSLayoutConstraint]()
 	var toggleTextView = NSTextView(frame: NSRect(x: 0, y: 0, width: 100, height: 20))
 
@@ -19,25 +20,26 @@ class TestColorViewController: NSViewController {
 		containerView.addSubview(scrollView)
 
 		let colorsStackView = NSStackView()
-		colorsStackView.translatesAutoresizingMaskIntoConstraints = false
-		colorsStackView.orientation = .vertical
-		colorsStackView.alignment = .leading
 
-		primaryColorsStackView.translatesAutoresizingMaskIntoConstraints = false
-		primaryColorsStackView.orientation = .vertical
-		primaryColorsStackView.alignment = .leading
+		[colorsStackView, dynamicColorsStackView, primaryColorsStackView].forEach { stackView in
+			stackView.translatesAutoresizingMaskIntoConstraints = false
+			stackView.orientation = .vertical
+			stackView.alignment = .leading
+		}
 
 		for color in Colors.Palette.allCases {
 			colorsStackView.addArrangedSubview(createColorRowStackView(name: color.name, color: color.color))
 		}
 
 		loadPrimaryColors()
+		loadDynamicColors()
 
 		let documentView = NSView()
 		documentView.translatesAutoresizingMaskIntoConstraints = false
 		scrollView.documentView = documentView
 		documentView.addSubview(colorsStackView)
 		documentView.addSubview(primaryColorsStackView)
+		documentView.addSubview(dynamicColorsStackView)
 
 		subviewConstraints = [
 			containerView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
@@ -47,7 +49,10 @@ class TestColorViewController: NSViewController {
 			colorsStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
 			primaryColorsStackView.topAnchor.constraint(equalTo: colorsStackView.bottomAnchor, constant: colorRowSpacing),
 			primaryColorsStackView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: colorRowSpacing),
-			primaryColorsStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor)
+			primaryColorsStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor),
+			dynamicColorsStackView.topAnchor.constraint(equalTo: colorsStackView.bottomAnchor, constant: colorRowSpacing),
+			dynamicColorsStackView.leadingAnchor.constraint(equalTo: documentView.leadingAnchor, constant: colorRowSpacing),
+			dynamicColorsStackView.trailingAnchor.constraint(equalTo: documentView.trailingAnchor)
 		]
 
 		let switchButton = NSSwitch(frame: CGRect(x: 1, y: 1, width: 100, height: 50))
@@ -117,6 +122,13 @@ class TestColorViewController: NSViewController {
 		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint30", color: Colors.primaryTint30))
 		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "primaryTint40", color: Colors.primaryTint40))
 		NSLayoutConstraint.activate(subviewConstraints)
+	}
+
+	private func loadDynamicColors() {
+		let dynamicColor = NSColor(light: NSColor.red, dark: NSColor.blue)
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "Dynamic", color: dynamicColor))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "Dynamic (light)", color: dynamicColor.light))
+		primaryColorsStackView.addArrangedSubview(createColorRowStackView(name: "Dynamic (dark)", color: dynamicColor.dark))
 	}
 }
 

--- a/Sources/FluentUI_macOS/Core/Extensions/NSColor+Extensions.swift
+++ b/Sources/FluentUI_macOS/Core/Extensions/NSColor+Extensions.swift
@@ -1,0 +1,86 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#if canImport(AppKit)
+import AppKit
+import SwiftUI
+
+extension NSColor {
+
+    /// Creates a dynamic color object that returns the appropriate color value based on the current
+    /// rendering context.
+    ///
+    /// The decision order for choosing between the colors is based on the following questions, in order:
+    /// - Is the current `userInterfaceStyle` `.dark` or `.light`?
+    ///
+    /// - Parameter light: The default color for a light context. Required.
+    /// - Parameter dark: The override color for a dark context. Optional.
+    @objc public convenience init(light: NSColor,
+                                  dark: NSColor? = nil) {
+        self.init(name: nil) { appearance -> NSColor in
+            let isDarkMode = appearance.bestMatch(from:[NSAppearance.Name.darkAqua]) == NSAppearance.Name.darkAqua
+            return isDarkMode ? (dark ?? light) : light
+        }
+    }
+
+    /// Creates an `NSColor` instance with the specified three-channel, 8-bit-per-channel color value, usually in hex.
+    ///
+    /// For example: `0xFF0000` represents red, `0x00FF00` green, and `0x0000FF` blue. There is no way to specify an
+    /// alpha channel via this initializer. For that, use `init(red:green:blue:alpha)` instead.
+    ///
+    /// - Parameter hexValue: The color value to store, in 24-bit (three-channel, 8-bit) RGB.
+    ///
+    /// - Returns: A color object that stores the provided color information.
+    @objc public convenience init(hexValue: UInt32) {
+        let red: CGFloat = CGFloat((hexValue & 0x00FF0000) >> 16) / 255.0
+        let green: CGFloat = CGFloat((hexValue & 0x0000FF00) >> 8) / 255.0
+        let blue: CGFloat = CGFloat(hexValue & 0x000000FF) / 255.0
+        self.init(red: red,
+                  green: green,
+                  blue: blue,
+                  alpha: 1.0)
+    }
+
+    @objc public var light: NSColor {
+        return resolvedColorValue(appearance: NSAppearance(named: .aqua))
+    }
+
+    @objc public var dark: NSColor {
+        return resolvedColorValue(appearance: NSAppearance(named: .darkAqua))
+    }
+
+    /// Returns the version of the current color that results from the specified traits as an `NSColor`.
+    ///
+    /// - Parameter appearance: The user interface appearance to use when resolving the color information.
+    ///
+    /// - Returns: The version of the color to display for the specified appearance.
+    private func resolvedColorValue(appearance: NSAppearance?) -> NSColor {
+        guard let appearance else {
+            return self
+        }
+
+        /// `NSAppearance.performAsCurrentDrawingAppearance` will let us
+        /// retrieve NSColor variants for a given drawing appearance.
+        /// Unfortunately there's no direct way to pass data out of the closure
+        /// passed into this method, so create a local class that can shuttle
+        /// values in and out.
+        class ColorHolder {
+            var cgColor: CGColor = .black
+        }
+
+        let holder = ColorHolder()
+        appearance.performAsCurrentDrawingAppearance { [holder] in
+            // Use `cgColor` to force `NSColor` to flatten into the appropriate
+            // set of values for this appearance.
+            holder.cgColor = self.cgColor
+        }
+
+        guard let nsColorValue = NSColor(cgColor: holder.cgColor) else {
+            preconditionFailure("Should not be possible to fail to create NSColor here!")
+        }
+        return nsColorValue
+    }
+}
+#endif // canImport(AppKit)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

Creates a new extension on `NSColor` that adds dynamic color support, similar to the equivalent methods in `UIColor+Extensions.swift`.

These changes will be important for `FluentTheme` integration, which is almost ready :)

New:
- Create an `NSColor` with explicit `light` and `dark` variants.
- Fetch these values back on demand.
- Add test UI to the demo app to validate this.

### Verification

Verified that the new dynamic colors work as expected:
- The `light` method always returns the light value.
- The `dark` method returns either dark if it exists, or light if not.
- Otherwise, the color will draw according to the current `NSAppearance` as expected. This includes redrawing when the system appearance changes.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="912" alt="dark" src="https://github.com/user-attachments/assets/4b4335ff-cd64-4cc8-a6c1-55a84f15c851" /> | <img width="912" alt="light" src="https://github.com/user-attachments/assets/44a64093-628f-4149-87c6-2fac8b3c7b27" /> |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2138)