### PR TITLE
Reverted bottom sheet animation skip

### DIFF
--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -531,7 +531,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     public override func viewSafeAreaInsetsDidChange() {
         super.viewSafeAreaInsetsDidChange()
-        completeAnimationsIfNeeded()
+        completeAnimationsIfNeeded(skipToEnd: true)
     }
 
     public override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes
Reverted change that makes `viewSafeAreaInsetsDidChange` play out its animations during a safe area adjustment. This is causing occasional layout issues with the frames of view presenting inside the bottom sheet.

### Binary change
(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
Fluent builds

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Animation would play out during a safe area adjustment | If a safe area change occurs we jump straight the location we need to be after the safe area adjusment |
</details>

### Pull request checklist

This PR has considered:
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2140)