### PR TITLE
Check build environment for PlatformProviding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,15 @@
-// swift-tools-version:5.9
+// swift-tools-version:5.10
 
 import PackageDescription
 
 let iOSPlatforms: [Platform] = [.iOS, .visionOS, .macCatalyst]
 let macOSPlatforms: [Platform] = [.macOS]
+
+let swiftSettings: [SwiftSetting] = [
+    .unsafeFlags([
+        "-warnings-as-errors"
+    ])
+]
 
 let targets: [Target] = [
     .target(
@@ -12,7 +18,8 @@ let targets: [Target] = [
             .targetItem(name: "FluentUI_ios", condition: .when(platforms: iOSPlatforms)),
             .targetItem(name: "FluentUI_macos", condition: .when(platforms: macOSPlatforms))
         ],
-        path: "Sources/FluentUI"
+        path: "Sources/FluentUI",
+        swiftSettings: swiftSettings
     ),
     .target(
         name: "FluentUI_ios",
@@ -22,35 +29,39 @@ let targets: [Target] = [
         path: "Sources/FluentUI_iOS",
         resources: [
             .copy("Resources/Version.plist")
-        ]
+        ],
+        swiftSettings: swiftSettings
     ),
     .target(
         name: "FluentUI_macos",
         dependencies: [
             .target(name: "FluentUI_common")
         ],
-        path: "Sources/FluentUI_macOS"
+        path: "Sources/FluentUI_macOS",
+        swiftSettings: swiftSettings
     ),
     .target(
         name: "FluentUI_common",
-        path: "Sources/FluentUI_common"
+        path: "Sources/FluentUI_common",
+        swiftSettings: swiftSettings
     )
 ]
-
 let testTargets: [Target] = [
     .testTarget(
         name: "FluentUI_iOS_Tests",
         dependencies: [
             .target(name: "FluentUI_ios", condition: .when(platforms: iOSPlatforms)),
         ],
-        path: "Tests/FluentUI_iOS_Tests"
+        path: "Tests/FluentUI_iOS_Tests",
+        swiftSettings: swiftSettings
     ),
     .testTarget(
         name: "FluentUI_macOS_Tests",
         dependencies: [
             .target(name: "FluentUI_macos", condition: .when(platforms: macOSPlatforms))
         ],
-        path: "Tests/FluentUI_macOS_Tests"
+        path: "Tests/FluentUI_macOS_Tests",
+        swiftSettings: swiftSettings
     )
 ]
 

--- a/Sources/FluentUI_common/Core/Theme/Tokens/GlobalTokens.swift
+++ b/Sources/FluentUI_common/Core/Theme/Tokens/GlobalTokens.swift
@@ -1667,10 +1667,7 @@ public class GlobalTokens: NSObject {
         case size900
     }
     public static func fontSize(_ token: FontSizeToken) -> CGFloat {
-        guard let platformGlobalTokenProviding = self as? PlatformGlobalTokenProviding.Type else {
-            fatalError("GlobalTokens should conform to PlatformGlobalTokenProviding")
-        }
-        return platformGlobalTokenProviding.fontSize(for: token)
+        return platformGlobalTokenProvider.fontSize(for: token)
     }
 
     // MARK: - FontWeight
@@ -1853,10 +1850,27 @@ public class GlobalTokens: NSObject {
         }
     }
 
-    // MARK: Initialization
+    // MARK: - Initialization
 
     @available(*, unavailable)
     private override init() {
         preconditionFailure("GlobalTokens should never be initialized!")
+    }
+
+    // MARK: - PlatformGlobalTokenProviding
+
+    private static var platformGlobalTokenProvider: any PlatformGlobalTokenProviding.Type {
+        // We need slightly different implementations depending on how our package is loaded.
+#if SWIFT_PACKAGE || COCOAPODS
+        // In this case, the protocol conformance happens in a different module, so we need to
+        // convert the type conditionally and fail if something goes wrong.
+        guard let platformGlobalTokenProvider = self as? PlatformGlobalTokenProviding.Type else {
+            preconditionFailure("GlobalTokens should conform to PlatformGlobalTokenProviding")
+        }
+#else
+        // Otherwise, we're all in one module and thus the type conversion is guaranteed.
+        let platformGlobalTokenProvider = self as PlatformGlobalTokenProviding.Type
+#endif
+        return platformGlobalTokenProvider
     }
 }

--- a/Sources/FluentUI_common/Core/module.modulemap
+++ b/Sources/FluentUI_common/Core/module.modulemap
@@ -1,3 +1,0 @@
-module FluentUI {
-    header "FluentUI-Swift.h"
-}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

Fetch our `Platform[*]Providing` protocols differently depending on the build system.
* SPM and Cocoapods: we're crossing a module boundary, so stick with the conditional conversion.
* Manual pull of code into repo: all the same module, so no conditional required.

### Verification

No functional change. Builds and runs across multiple build systems.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2175)