### PR TITLE
[FluentNotification] Enable showing an action button and a dismiss button

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -167,7 +167,7 @@ struct NotificationDemoView: View {
                                        actionButtonTitle: actionButtonTitle,
                                        actionButtonAction: actionButtonAction,
                                        showDefaultDismissActionButton: showDefaultDismissActionButton,
-                                       defaultDimissButtonAction: dismissButtonAction,
+                                       defaultDismissButtonAction: dismissButtonAction,
                                        messageButtonAction: messageButtonAction,
                                        showFromBottom: showFromBottom)
                     .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -46,6 +46,7 @@ struct NotificationDemoView: View {
     @State var overrideTokens: Bool = false
     @State var isFlexibleWidthToast: Bool = false
     @State var showDefaultDismissActionButton: Bool = true
+    @State var showActionButtonAndDismissButton: Bool = false
     @State var showFromBottom: Bool = true
     @State var showBackgroundGradient: Bool = false
     @State var useCustomTheme: Bool = false
@@ -167,6 +168,7 @@ struct NotificationDemoView: View {
                                        actionButtonTitle: actionButtonTitle,
                                        actionButtonAction: actionButtonAction,
                                        showDefaultDismissActionButton: showDefaultDismissActionButton,
+                                       showActionButtonAndDismissButton: showActionButtonAndDismissButton,
                                        defaultDismissButtonAction: dismissButtonAction,
                                        messageButtonAction: messageButtonAction,
                                        showFromBottom: showFromBottom)
@@ -207,6 +209,7 @@ struct NotificationDemoView: View {
                                actionButtonTitle: actionButtonTitle,
                                actionButtonAction: actionButtonAction,
                                showDefaultDismissActionButton: showDefaultDismissActionButton,
+                               showActionButtonAndDismissButton: showActionButtonAndDismissButton,
                                messageButtonAction: messageButtonAction,
                                showFromBottom: showFromBottom,
                                verticalOffset: verticalOffset)
@@ -265,6 +268,7 @@ struct NotificationDemoView: View {
             FluentListSection("Action") {
                 Toggle("Has Action Button Action", isOn: $hasActionButtonAction)
                 Toggle("Show Default Dismiss Button", isOn: $showDefaultDismissActionButton)
+                Toggle("Can Show Action & Dismiss Buttons", isOn: $showActionButtonAndDismissButton)
                 Toggle("Has Message Action", isOn: $hasMessageAction)
             }
 

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController_SwiftUI.swift
@@ -90,6 +90,7 @@ struct NotificationDemoView: View {
         let trailingImage = showTrailingImage ? UIImage(named: "Placeholder_24") : nil
         let trailingImageLabel = showTrailingImage ? "Circle" : nil
         let actionButtonAction = hasActionButtonAction ? { showAlert = true } : nil
+        let dismissButtonAction = { showAlert = true }
         let messageButtonAction = hasMessageAction ? { showAlert = true } : nil
         let hasMessage = !message.isEmpty
         let hasTitle = !title.isEmpty
@@ -166,6 +167,7 @@ struct NotificationDemoView: View {
                                        actionButtonTitle: actionButtonTitle,
                                        actionButtonAction: actionButtonAction,
                                        showDefaultDismissActionButton: showDefaultDismissActionButton,
+                                       defaultDimissButtonAction: dismissButtonAction,
                                        messageButtonAction: messageButtonAction,
                                        showFromBottom: showFromBottom)
                     .backgroundGradient(showBackgroundGradient ? backgroundGradient : nil)

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -48,7 +48,8 @@ import SwiftUI
     /// Bool to control if the Notification has a dismiss action by default.
     var showDefaultDismissActionButton: Bool { get set }
 
-	var defaultDimissButtonAction: (() -> Void)? { get set }
+    /// Action to be dispatched by the dismiss button on the trailing edge of the control.
+    var defaultDimissButtonAction: (() -> Void)? { get set }
 
     /// Action to be dispatched by tapping on the toast/bar notification.
     var messageButtonAction: (() -> Void)? { get set }
@@ -191,7 +192,7 @@ public struct FluentNotification: View, TokenizedControlView {
         @ViewBuilder
         var button: some View {
             let shouldHaveDefaultAction = state.showDefaultDismissActionButton && shouldSelfPresent
-            if let buttonAction = state.actionButtonAction ?? (shouldHaveDefaultAction ? dismissAnimated : nil) {
+            if let buttonAction = state.actionButtonAction ?? (shouldHaveDefaultAction ? (state.defaultDimissButtonAction ?? dismissAnimated) : nil) {
                 if let actionTitle = state.actionButtonTitle, !actionTitle.isEmpty {
                     SwiftUI.Button(actionTitle) {
                         isPresented = false
@@ -218,20 +219,19 @@ public struct FluentNotification: View, TokenizedControlView {
             }
         }
 
-		@ViewBuilder
-		var dismissButton: some View {
-			let shouldHaveDefaultAction = state.showDefaultDismissActionButton && state.actionButtonAction != nil
-			if shouldHaveDefaultAction, let dismissAction = state.defaultDimissButtonAction {
-					SwiftUI.Button(action: {
-						isPresented = false
-						dismissAction()
-					}, label: {
-						Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
-							.accessibilityLabel("Accessibility.Dismiss.Label".localized)
-					})
-					.hoverEffect()
-			}
-		}
+        @ViewBuilder
+        var dismissButton: some View {
+            if state.showDefaultDismissActionButton, state.actionButtonAction != nil, let actionButtonTitle = state.actionButtonTitle, !actionButtonTitle.isEmpty, let dismissAction = state.defaultDimissButtonAction {
+                SwiftUI.Button(action: {
+                    isPresented = false
+                    dismissAction()
+                }, label: {
+                    Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
+                        .accessibilityLabel("Accessibility.Dismiss.Label".localized)
+                })
+                .hoverEffect()
+            }
+        }
 
         let messageButtonAction = state.messageButtonAction
         @ViewBuilder
@@ -263,13 +263,11 @@ public struct FluentNotification: View, TokenizedControlView {
                         .buttonStyle(.borderless)
 #endif // os(visionOS)
                         .layoutPriority(1)
-					if state.showDefaultDismissActionButton {
-						dismissButton
-	#if os(visionOS)
-							.buttonStyle(.borderless)
-	#endif // os(visionOS)
-							.layoutPriority(1)
-					}
+                    dismissButton
+#if os(visionOS)
+                        .buttonStyle(.borderless)
+#endif // os(visionOS)
+                        .layoutPriority(1)
                 }
                 .onSizeChange { newSize in
                     innerContentsSize = newSize

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -49,7 +49,7 @@ import SwiftUI
     var showDefaultDismissActionButton: Bool { get set }
 
     /// Action to be dispatched by the dismiss button on the trailing edge of the control.
-    var defaultDimissButtonAction: (() -> Void)? { get set }
+    var defaultDismissButtonAction: (() -> Void)? { get set }
 
     /// Action to be dispatched by tapping on the toast/bar notification.
     var messageButtonAction: (() -> Void)? { get set }
@@ -87,7 +87,7 @@ public struct FluentNotification: View, TokenizedControlView {
     ///   - actionButtonTitle:Title to display in the action button on the trailing edge of the control.
     ///   - actionButtonAction: Action to be dispatched by the action button on the trailing edge of the control.
     ///   - showDefaultDismissActionButton: Bool to control if the Notification has a dismiss action by default.
-    ///   - defaultDimissButtonAction: Action to be dispatched by the dismiss button of the trailing edge of the control.
+    ///   - defaultDismissButtonAction: Action to be dispatched by the dismiss button of the trailing edge of the control.
     ///   - messageButtonAction: Action to be dispatched by tapping on the toast/bar notification.
     ///   - showFromBottom: Defines whether the notification shows from the bottom of the presenting view or the top.
     ///   - verticalOffset: How much to vertically offset the notification from its default position.
@@ -105,7 +105,7 @@ public struct FluentNotification: View, TokenizedControlView {
                 actionButtonTitle: String? = nil,
                 actionButtonAction: (() -> Void)? = nil,
                 showDefaultDismissActionButton: Bool? = nil,
-                defaultDimissButtonAction: (() -> Void)? = nil,
+                defaultDismissButtonAction: (() -> Void)? = nil,
                 messageButtonAction: (() -> Void)? = nil,
                 showFromBottom: Bool = true,
                 verticalOffset: CGFloat = 0.0) {
@@ -120,7 +120,7 @@ public struct FluentNotification: View, TokenizedControlView {
                                              actionButtonTitle: actionButtonTitle,
                                              actionButtonAction: actionButtonAction,
                                              showDefaultDismissActionButton: showDefaultDismissActionButton,
-                                             defaultDimissButtonAction: defaultDimissButtonAction,
+                                             defaultDismissButtonAction: defaultDismissButtonAction,
                                              messageButtonAction: messageButtonAction,
                                              showFromBottom: showFromBottom,
                                              verticalOffset: verticalOffset)
@@ -392,7 +392,7 @@ public struct FluentNotification: View, TokenizedControlView {
         if shouldUseActionButtonAction {
             dismissAction = state.actionButtonAction
         } else if state.showDefaultDismissActionButton {
-            if let defaultAction = state.defaultDimissButtonAction {
+            if let defaultAction = state.defaultDismissButtonAction {
                 dismissAction = defaultAction
             } else if shouldSelfPresent {
                 dismissAction = dismissAnimated
@@ -464,7 +464,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
     @Published var trailingImage: UIImage?
     @Published var trailingImageAccessibilityLabel: String?
     @Published var showDefaultDismissActionButton: Bool
-    @Published var defaultDimissButtonAction: (() -> Void)?
+    @Published var defaultDismissButtonAction: (() -> Void)?
     @Published var showFromBottom: Bool
     @Published var backgroundGradient: LinearGradientInfo?
     @Published var verticalOffset: CGFloat
@@ -514,7 +514,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
          actionButtonTitle: String? = nil,
          actionButtonAction: (() -> Void)? = nil,
          showDefaultDismissActionButton: Bool? = nil,
-         defaultDimissButtonAction: (() -> Void)? = nil,
+         defaultDismissButtonAction: (() -> Void)? = nil,
          messageButtonAction: (() -> Void)? = nil,
          showFromBottom: Bool = true,
          verticalOffset: CGFloat) {
@@ -531,7 +531,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
         self.messageButtonAction = messageButtonAction
         self.showFromBottom = showFromBottom
         self.showDefaultDismissActionButton = showDefaultDismissActionButton ?? style.isToast
-        self.defaultDimissButtonAction = defaultDimissButtonAction
+        self.defaultDismissButtonAction = defaultDismissButtonAction
         self.verticalOffset = verticalOffset
 
         super.init()

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -521,7 +521,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
         self.actionButtonAction = actionButtonAction
         self.messageButtonAction = messageButtonAction
         self.showFromBottom = showFromBottom
-        self.showDefaultDismissActionButton = showDefaultDismissActionButton ?? false//style.isToast
+        self.showDefaultDismissActionButton = showDefaultDismissActionButton ?? style.isToast
         self.verticalOffset = verticalOffset
 
         super.init()

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -48,6 +48,8 @@ import SwiftUI
     /// Bool to control if the Notification has a dismiss action by default.
     var showDefaultDismissActionButton: Bool { get set }
 
+	var defaultDimissButtonAction: (() -> Void)? { get set }
+
     /// Action to be dispatched by tapping on the toast/bar notification.
     var messageButtonAction: (() -> Void)? { get set }
 
@@ -216,6 +218,21 @@ public struct FluentNotification: View, TokenizedControlView {
             }
         }
 
+		@ViewBuilder
+		var dismissButton: some View {
+			let shouldHaveDefaultAction = state.showDefaultDismissActionButton && state.actionButtonAction != nil
+			if shouldHaveDefaultAction, let dismissAction = state.defaultDimissButtonAction {
+					SwiftUI.Button(action: {
+						isPresented = false
+						dismissAction()
+					}, label: {
+						Image("dismiss-20x20", bundle: FluentUIFramework.resourceBundle)
+							.accessibilityLabel("Accessibility.Dismiss.Label".localized)
+					})
+					.hoverEffect()
+			}
+		}
+
         let messageButtonAction = state.messageButtonAction
         @ViewBuilder
         var innerContents: some View {
@@ -246,6 +263,13 @@ public struct FluentNotification: View, TokenizedControlView {
                         .buttonStyle(.borderless)
 #endif // os(visionOS)
                         .layoutPriority(1)
+					if state.showDefaultDismissActionButton {
+						dismissButton
+	#if os(visionOS)
+							.buttonStyle(.borderless)
+	#endif // os(visionOS)
+							.layoutPriority(1)
+					}
                 }
                 .onSizeChange { newSize in
                     innerContentsSize = newSize
@@ -410,6 +434,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
     @Published var trailingImage: UIImage?
     @Published var trailingImageAccessibilityLabel: String?
     @Published var showDefaultDismissActionButton: Bool
+	@Published var defaultDimissButtonAction: (() -> Void)?
     @Published var showFromBottom: Bool
     @Published var backgroundGradient: LinearGradientInfo?
     @Published var verticalOffset: CGFloat

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -432,7 +432,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
     @Published var trailingImage: UIImage?
     @Published var trailingImageAccessibilityLabel: String?
     @Published var showDefaultDismissActionButton: Bool
-	@Published var defaultDimissButtonAction: (() -> Void)?
+    @Published var defaultDimissButtonAction: (() -> Void)?
     @Published var showFromBottom: Bool
     @Published var backgroundGradient: LinearGradientInfo?
     @Published var verticalOffset: CGFloat

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -36,9 +36,9 @@ import UIKit
             strongSelf.hide()
         }
 
-		if notification.state.showDefaultDismissActionButton {
-			notification.state.defaultDimissButtonAction = defaultDismissAction
-		}
+        if notification.state.defaultDimissButtonAction == nil {
+            notification.state.defaultDimissButtonAction = defaultDismissAction
+        }
     }
 
     required public init?(coder: NSCoder) {

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -35,7 +35,10 @@ import UIKit
             }
             strongSelf.hide()
         }
-        notification.state.actionButtonAction = notification.state.showDefaultDismissActionButton ? defaultDismissAction : nil
+
+		if notification.state.showDefaultDismissActionButton {
+			notification.state.defaultDimissButtonAction = defaultDismissAction
+		}
     }
 
     required public init?(coder: NSCoder) {

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -36,8 +36,8 @@ import UIKit
             strongSelf.hide()
         }
 
-        if notification.state.defaultDimissButtonAction == nil {
-            notification.state.defaultDimissButtonAction = defaultDismissAction
+        if notification.state.defaultDismissButtonAction == nil {
+            notification.state.defaultDismissButtonAction = defaultDismissAction
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

There is a use case where we need to be able to show an action button and a dismiss button on a single notification. Both show iff the `MSFNotificationState.showDefaultDismissActionButton ` is true, `actionButtonAction` is not `nil`,and `actionButtonTitle` is not `nil` and not empty.

To implement this:
- Add a `defaultDimissButtonAction` block property on the `MSFNotificationState`. If the value is not set by the consumer, we will give it a default value in the `MSFNotification` initializer.
- Create a `dismissButton` viewbuilder in the view implementation. This button will only show when the conditions in the first paragraph above are met.
- Add a call to add the dimiss button if the `dismissButtonAction` is non-nil. The code to determine the `dismissButtonAction` was broken out into its own private function so that it could be more easily called from two places in the view.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

- Validated the behavior in the Fluent Test App (see demo)

<details>
<summary>Visual Verification</summary>

https://github.com/user-attachments/assets/77b750b2-6c64-4875-967b-769fd93053c7

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2154)