### PR TITLE
Setting Unique tabID for tabBarItems

### DIFF
--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
@@ -43,7 +43,7 @@ open class TabBarItem: NSObject {
     }
 
     /// Unique tabID for tab Bar item.
-    @objc public var tabId: String? = ""
+    @objc public let tabId: String?
 
     /// Convenience method to set the badge value to a number.
     /// If the number is zero, the badge value will be hidden.

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
@@ -96,6 +96,7 @@ open class TabBarItem: NSObject {
     /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
     /// - Parameter largeContentImage: Used for tabbar item view's accessibility largeContentImage.
     /// - Parameter accessibilityLabelBadgeFormatString: Format string to use for the tabbar item's accessibility label when the badge number is greater than zero. When the badge number is zero, the accessibility label is set to the item's title. By default, when the badge number is greater than zero, the following format is used to builds the accessibility label: "%@, %ld items" where the item's title and the badge number are used to populate the format specifiers. If a format string is provided through this parameter, it must contain "%@" and "%ld" in the same order and will be populated with the title and badge number.
+    /// - Parameter tabId: Unique tabID for tab Bar item.
     @objc public init(title: String,
                       image: UIImage,
                       selectedImage: UIImage? = nil,

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
@@ -96,7 +96,7 @@ open class TabBarItem: NSObject {
     /// - Parameter landscapeSelectedImage: Used for imageView when tabbar item view is selected in landscape. If it is nil, it will use `selectedImage`. The image will be used in portrait mode if the tab bar item shows a label.
     /// - Parameter largeContentImage: Used for tabbar item view's accessibility largeContentImage.
     /// - Parameter accessibilityLabelBadgeFormatString: Format string to use for the tabbar item's accessibility label when the badge number is greater than zero. When the badge number is zero, the accessibility label is set to the item's title. By default, when the badge number is greater than zero, the following format is used to builds the accessibility label: "%@, %ld items" where the item's title and the badge number are used to populate the format specifiers. If a format string is provided through this parameter, it must contain "%@" and "%ld" in the same order and will be populated with the title and badge number.
-    /// - Parameter tabId: Unique tabID for tab Bar item.
+    /// - Parameter tabId: Unique tab Id for tab Bar item.
     @objc public init(title: String,
                       image: UIImage,
                       selectedImage: UIImage? = nil,

--- a/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
+++ b/Sources/FluentUI_iOS/Components/Tab Bar/TabBarItem.swift
@@ -42,6 +42,9 @@ open class TabBarItem: NSObject {
         }
     }
 
+    /// Unique tabID for tab Bar item.
+    @objc public var tabId: String? = ""
+
     /// Convenience method to set the badge value to a number.
     /// If the number is zero, the badge value will be hidden.
     @objc public func setBadgeNumber(_ number: UInt) {
@@ -99,7 +102,8 @@ open class TabBarItem: NSObject {
                       landscapeImage: UIImage? = nil,
                       landscapeSelectedImage: UIImage? = nil,
                       largeContentImage: UIImage? = nil,
-                      accessibilityLabelBadgeFormatString: String? = nil) {
+                      accessibilityLabelBadgeFormatString: String? = nil,
+                      tabId: String? = "") {
         self.image = image
         self.selectedImage = selectedImage
         self.title = title
@@ -107,6 +111,7 @@ open class TabBarItem: NSObject {
         self.landscapeImage = landscapeImage
         self.landscapeSelectedImage = landscapeSelectedImage
         self.accessibilityLabelBadgeFormatString = accessibilityLabelBadgeFormatString
+        self.tabId = tabId
         super.init()
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

- Setting tabID for tabBarItems to uniquely identify tab bar item view.
- Will be required to uniquely identify view element for the purpose of showing tooltip.

### Binary change

Negligible

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)