### PR TITLE
Moving DynamicColor back to struct

### DIFF
--- a/Sources/FluentUI_common/Core/Theme/Tokens/DynamicColor.swift
+++ b/Sources/FluentUI_common/Core/Theme/Tokens/DynamicColor.swift
@@ -6,8 +6,7 @@
 import SwiftUI
 
 /// A container that stores a dynamic set of `Color` values.
-@objc(MSFDynamicColor)
-public final class DynamicColor: NSObject {
+public struct DynamicColor: Hashable {
 
     /// Creates a custom `ShapeStyle` that stores a dynamic set of `Color` values.
     ///


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

We were running into a very rare crash when simultaneously accessing the same Fluent color on multiple threads. There appears to be some cacheing issue when creating a `UIColor` that wraps a dynamic SwiftUI `Color` when the resolver is a class instead of a struct. 

In the meantime, a quick fix is to change it back to a struct (I don't even remember why it was a class in the first place).

This does do away with Objective-C support for `DynamicColor`, but that was pretty short lived anyway :)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Verified that we can create 100,000 Fluent colors simultaneously without crashing (before this change, it would crash 100% at that scale).

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2150)