### PR TITLE
Partial sheet expansion support

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -31,6 +31,9 @@ class BottomSheetDemoController: DemoController {
         bottomSheetViewController.collapsedHeightResolver = { context in
             return context.containerTraitCollection.verticalSizeClass == .regular ? 100 : 70
         }
+        bottomSheetViewController.partialHeightResolver = { context in
+            return context.maximumHeight * 0.5
+        }
 
         self.bottomSheetViewController = bottomSheetViewController
 

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomSheetDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/BottomSheetDemoController.swift
@@ -31,6 +31,7 @@ class BottomSheetDemoController: DemoController {
         bottomSheetViewController.collapsedHeightResolver = { context in
             return context.containerTraitCollection.verticalSizeClass == .regular ? 100 : 70
         }
+
         bottomSheetViewController.partialHeightResolver = { context in
             return context.maximumHeight * 0.5
         }

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -1165,7 +1165,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     // Height of the sheet in collapsed state
     private var collapsedSheetHeight: CGFloat {
         let safeAreaSheetHeight: CGFloat
-        if let dynamicHeight = resolvedDynamicSheetHeights?.collapsedHeight, dynamicHeight > 0  {
+        if let dynamicHeight = resolvedDynamicSheetHeights?.collapsedHeight, dynamicHeight > 0 {
             safeAreaSheetHeight = dynamicHeight
         } else if collapsedContentHeight > 0 {
             safeAreaSheetHeight = collapsedContentHeight + currentResizingHandleHeight

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -195,7 +195,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     /// Changes to this property are animated. A new value is reflected in the getter only after the animation completes.
     @objc open var isExpanded: Bool {
         get {
-            return currentExpansionState == .expanded || currentExpansionState == .partial
+            return currentExpansionState == .expanded
         }
         set {
             setIsExpanded(newValue)
@@ -272,7 +272,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
     }
 
-    /// Represents where the sheet should appear on the screen. 
+    /// Represents where the sheet should appear on the screen.
     /// Defaults to being centered
     @objc open var anchoredEdge: BottomSheetAnchorEdge = .center {
         didSet {
@@ -687,11 +687,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     }
 
     private func updateResizingHandleViewAccessibility(for state: BottomSheetExpansionState) {
-        if state == .expanded || state == .partial {
+        if state == .expanded {
             resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.CollapseSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
-        } else if state == .collapsed {
+        } else if state == .collapsed || state == .partial {
             resizingHandleView.accessibilityLabel = handleExpandCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.ExpandSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Collapsed".localized
@@ -1307,10 +1307,11 @@ extension BottomSheetController: UIGestureRecognizerDelegate {
               let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
             return true
         }
+        // By default, the sheet pan gesture takes precedence.
         var shouldBegin = true
-        let fullyExpanded = currentSheetVerticalOffset <= offset(for: supportsPartialExpansion ? .partial : .expanded)
 
-        if fullyExpanded {
+        // If we're sufficiently expanded, we give the scroll view an opportunity to take over.
+        if currentSheetVerticalOffset <= offset(for: supportsPartialExpansion ? .partial : .expanded) {
             let scrolledToTop = scrollView.contentOffset.y <= 0
             let panningDown = panGesture.velocity(in: view).y > 0
             let panInHostedScrollView = scrollView.frame.contains(panGesture.location(in: scrollView.superview))

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -55,6 +55,7 @@ public protocol BottomSheetControllerDelegate: AnyObject {
 /// Defines the position the sheet is currently in
 @objc public enum BottomSheetExpansionState: Int {
     case expanded // Sheet is fully expanded
+    case partial // Sheet is partially expanded
     case collapsed // Sheet is collapsed
     case hidden // Sheet is hidden (fully off-screen)
     case transitioning // Sheet is between states, only used during user interaction / animation
@@ -194,7 +195,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     /// Changes to this property are animated. A new value is reflected in the getter only after the animation completes.
     @objc open var isExpanded: Bool {
         get {
-            return currentExpansionState == .expanded
+            return currentExpansionState == .expanded || currentExpansionState == .partial
         }
         set {
             setIsExpanded(newValue)
@@ -203,6 +204,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     /// A closure for resolving the desired collapsed sheet height given a resolution context.
     @objc open var collapsedHeightResolver: ((ContentHeightResolutionContext) -> CGFloat)? {
+        didSet {
+            if isViewLoaded {
+                invalidateSheetSize()
+            }
+        }
+    }
+
+    /// A closure for resolving the desired partially expanded sheet height given a resolution context.
+    @objc open var partialHeightResolver: ((ContentHeightResolutionContext) -> CGFloat)? {
         didSet {
             if isViewLoaded {
                 invalidateSheetSize()
@@ -344,11 +354,12 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
         switch expandedState {
         case .collapsed:
-            finishedState = expandedState
+            finishedState = .collapsed
         case .expanded:
-            finishedState = expandedState
-        // Collapsed and expanded are the only valid states so we will default to
-        // collapsed if the user tries anything else
+            finishedState = isExpandable ? .expanded : .collapsed
+        case .partial:
+            finishedState = isExpandable && supportsPartialExpansion ? .partial : .collapsed
+        // Safe fallback for any invalid target states
         default:
             finishedState = .collapsed
         }
@@ -421,11 +432,13 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             return
         }
 
-        lastCollapsedSheetHeightResolutionContext = nil
+        cachedResolvedDynamicSheetHeights = nil
 
-        // If we are animating to .collapsed or already collapsed, we need to move to refresh the animation target.
+        // If we are animating to one of the affected states, we need to retarget the animation.
         if targetExpansionState == .collapsed || (currentExpansionState == .collapsed && targetExpansionState == nil) {
             move(to: .collapsed)
+        } else if supportsPartialExpansion && (targetExpansionState == .partial || (currentExpansionState == .partial && targetExpansionState == nil)) {
+            move(to: .partial)
         }
     }
 
@@ -674,7 +687,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     }
 
     private func updateResizingHandleViewAccessibility(for state: BottomSheetExpansionState) {
-        if state == .expanded {
+        if state == .expanded || state == .partial {
             resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.CollapseSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
@@ -688,7 +701,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     private func updateExpandedContentAlpha() {
         let currentOffset = currentSheetVerticalOffset
         let collapsedOffset = offset(for: .collapsed)
-        let expandedOffset = offset(for: .expanded)
+        let expandedOffset = supportsPartialExpansion ? offset(for: .partial) : offset(for: .expanded)
 
         var targetAlpha: CGFloat = 1.0
         if shouldHideCollapsedContent && !isHeightRestricted {
@@ -738,7 +751,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
             let currentOffset = currentSheetVerticalOffset
             let highestDimmedOffset = offset(for: .expanded)
-            let lowestUndimmedOffset = isHeightRestricted ? offset(for: .hidden) : offset(for: .collapsed)
+            let lowestUndimmedOffset = offset(for: isHeightRestricted ? .hidden : supportsPartialExpansion ? .partial : .collapsed)
 
             if currentOffset <= highestDimmedOffset {
                 targetAlpha = 1.0
@@ -908,23 +921,38 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         var targetState: BottomSheetExpansionState
 
         if abs(velocity) < Constants.directionOverrideVelocityThreshold {
-            // Velocity too low, snap to the closest expansion state
-            var distances: [BottomSheetExpansionState: CGFloat] = [
-                .expanded: abs(offset(for: .expanded) - currentSheetVerticalOffset),
-                .collapsed: abs(offset(for: .collapsed) - currentSheetVerticalOffset)
+            // With a low velocity, we should snap to the closest state.
+            let eligibleStates: [BottomSheetExpansionState?] = [
+                .expanded,
+                .collapsed,
+                supportsPartialExpansion ? .partial : nil,
+                allowsSwipeToHide ? .hidden : nil
             ]
 
-            if allowsSwipeToHide {
-                distances[.hidden] = abs(offset(for: .hidden) - currentSheetVerticalOffset)
-            }
+            let distances = eligibleStates
+                .compactMap { $0 }
+                .reduce(into: [BottomSheetExpansionState: CGFloat]()) { result, state in
+                    result[state] = abs(offset(for: state) - currentSheetVerticalOffset)
+                }
 
+            // Choose the closest one
             targetState = distances.min(by: { $0.value < $1.value })?.key ?? .collapsed
         } else {
             // Velocity high enough, animate to the state we're swiping towards
             if currentSheetVerticalOffset > offset(for: .collapsed) && allowsSwipeToHide {
                 targetState = velocity > 0 ? .hidden : .collapsed
             } else {
-                targetState = velocity > 0 ? .collapsed : .expanded
+                if supportsPartialExpansion {
+                    if velocity > 0 {
+                        // Swiping down
+                        targetState = currentSheetVerticalOffset > offset(for: .partial) ? .collapsed : .partial
+                    } else {
+                        // Swiping up
+                        targetState = currentSheetVerticalOffset > offset(for: .partial) ? .partial : .expanded
+                    }
+                } else {
+                    targetState = velocity > 0 ? .collapsed : .expanded
+                }
             }
         }
         move(to: targetState, velocity: velocity, interaction: .swipe)
@@ -1038,17 +1066,25 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     private func offset(for expansionState: BottomSheetExpansionState) -> CGFloat {
         let offset: CGFloat
 
+        let minOffset = view.bounds.maxY - expandedSheetHeight
         switch expansionState {
         case .collapsed:
-            if !isHeightRestricted || !isExpandable {
-                offset = view.bounds.maxY - collapsedSheetHeight
-            } else {
+            if isHeightRestricted && isExpandable {
                 // When we're height restricted a distinct collapsed offset doesn't make sense,
                 // so we go straight to expanded.
-                fallthrough
+                offset = minOffset
+            } else {
+                offset = view.bounds.maxY - collapsedSheetHeight
+            }
+        case .partial:
+            if isHeightRestricted && isExpandable {
+                // Same here, in height restricted scenarios we want to utilize the space.
+                offset = minOffset
+            } else {
+                offset = view.bounds.maxY - mediumSheetHeight
             }
         case .expanded:
-            offset = view.bounds.maxY - expandedSheetHeight
+            offset = minOffset
         case .hidden:
             offset = view.bounds.maxY
         case .transitioning:
@@ -1127,11 +1163,20 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         return max(collapsedSheetHeight, height)
     }
 
+    private var mediumSheetHeight: CGFloat {
+        guard isExpandable, let mediumHeightResolver = partialHeightResolver else {
+            return collapsedSheetHeight
+        }
+
+        let context = ContentHeightResolutionContext(maximumHeight: maxSheetHeight - view.safeAreaInsets.bottom, containerTraitCollection: view.traitCollection)
+        return mediumHeightResolver(context)
+    }
+
     // Height of the sheet in collapsed state
     private var collapsedSheetHeight: CGFloat {
         let safeAreaSheetHeight: CGFloat
-        if resolvedCollapsedSheetHeight > 0 {
-            safeAreaSheetHeight = resolvedCollapsedSheetHeight
+        if let dynamicHeight = resolvedDynamicSheetHeights?.collapsedHeight, dynamicHeight > 0  {
+            safeAreaSheetHeight = dynamicHeight
         } else if collapsedContentHeight > 0 {
             safeAreaSheetHeight = collapsedContentHeight + currentResizingHandleHeight
         } else {
@@ -1155,25 +1200,23 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         return maxHeight
     }
 
-    // Output of `collapsedHeightResolver` wrapped in a cache.
-    private var resolvedCollapsedSheetHeight: CGFloat {
-        let oldContext = lastCollapsedSheetHeightResolutionContext
-        let newContext = ContentHeightResolutionContext(maximumHeight: maxSheetHeight - view.safeAreaInsets.bottom, containerTraitCollection: view.traitCollection)
+    private var resolvedDynamicSheetHeights: DynamicHeightResolutionResult? {
+        let currentContext = ContentHeightResolutionContext(maximumHeight: maxSheetHeight - view.safeAreaInsets.bottom, containerTraitCollection: view.traitCollection)
+        let cachedContext = cachedResolvedDynamicSheetHeights?.context
 
-        if oldContext?.maximumHeight != newContext.maximumHeight
-            || oldContext?.containerTraitCollection.horizontalSizeClass != newContext.containerTraitCollection.horizontalSizeClass
-            || oldContext?.containerTraitCollection.verticalSizeClass != newContext.containerTraitCollection.verticalSizeClass {
-            lastResolvedCollapsedSheetHeight = collapsedHeightResolver?(newContext) ?? 0
-            lastCollapsedSheetHeightResolutionContext = newContext
+        if cachedContext?.maximumHeight != currentContext.maximumHeight
+            || cachedContext?.containerTraitCollection.horizontalSizeClass != currentContext.containerTraitCollection.horizontalSizeClass
+            || cachedContext?.containerTraitCollection.verticalSizeClass != currentContext.containerTraitCollection.verticalSizeClass {
+            cachedResolvedDynamicSheetHeights = (context: currentContext,
+                                            collapsedHeight: collapsedHeightResolver?(currentContext),
+                                            partialHeight: partialHeightResolver?(currentContext))
         }
-        return lastResolvedCollapsedSheetHeight
+
+        return cachedResolvedDynamicSheetHeights
     }
 
-    // Last output of `collapsedHeightResolver`.
-    private var lastResolvedCollapsedSheetHeight: CGFloat = 0
-
-    // Context we last used for height resolving.
-    private var lastCollapsedSheetHeightResolutionContext: ContentHeightResolutionContext?
+    // Do not access directly. Use `resolvedDynamicSheetHeights` instead which wraps this cache.
+    private var cachedResolvedDynamicSheetHeights: DynamicHeightResolutionResult?
 
     private var currentResizingHandleHeight: CGFloat {
         (isExpandable ? ResizingHandleView.height : 0.0)
@@ -1195,6 +1238,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         maxSheetHeight - collapsedSheetHeight < Constants.heightRestrictedThreshold
     }
 
+    private var supportsPartialExpansion: Bool {
+        partialHeightResolver != nil
+    }
+
     private var currentSheetVerticalOffset: CGFloat {
         bottomSheetView.frame.minY
     }
@@ -1204,6 +1251,9 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     private var currentRootViewHeight: CGFloat = 0
 
     private let shouldShowDimmingView: Bool
+
+    // Dynamic heights, resolved with the corresponding context.
+    private typealias DynamicHeightResolutionResult = (context: ContentHeightResolutionContext, collapsedHeight: CGFloat?, partialHeight: CGFloat?)
 
     private struct Constants {
         // Maximum offset beyond the normal bounds with additional resistance
@@ -1267,7 +1317,7 @@ extension BottomSheetController: UIGestureRecognizerDelegate {
             return true
         }
         var shouldBegin = true
-        let fullyExpanded = currentSheetVerticalOffset <= offset(for: .expanded)
+        let fullyExpanded = currentSheetVerticalOffset <= offset(for: supportsPartialExpansion ? .partial : .expanded)
 
         if fullyExpanded {
             let scrolledToTop = scrollView.contentOffset.y <= 0

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -935,7 +935,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                     result[state] = abs(offset(for: state) - currentSheetVerticalOffset)
                 }
 
-            // Choose the closest one
             targetState = distances.min(by: { $0.value < $1.value })?.key ?? .collapsed
         } else {
             // Velocity high enough, animate to the state we're swiping towards

--- a/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/Bottom Sheet/BottomSheetController.swift
@@ -1081,7 +1081,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 // Same here, in height restricted scenarios we want to utilize the space.
                 offset = minOffset
             } else {
-                offset = view.bounds.maxY - mediumSheetHeight
+                offset = view.bounds.maxY - (resolvedDynamicSheetHeights?.partialHeight ?? collapsedSheetHeight)
             }
         case .expanded:
             offset = minOffset
@@ -1161,15 +1161,6 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         // One case when the lower bound is required is when view.frame is .zero (like before the initial layout pass)
         // This gives the sheet some space to layout in so the layout engine doesn't complain.
         return max(collapsedSheetHeight, height)
-    }
-
-    private var mediumSheetHeight: CGFloat {
-        guard isExpandable, let mediumHeightResolver = partialHeightResolver else {
-            return collapsedSheetHeight
-        }
-
-        let context = ContentHeightResolutionContext(maximumHeight: maxSheetHeight - view.safeAreaInsets.bottom, containerTraitCollection: view.traitCollection)
-        return mediumHeightResolver(context)
     }
 
     // Height of the sheet in collapsed state


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Adds support for a new partial expansion state to bottom sheet. Most of the diff is fairly simple, the main behavioral change is that on pan end, we don't just determine the target state based on direction + velocity, but also position to see if we go towards `.partial`, `.expanded`, or `.collapsed`.

The other bigger change is the addition of the `partialHeightResolver`, which is needed to pull fresh height from the client. It follows design of the existing `collapsedHeightResolver`. I chose to cache them together, because we usually pull them together as well.

Some semantic choices had to be made, like `isExpanded` still maps to `.expanded`, which also means tapping the resizing handle while in `.partial` state takes the sheet to `.expanded`. That choice is fairly arbitrary, given that `.partial` is in-between by definition.

To enable the partial state, we don't have a distinct bool - it's just inferred from the existence of the `partialHeightResolver`.

### Verification

Various manual testing in the demo app + sanity check with client team to early integrate and test E2E. Restricted height scenarios, landscape / portrait changes - verifying sheet frame recalculates to correct new calue.

<details>
<summary>Visual Verification</summary>

https://github.com/user-attachments/assets/4c27c10f-371f-4919-ad50-8d429349b2f0


</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2149)