### PR TITLE
Fixing broken dark mode colors in iOS 17

### DIFF
--- a/Sources/FluentUI_common/Core/Extensions/UIColor+Extensions.swift
+++ b/Sources/FluentUI_common/Core/Extensions/UIColor+Extensions.swift
@@ -138,10 +138,11 @@ extension UIColor {
                                   userInterfaceLevel: .elevated)
     }
 
-    convenience init(dynamicColor: DynamicColor) {
+    public convenience init(dynamicColor: DynamicColor) {
+        let colorResolver = { $0 != nil ? UIColor($0!) : nil }
         self.init(light: UIColor(dynamicColor.light),
-                  dark: dynamicColor.dark.map { UIColor($0) },
-                  darkElevated: dynamicColor.darkElevated.map { UIColor($0) })
+                  dark: colorResolver(dynamicColor.dark),
+                  darkElevated: colorResolver(dynamicColor.darkElevated))
     }
 
     /// Returns the version of the current color that results from the specified traits as a `ColorValue`.

--- a/Sources/FluentUI_common/Core/Extensions/UIColor+Extensions.swift
+++ b/Sources/FluentUI_common/Core/Extensions/UIColor+Extensions.swift
@@ -139,10 +139,9 @@ extension UIColor {
     }
 
     public convenience init(dynamicColor: DynamicColor) {
-        let colorResolver = { $0 != nil ? UIColor($0!) : nil }
         self.init(light: UIColor(dynamicColor.light),
-                  dark: colorResolver(dynamicColor.dark),
-                  darkElevated: colorResolver(dynamicColor.darkElevated))
+                  dark: dynamicColor.dark.map { UIColor($0) },
+                  darkElevated: dynamicColor.darkElevated.map { UIColor($0) })
     }
 
     /// Returns the version of the current color that results from the specified traits as a `ColorValue`.

--- a/Sources/FluentUI_common/Core/Theme/FluentTheme.swift
+++ b/Sources/FluentUI_common/Core/Theme/FluentTheme.swift
@@ -109,6 +109,13 @@ public class FluentTheme: NSObject, ObservableObject {
         return view.isApplicableThemeChange(notification)
     }
 
+    /// Workaround for a SwiftUI bug on iOS 17. We need to expose the `DynamicColor` for a given
+    /// `ColorToken` to initialize our platform-specific colors (`UIColor` and `NSColor`).
+    /// Creating directly from SwiftUI color is broken on these platforms.
+    public func dynamicColor(_ colorToken: ColorToken) -> DynamicColor {
+        return colorTokenSet[colorToken]
+    }
+
     // Token storage
     let colorTokenSet: TokenSet<ColorToken, DynamicColor>
     let shadowTokenSet: TokenSet<ShadowToken, ShadowInfo>

--- a/Sources/FluentUI_iOS/Core/Theme/FluentTheme+UIKit.swift
+++ b/Sources/FluentUI_iOS/Core/Theme/FluentTheme+UIKit.swift
@@ -55,7 +55,7 @@ public extension FluentTheme {
     /// - Returns: A `UIColor` for the given token.
     @objc(colorForToken:)
     func color(_ token: ColorToken) -> UIColor {
-		return UIColor(swiftUIColor(token))
+        return UIColor(dynamicColor: dynamicColor(token))
     }
 
     /// Returns the font value for the given token.


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

The APIs for creating a UIColor from SwiftUI Color don't work properly on iOS 17 when the Color is dynamic. This works fine on iOS 18, but results in dark mode issues on iOS 17.

Solution: reverting back to an older implementation of UIColor creation, with a few extra public markers to make it work in the new Fluent infrastructure.

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/user-attachments/assets/dc557ebc-6019-42c5-8bd6-31946d1070ed) | ![after](https://github.com/user-attachments/assets/ea17d6df-681e-4034-9911-90c66a2c7240) |
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2156)