### PR TITLE
Update ccb label/icon in updateState (#2164)

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUIDemoTests/CommandBarTest.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUIDemoTests/CommandBarTest.swift
@@ -28,7 +28,7 @@ class CommandBarTest: BaseTest {
 
     // ensures that tapping on text style button rotates through text styles
     func testChangeTextStyleButton() throws {
-        let textStyleButtonNumber: Int = 15
+        let textStyleButtonNumber: Int = 16
         let textStyleButton: XCUIElement = app.buttons.element(boundBy: textStyleButtonNumber)
 
         XCTAssert(app.buttons["Body"].exists)

--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButton.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButton.swift
@@ -48,8 +48,6 @@ class CommandBarButton: UIButton {
             isAccessibilityElement = false
         } else {
             var buttonConfiguration = UIButton.Configuration.plain()
-            buttonConfiguration.title = item.title
-            buttonConfiguration.image = item.iconImage
             buttonConfiguration.imagePadding = CommandBarTokenSet.buttonImagePadding
             buttonConfiguration.contentInsets = CommandBarTokenSet.buttonContentInsets
             buttonConfiguration.background.cornerRadius = 0
@@ -88,6 +86,9 @@ class CommandBarButton: UIButton {
         guard item.customControlView == nil else {
             return
         }
+
+        configuration?.title = item.title
+        configuration?.image = item.iconImage
 
         if let font = item.titleFont {
             let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Cherry-pick 1df2e45c561c2ad002046d3d852fc0bc0183267e

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)