### PR TITLE
Add support for a UIBlurEffect Background to the BottomSheetController

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -24,6 +24,7 @@ class BottomCommandingDemoController: DemoController {
         optionTableView.separatorStyle = .none
 
         let bottomCommandingVC = BottomCommandingController(with: optionTableViewController)
+
         bottomCommandingVC.heroItems = Array(heroItems.prefix(9))
         bottomCommandingVC.expandedListSections = shortCommandSectionList
         bottomCommandingVC.delegate = self

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomCommandingDemoController.swift
@@ -24,7 +24,6 @@ class BottomCommandingDemoController: DemoController {
         optionTableView.separatorStyle = .none
 
         let bottomCommandingVC = BottomCommandingController(with: optionTableViewController)
-
         bottomCommandingVC.heroItems = Array(heroItems.prefix(9))
         bottomCommandingVC.expandedListSections = shortCommandSectionList
         bottomCommandingVC.delegate = self

--- a/Sources/FluentUI_iOS/Components/Bottom Commanding/BottomCommandingController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Commanding/BottomCommandingController.swift
@@ -129,9 +129,8 @@ open class BottomCommandingController: UIViewController, TokenizedControl {
     /// When in sheet layout, `BottomSheetController` holds it's own `isHidden` state which is the main
     /// source of truth and the public getter will return that instead of this backing variable.
     private var _isHidden: Bool = false
-    
-    /// Uses a BlurEffect for the BottomSheet background
-    private let usesBlurEffectBackgroundForBottomSheet: Bool
+
+    private let bottomSheetControllerStyle: BottomSheetControllerStyle
 
     /// Indicates whether a more button is visible in the sheet style when `expandedListSections` is non-empty.
     /// Tapping the button will expand or collapse the sheet.
@@ -239,16 +238,20 @@ open class BottomCommandingController: UIViewController, TokenizedControl {
     }
 
     /// Initializes the bottom commanding controller with a given content view controller.
-    /// - Parameter contentViewController: View controller that will be displayed below the bottom commanding UI.
-    /// - Parameter usesBlurEffectBackgroundForBottomSheet: Bool value indicating if a BlurEffect should be applied to the BottomSheet background.
-    @objc public init(with contentViewController: UIViewController?, usesBlurEffectBackgroundForBottomSheet: Bool) {
+    /// - Parameters:
+    ///  - contentViewController: View controller that will be displayed below the bottom commanding UI.
+    ///  - bottomSheetControllerStyle: The style override for the BottomSheet's background material.
+    @objc public init(with contentViewController: UIViewController?, bottomSheetControllerStyle: BottomSheetControllerStyle) {
         self.contentViewController = contentViewController
-        self.usesBlurEffectBackgroundForBottomSheet = usesBlurEffectBackgroundForBottomSheet
+        self.bottomSheetControllerStyle = bottomSheetControllerStyle
         super.init(nibName: nil, bundle: nil)
     }
-    
+
+    /// Initializes the bottom commanding controller with a given content view controller.
+    /// - Parameters:
+    ///  - contentViewController: View controller that will be displayed below the bottom commanding UI.
     @objc public convenience init(with contentViewController: UIViewController?) {
-        self.init(with: contentViewController, usesBlurEffectBackgroundForBottomSheet: false)
+        self.init(with: contentViewController, bottomSheetControllerStyle: .primary)
     }
 
     @available(*, unavailable)
@@ -415,7 +418,7 @@ open class BottomCommandingController: UIViewController, TokenizedControl {
 
         let sheetController = BottomSheetController(headerContentView: headerView,
                                                     expandedContentView: makeSheetExpandedContent(with: tableView),
-                                                    usesBlurEffectBackground: usesBlurEffectBackgroundForBottomSheet)
+                                                    bottomSheetControllerStyle: bottomSheetControllerStyle)
         sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden

--- a/Sources/FluentUI_iOS/Components/Bottom Commanding/BottomCommandingController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Commanding/BottomCommandingController.swift
@@ -129,6 +129,9 @@ open class BottomCommandingController: UIViewController, TokenizedControl {
     /// When in sheet layout, `BottomSheetController` holds it's own `isHidden` state which is the main
     /// source of truth and the public getter will return that instead of this backing variable.
     private var _isHidden: Bool = false
+    
+    /// Uses a BlurEffect for the BottomSheet background
+    private let usesBlurEffectBackgroundForBottomSheet: Bool
 
     /// Indicates whether a more button is visible in the sheet style when `expandedListSections` is non-empty.
     /// Tapping the button will expand or collapse the sheet.
@@ -237,9 +240,15 @@ open class BottomCommandingController: UIViewController, TokenizedControl {
 
     /// Initializes the bottom commanding controller with a given content view controller.
     /// - Parameter contentViewController: View controller that will be displayed below the bottom commanding UI.
-    @objc public init(with contentViewController: UIViewController?) {
+    /// - Parameter usesBlurEffectBackgroundForBottomSheet: Bool value indicating if a BlurEffect should be applied to the BottomSheet background.
+    @objc public init(with contentViewController: UIViewController?, usesBlurEffectBackgroundForBottomSheet: Bool) {
         self.contentViewController = contentViewController
+        self.usesBlurEffectBackgroundForBottomSheet = usesBlurEffectBackgroundForBottomSheet
         super.init(nibName: nil, bundle: nil)
+    }
+    
+    @objc public convenience init(with contentViewController: UIViewController?) {
+        self.init(with: contentViewController, usesBlurEffectBackgroundForBottomSheet: false)
     }
 
     @available(*, unavailable)
@@ -404,7 +413,9 @@ open class BottomCommandingController: UIViewController, TokenizedControl {
         let headerView = UIView()
         headerView.addSubview(heroCommandStack)
 
-        let sheetController = BottomSheetController(headerContentView: headerView, expandedContentView: makeSheetExpandedContent(with: tableView))
+        let sheetController = BottomSheetController(headerContentView: headerView,
+                                                    expandedContentView: makeSheetExpandedContent(with: tableView),
+                                                    usesBlurEffectBackground: usesBlurEffectBackgroundForBottomSheet)
         sheetController.headerContentHeight = Constants.BottomSheet.headerHeight
         sheetController.hostedScrollView = tableView
         sheetController.isHidden = isHidden

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -69,6 +69,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 
 @objc(MSFBottomSheetController)
 public class BottomSheetController: UIViewController, Shadowable, TokenizedControl {
+
     /// Initializes the bottom sheet controller
     /// - Parameters:
     ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -83,7 +83,12 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         self.usesBlurEffectBackground = usesBlurEffectBackground
         super.init(nibName: nil, bundle: nil)
     }
-    
+
+    /// Initializes the bottom sheet controller
+    /// - Parameters:
+    ///   - headerContentView: Top part of the sheet content that is visible in both collapsed and expanded state.
+    ///   - expandedContentView: Sheet content below the header which is only visible when the sheet is expanded.
+    ///   - shouldShowDimmingView: Indicates if the main content is dimmed when the sheet is expanded.
     @objc public convenience init(headerContentView: UIView? = nil, expandedContentView: UIView, shouldShowDimmingView: Bool = true) {
         self.init(headerContentView: headerContentView,
                   expandedContentView: expandedContentView,

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -673,21 +673,21 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             blurEffectView.contentView.addSubview(contentView)
 
             bottomSheetView = blurEffectView
-		} else {
-			bottomSheetView = UIView()
-			
-			// We need to set the background color of the embedding view otherwise the shadows will not display
-			bottomSheetView.backgroundColor = tokenSet[.backgroundColor].uiColor
-			bottomSheetView.layer.cornerRadius = tokenSet[.cornerRadius].float
-			bottomSheetView.addSubview(contentView)
-		}
+        } else {
+            bottomSheetView = UIView()
 
-		NSLayoutConstraint.activate([
-			contentView.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
-			contentView.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
-			contentView.topAnchor.constraint(equalTo: bottomSheetView.topAnchor),
-			contentView.bottomAnchor.constraint(equalTo: bottomSheetView.bottomAnchor)
-		])
+            // We need to set the background color of the embedding view otherwise the shadows will not display
+            bottomSheetView.backgroundColor = tokenSet[.backgroundColor].uiColor
+            bottomSheetView.layer.cornerRadius = tokenSet[.cornerRadius].float
+            bottomSheetView.addSubview(contentView)
+        }
+
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(equalTo: bottomSheetView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: bottomSheetView.trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: bottomSheetView.topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomSheetView.bottomAnchor)
+        ])
 
 #if DEBUG
         bottomSheetView.accessibilityIdentifier = "Bottom Sheet View"

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetTokenSet.swift
@@ -48,3 +48,14 @@ extension BottomSheetTokenSet {
     static let blurEffectShadowOffset: CGSize = CGSize(width: 0, height: -2)
     static let blurEffectShadowRadius: CGFloat = 8
 }
+
+// MARK: - BottomSheetControllerStyle
+
+@objc(MSFBottomSheetControllerStyle)
+public enum BottomSheetControllerStyle: Int {
+    /// The default style, this applies a solid background color to the BottomSheet view
+    case primary
+
+    /// uses a UIVisualEffect BlurEffect Background for the BottomSheet view
+    case glass
+}

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetTokenSet.swift
@@ -43,8 +43,8 @@ public class BottomSheetTokenSet: ControlTokenSet<BottomSheetToken> {
 
 // MARK: Constants
 extension BottomSheetTokenSet {
-	static let blurEffectShadowColor: CGColor = UIColor.black.cgColor
-	static let blurEffectShadowOpacity: Float = 0.25
-	static let blurEffectShadowOffset: CGSize = CGSize(width: 0, height: -2)
-	static let blurEffectShadowRadius: CGFloat = 8
+    static let blurEffectShadowColor: CGColor = UIColor.black.cgColor
+    static let blurEffectShadowOpacity: Float = 0.25
+    static let blurEffectShadowOffset: CGSize = CGSize(width: 0, height: -2)
+    static let blurEffectShadowRadius: CGFloat = 8
 }

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetTokenSet.swift
@@ -40,3 +40,11 @@ public class BottomSheetTokenSet: ControlTokenSet<BottomSheetToken> {
         }
     }
 }
+
+// MARK: Constants
+extension BottomSheetTokenSet {
+	static let blurEffectShadowColor: CGColor = UIColor.black.cgColor
+	static let blurEffectShadowOpacity: Float = 0.25
+	static let blurEffectShadowOffset: CGSize = CGSize(width: 0, height: -2)
+	static let blurEffectShadowRadius: CGFloat = 8
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
DESCRIPTION
- Adds an opt-in Blur Effect background for the BottomSheet Contro
- Add UIBlurEffect support to the BottomSheet by using a UIVisualEffectsView.
- Add an optional usesBlurEffectBackground to BottomSheetController and BottomCommandingController initializers, to opt into this new effect.
-  Also account for a ShadowEffect which needs a special case handling for UIVisualEffectsView shadows, which would need a different logic from that currently implemented in Fluent Shadow API `ShadowInfo:applyShadow:to:`. This applyShadow API adds additional CALayers (configured with shadow properties) as shadow layers to the View essentially relying on the view having an opaque backgroundColor for the shadow to show (the opacity of the backgroundColor is directly proportional to the shadow opacity). But when using a UIVisualEffectsView, we can't set an opaque backgroundColor, as it would obstruct the content blurring/sampling feature of this special effects view and would defeat the purpose of using it entirely. So directly add the Shadow tokens to the UIVisualEffectsView layer. 

### Verification

- Tested locally by opting into the usesBlurEffectBackground by doing a        ` let bottomCommandingVC = BottomCommandingController(with: optionTableViewController, usesBlurEffectBackgroundForBottomSheet: true)` in the corresponding demo controller. 
- The default behavior is unaffected. ie. uses opaque background.

<details>
<summary>Visual Verification (NOTE: very subtle difference - there's a blue color bleed through under the Mode button</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="442" alt="Screenshot 2025-05-02 at 19 12 46" src="https://github.com/user-attachments/assets/ee3fed26-169f-4c4c-bb2b-c46c01ab8162" /> | <img width="440" alt="Screenshot 2025-05-02 at 19 12 25" src="https://github.com/user-attachments/assets/a65ea5b9-e507-4fa3-89fa-242f2f6ab36b" /> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)