### PR TITLE
Move vision token file to FluentUI_common module

### DIFF
--- a/Sources/FluentUI_common/Core/Theme/FluentTheme+visionOS.swift
+++ b/Sources/FluentUI_common/Core/Theme/FluentTheme+visionOS.swift
@@ -3,9 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-#if canImport(FluentUI_common)
-import FluentUI_common
-#endif
 import SwiftUI
 
 #if os(visionOS)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Although theoretically we only need the vision token file in the iOS module, we still reference it in the common module in `FluentTheme.swift`. Moving it to `FluentUI_common`.

### Verification

Demo app builds

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2161)