### PR TITLE
Make UINavigationItem's subtitle obsolete for iOS 26 to fix fluent build with Xcode 26

### DIFF
--- a/Sources/FluentUI_iOS/Components/Navigation/UINavigationItem+Navigation.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/UINavigationItem+Navigation.swift
@@ -124,6 +124,7 @@ import UIKit
     }
 
     /// The navigation item's subtitle that displays in the navigation bar.
+    @available(iOS, obsoleted: 26.0)
     var subtitle: String? {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.subtitle) as? String


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

There is a new subtitle added to the UINavigationItem on iOS 26 https://developer.apple.com/documentation/uikit/uinavigationitem/subtitle. This conflicts with the existing fluent subtitle so let's make that obsolete for iOS 26.0 to fix build break with Xcode 26 beta.

### Verification

Builds fine on Xcode 26 beta. Subtitle shows up on iOS 26 with the system subtitle.

![Image 6-11-25 at 7 17 PM](https://github.com/user-attachments/assets/f6a07516-9a96-4faa-8edf-dbbd9590f1c2)


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2178)