### PR TITLE
Mark TokenSetKey as Sendable

### DIFF
--- a/Sources/FluentUI_common/Core/Theme/Tokens/TokenSet.swift
+++ b/Sources/FluentUI_common/Core/Theme/Tokens/TokenSet.swift
@@ -4,7 +4,7 @@
 //
 
 /// Defines the key used for token value indexing.
-public typealias TokenSetKey = Hashable
+public typealias TokenSetKey = Hashable & Sendable
 
 /// Template for all token sets, both global and alias. This ensures a unified return type for any given token set.
 public final class TokenSet<T: TokenSetKey, V> {


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

Xcode 26 is a bit more sensitive about marking types as Sendable. While we're still working towards full Swift 6 compatibility, this will unblock building FluentUI on the new compiler.

### Verification

Apps build and runs on both Xcode 16.4 and 26b1.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2176)