### PR TITLE
Update CCB label accessibility

### DIFF
--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButtonGroupView.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarButtonGroupView.swift
@@ -62,11 +62,18 @@ class CommandBarButtonGroupView: UIView {
     }()
 
     private lazy var groupLabel: Label = {
-        let label = Label(textStyle: .caption2, colorStyle: .regular)
+        let label = Label()
         label.text = title
+        label.font = tokenSet[.itemGroupLabelFont].uiFont
         label.translatesAutoresizingMaskIntoConstraints = false
         label.setContentHuggingPriority(.required, for: .vertical)
         label.lineBreakMode = .byClipping
+
+        label.accessibilityTraits.insert(.header)
+        label.isUserInteractionEnabled = true
+        label.addInteraction(UILargeContentViewerInteraction())
+        label.showsLargeContentViewer = true
+        label.largeContentTitle = title
         return label
     }()
 

--- a/Sources/FluentUI_iOS/Components/Command Bar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Command Bar/CommandBarTokenSet.swift
@@ -44,6 +44,9 @@ public enum CommandBarToken: Int, TokenSetKey {
 
     /// The icon color of a Command Bar Item when disabled.
     case itemIconColorDisabled
+
+    /// The font of a Command Bar Item Group label.
+    case itemGroupLabelFont
 }
 
 /// Design token set for the `CommandBar` control.
@@ -89,6 +92,9 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
 
             case .itemIconColorDisabled:
                 return .uiColor { theme.color(.foregroundDisabled1) }
+
+            case .itemGroupLabelFont:
+                return .uiFont { theme.typography(.caption2, adjustsForContentSizeCategory: false) }
             }
         }
     }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Updating ccb group label accessiblity
- Add `header` accessibility trait
- Prevent label from scaling and add large content viewer

While I'm here, allow label font to be customizable

### Verification

<details>
<summary>Visual Verification</summary>

| Header                                       | Large content viewer                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1523" alt="vo" src="https://github.com/user-attachments/assets/7d2547c6-69c3-498c-9e4c-37c0a8645867" /> | ![lcv](https://github.com/user-attachments/assets/9aa0cf8a-75df-4d9f-817c-33ba907a29d8) |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)