### PR TITLE
Update ccb label/icon in updateState

### DIFF
--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButton.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButton.swift
@@ -51,8 +51,6 @@ class CommandBarButton: UIButton {
             isAccessibilityElement = false
         } else {
             var buttonConfiguration = UIButton.Configuration.plain()
-            buttonConfiguration.title = item.title
-            buttonConfiguration.image = item.iconImage
             buttonConfiguration.imagePadding = CommandBarTokenSet.buttonImagePadding
             buttonConfiguration.contentInsets = CommandBarTokenSet.buttonContentInsets
             buttonConfiguration.background.cornerRadius = 0
@@ -89,6 +87,9 @@ class CommandBarButton: UIButton {
         isEnabled = item.isEnabled
         isSelected = isPersistSelection && item.isSelected
         isHidden = item.isHidden
+
+        configuration?.title = item.title
+        configuration?.image = item.iconImage
 
         /// Additional state update is not needed if the `customControlView` is being shown
         guard item.customControlView == nil else {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Currently, `CommandBarButton` sets its title/icon once in its init and never again. Move it to `updateState` to handle updates after init.

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| ![before](https://github.com/user-attachments/assets/b3f94ea2-3daa-4780-8eb5-952c784b3ea8) | ![after](https://github.com/user-attachments/assets/c3359c0d-d691-49b3-82ef-4f796e4565b2) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)