### PR TITLE
[List][SwiftUI control] Add color and font from token set for List header & footer

### DIFF
--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
@@ -17,14 +17,25 @@ public struct FluentListSectionFooter<Description: StringProtocol>: View {
     ///   - description: description of the section to be shown in the footer.
     public init(description: Description) {
         self.description = description
+		self.tokenSet = .init(style: { .footer }, accessoryButtonStyle: { .regular })
     }
 
     public var body: some View {
-        Text(description)
-            .textCase(nil)
+		tokenSet.update(fluentTheme)
+
+		@ViewBuilder var descriptionView: some View {
+			Text(description)
+				.textCase(nil)
+				.font(Font(tokenSet[.textFont].uiFont))
+				.foregroundStyle(tokenSet[.textColor].color)
+		}
+
+		return descriptionView
     }
 
     // MARK: Private variables
 
     private let description: Description
+	private let tokenSet: TableViewHeaderFooterViewTokenSet
+	@Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 }

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
@@ -36,6 +36,6 @@ public struct FluentListSectionFooter<Description: StringProtocol>: View {
     // MARK: Private variables
 
     private let description: Description
-    private let tokenSet: TableViewHeaderFooterViewTokenSet
+    private let tokenSet: ListSectionHeaderFooterTokenSet
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 }

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
@@ -24,7 +24,7 @@ public struct FluentListSectionFooter<Description: StringProtocol>: View {
         tokenSet.update(fluentTheme)
 
         @ViewBuilder var descriptionView: some View {
-		    Text(description)
+            Text(description)
                 .textCase(nil)
                 .font(Font(tokenSet[.textFont].uiFont))
                 .foregroundStyle(tokenSet[.textColor].color)

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionFooter.swift
@@ -17,25 +17,25 @@ public struct FluentListSectionFooter<Description: StringProtocol>: View {
     ///   - description: description of the section to be shown in the footer.
     public init(description: Description) {
         self.description = description
-		self.tokenSet = .init(style: { .footer }, accessoryButtonStyle: { .regular })
+        self.tokenSet = .init(style: { .footer }, accessoryButtonStyle: { .regular })
     }
 
     public var body: some View {
-		tokenSet.update(fluentTheme)
+        tokenSet.update(fluentTheme)
 
-		@ViewBuilder var descriptionView: some View {
-			Text(description)
-				.textCase(nil)
-				.font(Font(tokenSet[.textFont].uiFont))
-				.foregroundStyle(tokenSet[.textColor].color)
-		}
+        @ViewBuilder var descriptionView: some View {
+		    Text(description)
+                .textCase(nil)
+                .font(Font(tokenSet[.textFont].uiFont))
+                .foregroundStyle(tokenSet[.textColor].color)
+        }
 
-		return descriptionView
+        return descriptionView
     }
 
     // MARK: Private variables
 
     private let description: Description
-	private let tokenSet: TableViewHeaderFooterViewTokenSet
-	@Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+    private let tokenSet: TableViewHeaderFooterViewTokenSet
+    @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 }

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
@@ -5,6 +5,8 @@
 
 import SwiftUI
 
+public typealias ListSectionHeaderFooterTokenSet = TableViewHeaderFooterViewTokenSet
+
 /// Defines the visual style of the FluentListSectionHeader
 public enum ListSectionHeaderStyle {
     case regular
@@ -72,7 +74,7 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
 
     private var trailingContent: (() -> TrailingContent)?
     private let title: Title
-    private let tokenSet: TableViewHeaderFooterViewTokenSet
+    private let tokenSet: ListSectionHeaderFooterTokenSet
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 }
 

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
@@ -5,6 +5,12 @@
 
 import SwiftUI
 
+/// Defines the visual style of the FluentListSectionHeader
+public enum ListSectionHeaderStyle {
+	case regular
+	case primary
+}
+
 /// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
 ///
 /// It is intended to be used in conjunction with `FluentUI.FluentListSection` and `FluentUI.ListItem`
@@ -15,18 +21,25 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
     /// Creates a `FluentListSectionHeader`
     /// - Parameters:
     ///   - title: title of the section to be shown in the header.
+	///   - style:  The visual style of how the header should be displayed.
     ///   - trailingContent: content that appears on the trailing edge of the view.
     public init(title: Title,
+				style: ListSectionHeaderStyle,
                 @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
         self.title = title
+		self.tokenSet = .init(style: { FluentListSectionHeader.tokenSetStyle(style) }, accessoryButtonStyle: { .regular })
         self.trailingContent = trailingContent
     }
 
     public var body: some View {
+		tokenSet.update(fluentTheme)
+
         @ViewBuilder var titleView: some View {
-            Text(title)
-                // By default uppercasing is applied, setting nil to not enforce casing
-                .textCase(nil)
+			Text(title)
+			// By default uppercasing is applied, setting nil to not enforce casing
+				.textCase(nil)
+				.font(Font(tokenSet[.textFont].uiFont))
+				.foregroundStyle(tokenSet[.textColor].color)
         }
 
         @ViewBuilder var contentView: some View {
@@ -44,10 +57,23 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
         return contentView
     }
 
+	// MARK: private methods
+
+	static func tokenSetStyle(_ style: ListSectionHeaderStyle) -> TableViewHeaderFooterView.Style {
+		switch style {
+		case .regular:
+			return .header
+		case .primary:
+			return .headerPrimary
+		}
+	}
+
     // MARK: Private variables
 
     private var trailingContent: (() -> TrailingContent)?
     private let title: Title
+	private let tokenSet: TableViewHeaderFooterViewTokenSet
+	@Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 }
 
 // MARK: Additional Initializers
@@ -55,5 +81,13 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
 public extension FluentListSectionHeader where TrailingContent == EmptyView {
     init(title: Title) {
         self.title = title
+		self.tokenSet = .init(style: { .header }, accessoryButtonStyle: { .regular })
     }
+}
+
+public extension FluentListSectionHeader where TrailingContent == EmptyView {
+	init(title: Title, style: ListSectionHeaderStyle) {
+		self.title = title
+		self.tokenSet = .init(style: { FluentListSectionHeader.tokenSetStyle(style) }, accessoryButtonStyle: { .regular })
+	}
 }

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
@@ -7,8 +7,8 @@ import SwiftUI
 
 /// Defines the visual style of the FluentListSectionHeader
 public enum ListSectionHeaderStyle {
-	case regular
-	case primary
+    case regular
+    case primary
 }
 
 /// This component is a work in progress. Expect changes to be made to it on a somewhat regular basis.
@@ -21,25 +21,25 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
     /// Creates a `FluentListSectionHeader`
     /// - Parameters:
     ///   - title: title of the section to be shown in the header.
-	///   - style:  The visual style of how the header should be displayed.
+    ///   - style:  The visual style of how the header should be displayed.
     ///   - trailingContent: content that appears on the trailing edge of the view.
     public init(title: Title,
-				style: ListSectionHeaderStyle,
+                style: ListSectionHeaderStyle,
                 @ViewBuilder trailingContent: @escaping () -> TrailingContent) {
         self.title = title
-		self.tokenSet = .init(style: { FluentListSectionHeader.tokenSetStyle(style) }, accessoryButtonStyle: { .regular })
+        self.tokenSet = .init(style: { FluentListSectionHeader.tokenSetStyle(style) }, accessoryButtonStyle: { .regular })
         self.trailingContent = trailingContent
     }
 
     public var body: some View {
-		tokenSet.update(fluentTheme)
+        tokenSet.update(fluentTheme)
 
         @ViewBuilder var titleView: some View {
 			Text(title)
-			// By default uppercasing is applied, setting nil to not enforce casing
-				.textCase(nil)
-				.font(Font(tokenSet[.textFont].uiFont))
-				.foregroundStyle(tokenSet[.textColor].color)
+                // By default uppercasing is applied, setting nil to not enforce casing
+                .textCase(nil)
+                .font(Font(tokenSet[.textFont].uiFont))
+                .foregroundStyle(tokenSet[.textColor].color)
         }
 
         @ViewBuilder var contentView: some View {
@@ -60,20 +60,20 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
 	// MARK: private methods
 
 	static func tokenSetStyle(_ style: ListSectionHeaderStyle) -> TableViewHeaderFooterView.Style {
-		switch style {
-		case .regular:
-			return .header
-		case .primary:
-			return .headerPrimary
-		}
-	}
+        switch style {
+        case .regular:
+            return .header
+        case .primary:
+            return .headerPrimary
+        }
+    }
 
     // MARK: Private variables
 
     private var trailingContent: (() -> TrailingContent)?
     private let title: Title
-	private let tokenSet: TableViewHeaderFooterViewTokenSet
-	@Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+    private let tokenSet: TableViewHeaderFooterViewTokenSet
+    @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 }
 
 // MARK: Additional Initializers
@@ -81,13 +81,13 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
 public extension FluentListSectionHeader where TrailingContent == EmptyView {
     init(title: Title) {
         self.title = title
-		self.tokenSet = .init(style: { .header }, accessoryButtonStyle: { .regular })
+        self.tokenSet = .init(style: { .header }, accessoryButtonStyle: { .regular })
     }
 }
 
 public extension FluentListSectionHeader where TrailingContent == EmptyView {
-	init(title: Title, style: ListSectionHeaderStyle) {
-		self.title = title
-		self.tokenSet = .init(style: { FluentListSectionHeader.tokenSetStyle(style) }, accessoryButtonStyle: { .regular })
-	}
+    init(title: Title, style: ListSectionHeaderStyle) {
+        self.title = title
+        self.tokenSet = .init(style: { FluentListSectionHeader.tokenSetStyle(style) }, accessoryButtonStyle: { .regular })
+    }
 }

--- a/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
+++ b/Sources/FluentUI_iOS/Components/List/FluentListSectionHeader.swift
@@ -35,7 +35,7 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
         tokenSet.update(fluentTheme)
 
         @ViewBuilder var titleView: some View {
-			Text(title)
+            Text(title)
                 // By default uppercasing is applied, setting nil to not enforce casing
                 .textCase(nil)
                 .font(Font(tokenSet[.textFont].uiFont))
@@ -57,9 +57,9 @@ public struct FluentListSectionHeader<Title: StringProtocol, TrailingContent: Vi
         return contentView
     }
 
-	// MARK: private methods
+    // MARK: private methods
 
-	static func tokenSetStyle(_ style: ListSectionHeaderStyle) -> TableViewHeaderFooterView.Style {
+    static func tokenSetStyle(_ style: ListSectionHeaderStyle) -> TableViewHeaderFooterView.Style {
         switch style {
         case .regular:
             return .header


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

For the swiftUI control for List / ListItem, which is the TableViewCell swiftUI version, we don't support tokens yet. This change is to add in color and font.

- Added in a token set on the view
- Added a new enum for header style. We have `TableViewHeaderFooterView.Style` which maps to the token set, but the new swiftUI control, header and footer are distinctly different and will be in the future. To break that trend, from a consumer standpoint we can separate out the styles to just be an option for a header as we only have 1 footer style.


### Binary change

Not measured

### Verification

Tested with the demo app. We dont have a demo page for this yet, but could be added in a future change.

<details>
<summary>Visual Verification</summary>

| header regular style                                       | header primary style                                      |
|----------------------------------------------|--------------------------------------------|
| ![image](https://github.com/user-attachments/assets/4bb3c921-ed70-4dbf-838d-6630a4e7e32b) | ![image](https://github.com/user-attachments/assets/33256b6e-96ef-4730-89f2-39f5d1ec229d) |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2141)