### PR TITLE
Adding nsfont+extension and test view controller

### DIFF
--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestTypographyViewController.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestTypographyViewController.swift
@@ -1,0 +1,60 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#if canImport(FluentUI_common)
+import FluentUI_common
+#endif
+import AppKit
+import FluentUI
+
+class TestTypographyViewController: NSViewController {
+	override func viewDidLoad() {
+		let containerView = NSStackView(frame: .zero)
+		containerView.orientation = .vertical
+
+		for typographyToken in FluentTheme.TypographyToken.allCases {
+			let text = NSTextField(labelWithString: typographyToken.text)
+			text.font = NSFont.fluent(fluentTheme.typographyInfo(typographyToken))
+			containerView.addArrangedSubview(text)
+		}
+
+		view = containerView
+	}
+}
+
+// MARK: - Private extensions
+private let fluentTheme = FluentTheme()
+
+private extension FluentTheme.TypographyToken {
+	var text: String {
+		switch self {
+		case .display:
+			return "Display"
+		case .largeTitle:
+			return "Large Title"
+		case .title1:
+			return "Title 1"
+		case .title2:
+			return "Title 2"
+		case .title3:
+			return "Title 3"
+		case .body1Strong:
+			return "Body 1 Strong"
+		case .body1:
+			return "Body 1"
+		case .body2Strong:
+			return "Body 2 Strong"
+		case .body2:
+			return "Body 2"
+		case .caption1Strong:
+			return "Caption 1 Strong"
+		case .caption1:
+			return "Caption 1"
+		case .caption2:
+			return "Caption 2"
+		}
+	}
+}
+

--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestTypographyViewController.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestTypographyViewController.swift
@@ -3,9 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if canImport(FluentUI_common)
-import FluentUI_common
-#endif
 import AppKit
 import FluentUI
 

--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestViewControllers.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestViewControllers.swift
@@ -30,4 +30,6 @@ public let testViewControllers = [TestViewController(title: "Avatar View",
 								  TestViewController(title: "Notification Bar View",
 													 type: TestNotificationBarViewController.self),
 								  TestViewController(title: "Separator",
-													 type: TestSeparatorViewController.self)]
+													 type: TestSeparatorViewController.self),
+								  TestViewController(title: "Typography",
+													 type: TestTypographyViewController.self)]

--- a/Demos/FluentUIDemo_macOS/xcode/FluentUI.xcodeproj/project.pbxproj
+++ b/Demos/FluentUIDemo_macOS/xcode/FluentUI.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3A42752729677D3700F36FBE /* ColorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A42752629677D3700F36FBE /* ColorTest.swift */; };
 		3A80A049299EE88900A4A3D2 /* NotificationBarViewTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A80A048299EE88900A4A3D2 /* NotificationBarViewTest.swift */; };
 		3A8CB0E32996CDA200B68FCF /* TestNotificationBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A8CB0E12996CD6400B68FCF /* TestNotificationBarViewController.swift */; };
+		89668E792DC2C055002D0F68 /* TestTypographyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89668E782DC2BFC8002D0F68 /* TestTypographyViewController.swift */; };
 		8F5368052295F4BF0098AC8F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F5368042295F4BF0098AC8F /* AppDelegate.swift */; };
 		8F5368072295F4C10098AC8F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8F5368062295F4C10098AC8F /* Assets.xcassets */; };
 		8F53680A2295F4C10098AC8F /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8F5368082295F4C10098AC8F /* MainMenu.xib */; };
@@ -93,6 +94,7 @@
 		3A80A048299EE88900A4A3D2 /* NotificationBarViewTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBarViewTest.swift; sourceTree = "<group>"; };
 		3A8CB0E12996CD6400B68FCF /* TestNotificationBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNotificationBarViewController.swift; sourceTree = "<group>"; };
 		8061BF8222EF957200F2D245 /* TestDatePickerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDatePickerController.swift; sourceTree = "<group>"; };
+		89668E782DC2BFC8002D0F68 /* TestTypographyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTypographyViewController.swift; sourceTree = "<group>"; };
 		8F250B8C22B3062A00142B0E /* TestAvatarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAvatarViewController.swift; sourceTree = "<group>"; };
 		8F3572322361143B0076FBBE /* FluentUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = FluentUI.xctestplan; sourceTree = "<group>"; };
 		8F38AE402303537800F5D7B0 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/MainMenu.strings; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				92AD71262D4064B00089499E /* TestMultilinePillPickerViewController.swift */,
 				3A8CB0E12996CD6400B68FCF /* TestNotificationBarViewController.swift */,
 				AC97EFE8247FAB1D00DADC99 /* TestSeparatorViewController.swift */,
+				89668E782DC2BFC8002D0F68 /* TestTypographyViewController.swift */,
 				E6A92D4E24BEAEEA00562BCA /* TestViewControllers.swift */,
 			);
 			name = FluentUITestViewControllers;
@@ -632,6 +635,7 @@
 				3A8CB0E32996CDA200B68FCF /* TestNotificationBarViewController.swift in Sources */,
 				E6A92D2F24BEA8AC00562BCA /* TestButtonViewController.swift in Sources */,
 				E6A92D2D24BEA8AC00562BCA /* TestSeparatorViewController.swift in Sources */,
+				89668E792DC2C055002D0F68 /* TestTypographyViewController.swift in Sources */,
 				EC3AF6A726BDDD30009118F4 /* TestBadgeViewController.swift in Sources */,
 				A257F81E2512DE45002CAA6E /* TestColorViewController.swift in Sources */,
 				9B4AEBAB2705206300B68020 /* TestFilledTemplateImageViewController.swift in Sources */,

--- a/Sources/FluentUI_common/Core/Theme/Tokens/FontInfo.swift
+++ b/Sources/FluentUI_common/Core/Theme/Tokens/FontInfo.swift
@@ -5,6 +5,8 @@
 
 import SwiftUI
 
+public typealias FluentFontInfo = FontInfo
+
 /// Represents the description of a font used by FluentUI components.
 @objc(MSFFontInfo)
 public class FontInfo: NSObject {

--- a/Sources/FluentUI_macOS/Core/Extensions/NSFont+Extensions.swift
+++ b/Sources/FluentUI_macOS/Core/Extensions/NSFont+Extensions.swift
@@ -10,7 +10,7 @@ import AppKit
 import SwiftUI
 
 public extension Font {
-	static func fluent(_ fontInfo: FluentUI_common.FontInfo, shouldScale: Bool = true) -> Font {
+	static func fluent(_ fontInfo: FluentFontInfo, shouldScale: Bool = true) -> Font {
 		// SwiftUI Font is missing some of the ease of construction available in NSFont.
 		// So just leverage the logic there to create the equivalent SwiftUI font.
 		let nsFont = NSFont.fluent(fontInfo, shouldScale: shouldScale)
@@ -19,7 +19,7 @@ public extension Font {
 }
 
 extension NSFont {
-	@objc public static func fluent(_ fontInfo: FluentUI_common.FontInfo, shouldScale: Bool = true) -> NSFont {
+	@objc public static func fluent(_ fontInfo: FluentFontInfo, shouldScale: Bool = true) -> NSFont {
 		let weight = nsWeight(fontInfo.weight)
 
 		if let name = fontInfo.name,

--- a/Sources/FluentUI_macOS/Core/Extensions/NSFont+Extensions.swift
+++ b/Sources/FluentUI_macOS/Core/Extensions/NSFont+Extensions.swift
@@ -1,0 +1,131 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#if canImport(FluentUI_common)
+import FluentUI_common
+#endif
+import SwiftUI
+import AppKit
+
+public extension Font {
+	static func fluent(_ fontInfo: FluentUI_common.FontInfo, shouldScale: Bool = true) -> Font {
+		// SwiftUI Font is missing some of the ease of construction available in UIFont.
+		// So just leverage the logic there to create the equivalent SwiftUI font.
+		let nsFont = NSFont.fluent(fontInfo, shouldScale: shouldScale)
+		return Font(nsFont)
+	}
+}
+
+extension NSFont {
+	@objc public static func fluent(_ fontInfo: FluentUI_common.FontInfo, shouldScale: Bool = true) -> NSFont {
+		let weight = nsWeight(fontInfo.weight)
+
+		if let name = fontInfo.name,
+		   let font = NSFont(name: name, size: fontInfo.size) {
+			// Named font
+			let unscaledFont = font.withWeight(weight)
+			if shouldScale {
+				return font.scale(nsTextStyle(fontInfo.textStyle))
+			} else {
+				return unscaledFont
+			}
+		} else {
+			// System font
+			if !shouldScale {
+				return .systemFont(ofSize: fontInfo.size, weight: weight)
+			}
+
+			let textStyle = nsTextStyle(fontInfo.textStyle)
+			if fontInfo.matchesSystemSize {
+				// System-recognized font size, let the OS scale it for us
+				return NSFont.preferredFont(forTextStyle: textStyle).withWeight(weight)
+			}
+
+			// Custom font size, we need to scale it ourselves
+			return .systemFont(ofSize: fontInfo.size, weight: weight).scale(textStyle)
+		}
+	}
+
+	func scale(_ textStyle: NSFont.TextStyle) -> NSFont {
+		let fontDescriptor = NSFontDescriptor.preferredFontDescriptor(forTextStyle: textStyle)
+		let scaledFont = NSFont(descriptor: fontDescriptor, size: pointSize)!
+		return scaledFont
+	}
+
+	private func withWeight(_ weight: NSFont.Weight) -> NSFont {
+		var attributes = fontDescriptor.fontAttributes
+		var traits = (attributes[.traits] as? [NSFontDescriptor.TraitKey: Any]) ?? [:]
+
+		traits[.weight] = weight
+
+		// We need to remove `.name` since it may clash with the requested font weight, but
+		// `.family` will ensure that e.g. Helvetica stays Helvetica.
+		attributes[.name] = nil
+		attributes[.traits] = traits
+		attributes[.family] = familyName
+
+		let descriptor = NSFontDescriptor(fontAttributes: attributes)
+
+		return NSFont(descriptor: descriptor, size: pointSize)!
+	}
+
+	private static func nsTextStyle(_ textStyle: Font.TextStyle) -> NSFont.TextStyle {
+		switch textStyle {
+		case .largeTitle:
+			return .largeTitle
+		case .title:
+			return .title1
+		case .title2:
+			return .title2
+		case .title3:
+			return .title3
+		case .headline:
+			return .headline
+		case .body:
+			return .body
+		case .callout:
+			return .callout
+		case .subheadline:
+			return .subheadline
+		case .footnote:
+			return .footnote
+		case .caption:
+			return .caption1
+		case .caption2:
+			return .caption2
+		default:
+			// Font.TextStyle has `@unknown default` attribute, so we need a default.
+			assertionFailure("Unknown Font.TextStyle found! Reverting to .body style.")
+			return .body
+		}
+	}
+
+	private static func nsWeight(_ weight: Font.Weight) -> NSFont.Weight {
+		switch weight {
+		case .ultraLight:
+			return .ultraLight
+		case .thin:
+			return .thin
+		case .light:
+			return .light
+		case .regular:
+			return .regular
+		case .medium:
+			return .medium
+		case .semibold:
+			return .semibold
+		case .bold:
+			return .bold
+		case .heavy:
+			return .heavy
+		case .black:
+			return .black
+		default:
+			// Font.Weight has `@unknown default` attribute, so we need a default.
+			assertionFailure("Unknown Font.Weight found! Reverting to .regular weight.")
+			return .regular
+		}
+	}
+}

--- a/Sources/FluentUI_macOS/Core/Extensions/NSFont+Extensions.swift
+++ b/Sources/FluentUI_macOS/Core/Extensions/NSFont+Extensions.swift
@@ -6,12 +6,12 @@
 #if canImport(FluentUI_common)
 import FluentUI_common
 #endif
-import SwiftUI
 import AppKit
+import SwiftUI
 
 public extension Font {
 	static func fluent(_ fontInfo: FluentUI_common.FontInfo, shouldScale: Bool = true) -> Font {
-		// SwiftUI Font is missing some of the ease of construction available in UIFont.
+		// SwiftUI Font is missing some of the ease of construction available in NSFont.
 		// So just leverage the logic there to create the equivalent SwiftUI font.
 		let nsFont = NSFont.fluent(fontInfo, shouldScale: shouldScale)
 		return Font(nsFont)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

Creating the NSFont+Extensions in order to use Fluent Typography on MacOS

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

To test the changes, I created the `TestTypographyViewController.swift` which I then added to the existing `TestViewControlers.swift` 

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| None | ![typography_fluentui_apple_mac_light_mode](https://github.com/user-attachments/assets/d8e99f45-83c3-40b7-9aa6-74a75d8e5cc2) |
| None | ![typography_fluentui_apple_mac_dark_mode](https://github.com/user-attachments/assets/d8209524-eaf3-4124-aa7a-945d3a24c3c2) |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2145)