### PR TITLE
Bump to 0.33.2

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Info.plist
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.33.1</string>
+	<string>1.33.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>137.33.1</string>
+	<string>137.33.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Demos/FluentUIDemo_macOS/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/Demos/FluentUIDemo_macOS/FluentUITestApp/FluentUITestApp-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.33.1</string>
+	<string>0.33.2</string>
 	<key>CFBundleVersion</key>
-	<string>62.33.1</string>
+	<string>62.33.2</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -8,7 +8,7 @@ resources_dir = 'Resources'
 
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUI'
-  s.version          = '0.33.1'
+  s.version          = '0.33.2'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/FluentUI_iOS/Resources/Version.plist
+++ b/Sources/FluentUI_iOS/Resources/Version.plist
@@ -3,8 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>0.33.1</string>
+	<string>0.33.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.33.1</string>
+	<string>0.33.2</string>
 </dict>
 </plist>

--- a/Sources/FluentUI_macOS/FluentUI-Info.plist
+++ b/Sources/FluentUI_macOS/FluentUI-Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.33.1</string>
+	<string>0.33.2</string>
 	<key>CFBundleVersion</key>
-	<string>0.33.1</string>
+	<string>0.33.2</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

Bump to 0.33.2

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2167)