### PR TITLE
MSFNotification can set a closure to run regardless of the source of the disimissal

### DIFF
--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -51,6 +51,9 @@ import SwiftUI
     /// Action to be dispatched by tapping on the toast/bar notification.
     var messageButtonAction: (() -> Void)? { get set }
 
+    /// The callback to execute when the notification is dismissed.
+    var onDismiss: (() -> Void)? { get set }
+
     /// Defines whether the notification shows from the bottom of the presenting view or the top.
     var showFromBottom: Bool { get set }
 
@@ -118,6 +121,7 @@ public struct FluentNotification: View, TokenizedControlView {
         self.state = state
         self.shouldSelfPresent = shouldSelfPresent
         self.isFlexibleWidthToast = isFlexibleWidthToast && style.isToast
+        self.onDismiss = nil
 
         self.tokenSet = NotificationTokenSet(style: { state.style })
 
@@ -335,7 +339,21 @@ public struct FluentNotification: View, TokenizedControlView {
             }
         }
 
-        return presentableNotification
+        @ViewBuilder
+        var notificationWithOnDisappear: some View {
+            if (state.onDismiss != nil) {
+                presentableNotification
+                    .onDisappear {
+                        if let onDismissAction = state.onDismiss {
+                            onDismissAction()
+                        }
+                    }
+            } else {
+                presentableNotification
+            }
+        }
+
+        return notificationWithOnDisappear
     }
 
     @Environment(\.fluentTheme) var fluentTheme: FluentTheme
@@ -393,6 +411,9 @@ public struct FluentNotification: View, TokenizedControlView {
     // When true, the notification will fit the size of its contents.
     // When false, the notification will be fixed based on the size of the screen.
     private let isFlexibleWidthToast: Bool
+
+    // The callback to execute when the notification is dismissed.
+    private let onDismiss: (() -> Void)?
 }
 
 class MSFNotificationStateImpl: ControlState, MSFNotificationState {
@@ -407,6 +428,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
     @Published var showFromBottom: Bool
     @Published var backgroundGradient: LinearGradientInfo?
     @Published var verticalOffset: CGFloat
+    @Published var onDismiss: (() -> Void)?
 
     /// Title to display in the action button on the trailing edge of the control.
     ///

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -201,6 +201,13 @@ import UIKit
     @objc public static var allowsMultipleToasts: Bool = false
     var isFlexibleWidthToast: Bool
 
+    /// The closure that will be executed once the view disapears. This will be called in seperately from the completion handler of the hide method and will execute after that one is complete.
+   @objc public var onDismissHandler: (() -> Void)? {
+        didSet {
+            notification.state.onDismiss = onDismissHandler
+        }
+    }
+
     // MARK: - Private variables
     private static var currentToast: MSFNotification? {
         didSet {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes
Added a new onDismiss closure that will be called whenever the Notification View disappears. This allows for consumers to ensure that some action will always be taken whenever the notification is dismissed regardless of what the source of the notification being dismissed is. 

### Binary change
(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
Tested with closures in demo app.
Created notificatiosn from both swift and objective c code

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Consumers of MSFNotifications could only have a dimiss block if they have a custom dismiss button or if they explicity call hide on the notification  | Consumers can define a closure that will be called everytime the notification view will disappear |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)