### PR TITLE
Move `UINavigationItem` extensions to new `FluentNavigationItemConfiguration`

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NavigationControllerDemoController.swift
@@ -219,18 +219,18 @@ class NavigationControllerDemoController: DemoController {
                                    leadingItem: LeadingItem = .avatar,
                                    updateStylePeriodically: Bool = false) -> NavigationController {
         let content = RootViewController()
-        content.navigationItem.titleStyle = titleStyle
-        content.navigationItem.subtitle = subtitle
+        content.navigationItem.fluentConfiguration.titleStyle = titleStyle
+        content.navigationItem.fluentConfiguration.subtitle = subtitle
         content.navigationItem.backButtonTitle = "99+"
-        content.navigationItem.navigationBarStyle = style
-        content.navigationItem.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
-        content.navigationItem.accessoryView = accessoryView
-        content.navigationItem.secondaryAccessoryView = secondaryAccessoryView
-        content.navigationItem.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
-        content.navigationItem.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
+        content.navigationItem.fluentConfiguration.navigationBarStyle = style
+        content.navigationItem.fluentConfiguration.navigationBarShadow = showShadow ? .automatic : .alwaysHidden
+        content.navigationItem.fluentConfiguration.accessoryView = accessoryView
+        content.navigationItem.fluentConfiguration.secondaryAccessoryView = secondaryAccessoryView
+        content.navigationItem.fluentConfiguration.topAccessoryViewAttributes = NavigationBarTopSearchBarAttributes()
+        content.navigationItem.fluentConfiguration.contentScrollView = contractNavigationBarOnScroll ? content.tableView : nil
         content.showsTopAccessoryView = showsTopAccessory
 
-        content.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
+        content.navigationItem.fluentConfiguration.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: view.frame.width)
 
         if updateStylePeriodically {
             changeStyleContinuously(in: content.navigationItem)
@@ -276,7 +276,7 @@ class NavigationControllerDemoController: DemoController {
     private func changeStyleContinuously(in navigationItem: UINavigationItem) {
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
             let newStyle: NavigationBar.Style
-            switch navigationItem.navigationBarStyle {
+            switch navigationItem.fluentConfiguration.navigationBarStyle {
             case .custom:
                 newStyle = .default
             case .default:
@@ -287,7 +287,7 @@ class NavigationControllerDemoController: DemoController {
                 newStyle = .custom
             }
 
-            navigationItem.navigationBarStyle = newStyle
+            navigationItem.fluentConfiguration.navigationBarStyle = newStyle
 #if os(iOS)
             self.setNeedsStatusBarAppearanceUpdate()
 #endif
@@ -382,81 +382,81 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     lazy var titleViewFeaturesByRow: [Int: TitleViewFeature] = [
         4: TitleViewFeature(name: "Large title") {
-            $0.navigationItem.titleStyle = .largeLeading
+            $0.navigationItem.fluentConfiguration.titleStyle = .largeLeading
         },
         5: TitleViewFeature(name: "Leading-aligned, two titles, collapsible") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.subtitle = "Subtitle"
-            $0.navigationItem.contentScrollView = $0.tableView
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.contentScrollView = $0.tableView
         },
         6: TitleViewFeature(name: "Two titles with subtitle disclosure") {
-            $0.navigationItem.subtitle = "Press me!"
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .disclosure, delegate: self)
+            $0.navigationItem.fluentConfiguration.subtitle = "Press me!"
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .disclosure, delegate: self)
         },
         7: TitleViewFeature(name: "Leading-aligned, image, subtitle") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
         },
         8: TitleViewFeature(name: "Centered, image, subtitle") {
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
         },
         9: TitleViewFeature(name: "Leading-aligned, image, down arrow, subtitle") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.subtitle = "Subtitle"
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         10: TitleViewFeature(name: "Centered, image, down arrow, subtitle") {
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.subtitle = "Subtitle"
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         11: TitleViewFeature(name: "Leading, down arrow") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         12: TitleViewFeature(name: "Centered, down arrow") {
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .downArrow, delegate: self)
         },
         13: TitleViewFeature(name: "Leading, image, disclosure") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
         },
         14: TitleViewFeature(name: "Centered, image, disclosure") {
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
         },
         15: TitleViewFeature(name: "Centered, collapsible search bar") {
             let searchBar = SearchBar()
-            searchBar.style = ($0.navigationItem.navigationBarStyle == .system || $0.navigationItem.navigationBarStyle == .gradient) ? .onSystemNavigationBar : .onBrandNavigationBar
+            searchBar.style = ($0.navigationItem.fluentConfiguration.navigationBarStyle == .system || $0.navigationItem.fluentConfiguration.navigationBarStyle == .gradient) ? .onSystemNavigationBar : .onBrandNavigationBar
             searchBar.placeholderText = "Search"
-            $0.navigationItem.accessoryView = searchBar
-            $0.navigationItem.contentScrollView = $0.tableView
+            $0.navigationItem.fluentConfiguration.accessoryView = searchBar
+            $0.navigationItem.fluentConfiguration.contentScrollView = $0.tableView
         },
         16: TitleViewFeature(name: "Leading-aligned, subtitle with custom trailing image") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.subtitle = "Subtitle"
-            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .custom, delegate: self)
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .custom, delegate: self)
         },
         17: TitleViewFeature(name: "Leading title with leading image for both title and subtitle") {
-            $0.navigationItem.titleStyle = .leading
-            $0.navigationItem.subtitle = "Subtitle"
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_24_regular")
-            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .custom, delegate: self)
-            $0.navigationItem.isTitleImageLeadingForTitleAndSubtitle = true
+            $0.navigationItem.fluentConfiguration.titleStyle = .leading
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_24_regular")
+            $0.navigationItem.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .subtitle, style: .custom, delegate: self)
+            $0.navigationItem.fluentConfiguration.isTitleImageLeadingForTitleAndSubtitle = true
         },
         18: TitleViewFeature(name: "Centered title with leading image for both title and subtitle") {
-            $0.navigationItem.titleStyle = .system
-            $0.navigationItem.subtitle = "Subtitle"
-            $0.navigationItem.titleImage = UIImage(named: "ic_fluent_star_24_regular")
-            $0.navigationItem.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.navigationItem.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
-            $0.navigationItem.isTitleImageLeadingForTitleAndSubtitle = true
+            $0.navigationItem.fluentConfiguration.titleStyle = .system
+            $0.navigationItem.fluentConfiguration.subtitle = "Subtitle"
+            $0.navigationItem.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_24_regular")
+            $0.navigationItem.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.navigationItem.fluentConfiguration.titleAccessory = NavigationBarTitleAccessory(location: .title, style: .disclosure, delegate: self)
+            $0.navigationItem.fluentConfiguration.isTitleImageLeadingForTitleAndSubtitle = true
         }
     ]
 
@@ -570,8 +570,8 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         tableView.contentInset.bottom = size.height
 
         navigationBarFrameObservation = navigationController?.navigationBar.observe(\.frame, options: [.old, .new]) { [unowned self] navigationBar, change in
-            if change.newValue?.width != change.oldValue?.width && self.navigationItem.navigationBarStyle == .custom {
-                self.navigationItem.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: navigationBar.frame.width)
+            if change.newValue?.width != change.oldValue?.width && self.navigationItem.fluentConfiguration.navigationBarStyle == .custom {
+                self.navigationItem.fluentConfiguration.customNavigationBarColor = CustomGradient.getCustomBackgroundColor(width: navigationBar.frame.width)
             }
         }
     }
@@ -582,15 +582,15 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         if showsTopAccessoryView {
             let showTopAccessoryView = view.frame.size.width >= Constants.topAccessoryViewWidthThreshold
 
-            if let accessoryView = navigationItem.accessoryView as? SearchBar, showTopAccessoryView {
+            if let accessoryView = navigationItem.fluentConfiguration.accessoryView as? SearchBar, showTopAccessoryView {
                 accessoryView.hidesNavigationBarDuringSearch = false
-                navigationItem.accessoryView = nil
-                navigationItem.topAccessoryView = accessoryView
-            } else if let accessoryView = navigationItem.topAccessoryView as? SearchBar, !showTopAccessoryView {
+                navigationItem.fluentConfiguration.accessoryView = nil
+                navigationItem.fluentConfiguration.topAccessoryView = accessoryView
+            } else if let accessoryView = navigationItem.fluentConfiguration.topAccessoryView as? SearchBar, !showTopAccessoryView {
                 accessoryView.hidesNavigationBarDuringSearch = true
 
-                navigationItem.topAccessoryView = nil
-                navigationItem.accessoryView = accessoryView
+                navigationItem.fluentConfiguration.topAccessoryView = nil
+                navigationItem.fluentConfiguration.accessoryView = accessoryView
             }
         }
     }
@@ -616,7 +616,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             guard let cell = tableView.dequeueReusableCell(withIdentifier: BooleanCell.identifier, for: indexPath) as? BooleanCell else {
                 return UITableViewCell()
             }
-            let isSwitchEnabled = navigationItem.titleStyle == .largeLeading && msfNavigationController?.msfNavigationBar.personaData != nil
+            let isSwitchEnabled = navigationItem.fluentConfiguration.titleStyle == .largeLeading && msfNavigationController?.msfNavigationBar.personaData != nil
             cell.setup(title: "Show rainbow ring on avatar",
                        isOn: showRainbowRingForAvatar,
                        isSwitchEnabled: isSwitchEnabled)
@@ -633,7 +633,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             }
             cell.setup(title: "Show badge on right bar button items",
                        isOn: showBadgeOnBarButtonItem,
-                       isSwitchEnabled: navigationItem.titleStyle == .largeLeading)
+                       isSwitchEnabled: navigationItem.fluentConfiguration.titleStyle == .largeLeading)
             cell.titleNumberOfLines = 0
             cell.onValueChanged = { [weak self, weak cell] in
                 self?.shouldShowBadge(isOn: cell?.isOn ?? false)
@@ -667,11 +667,11 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
         } else {
             let row = indexPath.row
             let controller = ChildViewController(parentIndex: row)
-            if navigationItem.accessoryView == nil {
-                if navigationItem.navigationBarStyle == .gradient {
-                    controller.navigationItem.navigationBarStyle = .gradient
+            if navigationItem.fluentConfiguration.accessoryView == nil {
+                if navigationItem.fluentConfiguration.navigationBarStyle == .gradient {
+                    controller.navigationItem.fluentConfiguration.navigationBarStyle = .gradient
                 } else {
-                    controller.navigationItem.navigationBarStyle = .system
+                    controller.navigationItem.fluentConfiguration.navigationBarStyle = .system
                 }
             }
             if let feature = titleViewFeaturesByRow[row] {
@@ -696,7 +696,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
             let selectedCount = tableView.indexPathsForSelectedRows?.count ?? 0
             navigationItem.title = selectedCount == 1 ? "1 item selected" : "\(selectedCount) items selected"
         } else {
-            navigationItem.title = navigationItem.titleStyle == .largeLeading ? "Large Title" : "Regular Title"
+            navigationItem.title = navigationItem.fluentConfiguration.titleStyle == .largeLeading ? "Large Title" : "Regular Title"
         }
     }
 
@@ -840,7 +840,7 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 
     func navigationBarDidTapOnTitle(_ sender: NavigationBar) {
         if let topItem = sender.topItem {
-            topItem.navigationBarStyle = topItem.navigationBarStyle == .primary ? .system : .primary
+            topItem.fluentConfiguration.navigationBarStyle = topItem.fluentConfiguration.navigationBarStyle == .primary ? .system : .primary
 #if os(iOS)
             setNeedsStatusBarAppearanceUpdate()
 #endif
@@ -853,9 +853,9 @@ class RootViewController: UIViewController, UITableViewDataSource, UITableViewDe
 extension RootViewController: SearchBarDelegate {
     func searchBarDidBeginEditing(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
-        if navigationItem.secondaryAccessoryView != nil && !showsTopAccessoryView {
-            secondaryAccessoryView = navigationItem.secondaryAccessoryView
-            navigationItem.secondaryAccessoryView = nil
+        if navigationItem.fluentConfiguration.secondaryAccessoryView != nil && !showsTopAccessoryView {
+            secondaryAccessoryView = navigationItem.fluentConfiguration.secondaryAccessoryView
+            navigationItem.fluentConfiguration.secondaryAccessoryView = nil
         }
     }
 
@@ -865,7 +865,7 @@ extension RootViewController: SearchBarDelegate {
     func searchBarDidCancel(_ searchBar: SearchBar) {
         searchBar.progressSpinner.state.isAnimating = false
         if secondaryAccessoryView != nil && !showsTopAccessoryView {
-            navigationItem.secondaryAccessoryView = secondaryAccessoryView
+            navigationItem.fluentConfiguration.secondaryAccessoryView = secondaryAccessoryView
         }
     }
 
@@ -912,11 +912,11 @@ class ChildViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let controller = GrandchildViewController(grandparentIndex: parentIndex, parentIndex: 1 + indexPath.row)
-        if navigationItem.accessoryView == nil {
-            if navigationItem.navigationBarStyle == .gradient {
-                controller.navigationItem.navigationBarStyle = .gradient
+        if navigationItem.fluentConfiguration.accessoryView == nil {
+            if navigationItem.fluentConfiguration.navigationBarStyle == .gradient {
+                controller.navigationItem.fluentConfiguration.navigationBarStyle = .gradient
             } else {
-                controller.navigationItem.navigationBarStyle = .system
+                controller.navigationItem.fluentConfiguration.navigationBarStyle = .system
             }
         }
         navigationController?.pushViewController(controller, animated: true)

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/TwoLineTitleViewDemoController.swift
@@ -71,56 +71,56 @@ class TwoLineTitleViewDemoController: DemoController {
         },
         makeExampleNavigationItem {
             $0.title = "Another title"
-            $0.subtitle = "With a subtitle"
+            $0.fluentConfiguration.subtitle = "With a subtitle"
         },
         makeExampleNavigationItem {
             $0.title = "This one"
-            $0.subtitle = "has an image"
-            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.subtitle = "has an image"
+            $0.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
         },
         makeExampleNavigationItem {
             $0.title = "This one"
-            $0.subtitle = "has a disclosure chevron"
-            $0.titleAccessory = .init(location: .title, style: .disclosure)
+            $0.fluentConfiguration.subtitle = "has a disclosure chevron"
+            $0.fluentConfiguration.titleAccessory = .init(location: .title, style: .disclosure)
         },
         makeExampleNavigationItem {
             $0.title = "They can also be"
-            $0.subtitle = "leading-aligned"
-            $0.titleStyle = .leading
+            $0.fluentConfiguration.subtitle = "leading-aligned"
+            $0.fluentConfiguration.titleStyle = .leading
         },
         makeExampleNavigationItem {
             $0.title = "Leading Title"
-            $0.titleStyle = .leading
-            $0.subtitle = "Custom icon"
-            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.titleAccessory = .init(location: .subtitle, style: .custom)
+            $0.fluentConfiguration.titleStyle = .leading
+            $0.fluentConfiguration.subtitle = "Custom icon"
+            $0.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.titleAccessory = .init(location: .subtitle, style: .custom)
         },
         makeExampleNavigationItem {
             $0.title = "Centered Title"
-            $0.titleStyle = .system
-            $0.subtitle = "Custom icon"
-            $0.titleImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.titleAccessory = .init(location: .subtitle, style: .custom)
+            $0.fluentConfiguration.titleStyle = .system
+            $0.fluentConfiguration.subtitle = "Custom icon"
+            $0.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.titleAccessory = .init(location: .subtitle, style: .custom)
         },
         makeExampleNavigationItem {
             $0.title = "Centered Title"
-            $0.titleStyle = .system
-            $0.subtitle = "Custom icon"
-            $0.titleImage = UIImage(named: "ic_fluent_star_24_regular")
-            $0.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.titleAccessory = .init(location: .subtitle, style: .custom)
-            $0.isTitleImageLeadingForTitleAndSubtitle = true
+            $0.fluentConfiguration.titleStyle = .system
+            $0.fluentConfiguration.subtitle = "Custom icon"
+            $0.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_24_regular")
+            $0.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.titleAccessory = .init(location: .subtitle, style: .custom)
+            $0.fluentConfiguration.isTitleImageLeadingForTitleAndSubtitle = true
         },
         makeExampleNavigationItem {
             $0.title = "Leading Title"
-            $0.titleStyle = .leading
-            $0.subtitle = "Subtitle"
-            $0.titleImage = UIImage(named: "ic_fluent_star_24_regular")
-            $0.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
-            $0.titleAccessory = .init(location: .title, style: .downArrow)
-            $0.isTitleImageLeadingForTitleAndSubtitle = true
+            $0.fluentConfiguration.titleStyle = .leading
+            $0.fluentConfiguration.subtitle = "Subtitle"
+            $0.fluentConfiguration.titleImage = UIImage(named: "ic_fluent_star_24_regular")
+            $0.fluentConfiguration.customSubtitleTrailingImage = UIImage(named: "ic_fluent_star_16_regular")
+            $0.fluentConfiguration.titleAccessory = .init(location: .title, style: .downArrow)
+            $0.fluentConfiguration.isTitleImageLeadingForTitleAndSubtitle = true
         }
     ]
 

--- a/Sources/FluentUI_iOS/Components/Navigation/NavigationController.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/NavigationController.swift
@@ -136,7 +136,7 @@ open class NavigationController: UINavigationController {
         if viewController is ShyHeaderController {
             return false
         }
-        if viewController.navigationItem.titleStyle == .largeLeading || viewController.navigationItem.accessoryView != nil {
+        if viewController.navigationItem.fluentConfiguration.titleStyle == .largeLeading || viewController.navigationItem.fluentConfiguration.accessoryView != nil {
             return true
         }
         return false

--- a/Sources/FluentUI_iOS/Components/Navigation/SearchBar/SearchBar.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/SearchBar/SearchBar.swift
@@ -607,7 +607,7 @@ extension SearchBar: UITextFieldDelegate {
 // MARK: - UINavigationItem extension
 
 extension UINavigationItem {
-    var accessorySearchBar: SearchBar? { return accessoryView as? SearchBar }
+    var accessorySearchBar: SearchBar? { return fluentConfiguration.accessoryView as? SearchBar }
 }
 
 // MARK: - SearchBarTextField

--- a/Sources/FluentUI_iOS/Components/Navigation/Shy Header/ShyHeaderController.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/Shy Header/ShyHeaderController.swift
@@ -87,7 +87,7 @@ class ShyHeaderController: UIViewController {
         contentViewController.didMove(toParent: self)
         contentViewController.view.fitIntoSuperview(usingConstraints: true)
 
-        contentScrollViewObservation = contentViewController.navigationItem.observe(\.contentScrollView, options: [.new]) { [weak self] (_, change) in
+        contentScrollViewObservation = contentViewController.navigationItem.observe(\.fluentConfiguration.contentScrollView, options: [.new]) { [weak self] (_, change) in
             guard let strongSelf = self else {
                 return
             }
@@ -99,15 +99,15 @@ class ShyHeaderController: UIViewController {
             }
         }
         defer {
-            contentScrollView = contentViewController.navigationItem.contentScrollView
+            contentScrollView = contentViewController.navigationItem.fluentConfiguration.contentScrollView
         }
 
-        accessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.accessoryView) { [weak self] item, _ in
-            self?.shyHeaderView.accessoryView = item.accessoryView
+        accessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.fluentConfiguration.accessoryView) { [weak self] item, _ in
+            self?.shyHeaderView.accessoryView = item.fluentConfiguration.accessoryView
         }
 
-        secondaryAccessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.secondaryAccessoryView) { [weak self] item, _ in
-            self?.shyHeaderView.secondaryAccessoryView = item.secondaryAccessoryView
+        secondaryAccessoryViewObservation = contentViewController.navigationItem.observe(\UINavigationItem.fluentConfiguration.secondaryAccessoryView) { [weak self] item, _ in
+            self?.shyHeaderView.secondaryAccessoryView = item.fluentConfiguration.secondaryAccessoryView
         }
     }
 
@@ -220,9 +220,9 @@ class ShyHeaderController: UIViewController {
 
     private func setupShyHeaderView() {
         let navigationItem = contentViewController.navigationItem
-        shyHeaderView.accessoryView = navigationItem.accessoryView
-        shyHeaderView.secondaryAccessoryView = navigationItem.secondaryAccessoryView
-        shyHeaderView.navigationBarShadow = navigationItem.navigationBarShadow
+        shyHeaderView.accessoryView = navigationItem.fluentConfiguration.accessoryView
+        shyHeaderView.secondaryAccessoryView = navigationItem.fluentConfiguration.secondaryAccessoryView
+        shyHeaderView.navigationBarShadow = navigationItem.fluentConfiguration.navigationBarShadow
         shyHeaderView.paddingView = paddingView
         shyHeaderView.parentController = self
         shyHeaderView.maxHeightChanged = { [weak self] in
@@ -281,12 +281,12 @@ class ShyHeaderController: UIViewController {
     }
 
     private func updateBackgroundColor(with item: UINavigationItem) {
-        let color = item.navigationBarColor(fluentTheme: containingView?.fluentTheme ?? view.fluentTheme)
+        let color = item.fluentConfiguration.navigationBarColor(fluentTheme: containingView?.fluentTheme ?? view.fluentTheme)
         shyHeaderView.backgroundColor = color
         view.backgroundColor = color
         paddingView.backgroundColor = color
 
-        navigationBarColorObservation = item.observe(\.customNavigationBarColor) { [weak self] item, _ in
+        navigationBarColorObservation = item.observe(\.fluentConfiguration.customNavigationBarColor) { [weak self] item, _ in
             self?.updateBackgroundColor(with: item)
         }
     }

--- a/Sources/FluentUI_iOS/Components/Navigation/Shy Header/ShyHeaderView.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/Shy Header/ShyHeaderView.swift
@@ -217,7 +217,7 @@ class ShyHeaderView: UIView, TokenizedControl {
         guard let parentController = parentController, let (_, actualItem) = parentController.msfNavigationController?.msfNavigationBar.actualStyleAndItem(for: parentController.navigationItem) else {
             return
         }
-        let color = actualItem.navigationBarColor(fluentTheme: tokenSet.fluentTheme)
+        let color = actualItem.fluentConfiguration.navigationBarColor(fluentTheme: tokenSet.fluentTheme)
         backgroundColor = color
         paddingView?.backgroundColor = color
     }

--- a/Sources/FluentUI_iOS/Components/Navigation/TwoLineTitleView+Navigation.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/TwoLineTitleView+Navigation.swift
@@ -47,12 +47,12 @@ fileprivate extension NavigationBarTitleAccessory.Style {
 extension TwoLineTitleView {
     @objc open func setup(navigationItem: UINavigationItem) {
         let title = navigationItem.title ?? ""
-        let alignment: Alignment = navigationItem.titleStyle == .system ? .center : .leading
+        let alignment: Alignment = navigationItem.fluentConfiguration.titleStyle == .system ? .center : .leading
 
         let interactivePart: InteractivePart
         let accessoryType: AccessoryType
         let animatesWhenPressed: Bool
-        if let titleAccessory = navigationItem.titleAccessory {
+        if let titleAccessory = navigationItem.fluentConfiguration.titleAccessory {
             // Use the custom action provided by the title accessory specification
             interactivePart = titleAccessory.location.twoLineTitleViewInteractivePart
             accessoryType = titleAccessory.style.twoLineTitleViewAccessoryType
@@ -65,6 +65,25 @@ extension TwoLineTitleView {
             animatesWhenPressed = false
         }
 
-        setup(title: title, titleImage: navigationItem.titleImage, subtitle: navigationItem.subtitle, alignment: alignment, interactivePart: interactivePart, animatesWhenPressed: animatesWhenPressed, accessoryType: accessoryType, customSubtitleTrailingImage: navigationItem.customSubtitleTrailingImage, isTitleImageLeadingForTitleAndSubtitle: navigationItem.isTitleImageLeadingForTitleAndSubtitle)
+        var subtitle: String?
+#if compiler(>=6.2)
+        // Prefer the UINavigationItem `.subtitle` property over the one on fluentConfiguration.
+        if #available(iOS 26, visionOS 26, macCatalyst 26, *) {
+            subtitle = navigationItem.subtitle
+        }
+#endif // compiler(>=6.2)
+        if subtitle == nil {
+            subtitle = navigationItem.fluentConfiguration.subtitle
+        }
+
+        setup(title: title,
+              titleImage: navigationItem.fluentConfiguration.titleImage,
+              subtitle: navigationItem.fluentConfiguration.subtitle,
+              alignment: alignment,
+              interactivePart: interactivePart,
+              animatesWhenPressed: animatesWhenPressed,
+              accessoryType: accessoryType,
+              customSubtitleTrailingImage: navigationItem.fluentConfiguration.customSubtitleTrailingImage,
+              isTitleImageLeadingForTitleAndSubtitle: navigationItem.fluentConfiguration.isTitleImageLeadingForTitleAndSubtitle)
     }
 }

--- a/Sources/FluentUI_iOS/Components/Navigation/UINavigationItem+Navigation.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/UINavigationItem+Navigation.swift
@@ -8,154 +8,49 @@ import FluentUI_common
 #endif
 import UIKit
 
-@objc public extension UINavigationItem {
-    private struct AssociatedKeys {
-        static var accessoryView: UInt8 = 0
-        static var secondaryAccessoryView: UInt8 = 0
-        static var titleAccessory: UInt8 = 0
-        static var titleImage: UInt8 = 0
-        static var topAccessoryView: UInt8 = 0
-        static var topAccessoryViewAttributes: UInt8 = 0
-        static var contentScrollView: UInt8 = 0
-        static var navigationBarStyle: UInt8 = 0
-        static var navigationBarShadow: UInt8 = 0
-        static var subtitle: UInt8 = 0
-        static var titleStyle: UInt8 = 0
-        static var customNavigationBarColor: UInt8 = 0
-        static var customSubtitleTrailingImage: UInt8 = 0
-        static var isTitleImageLeadingForTitleAndSubtitle: UInt8 = 0
-    }
-
-    var accessoryView: UIView? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.accessoryView) as? UIView
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.accessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-
+/// An object used to store configuration information used by FluentUI when styling a `UINavigationItem`.
+@objc(MSFFluentNavigationItemConfiguration)
+@objcMembers public class FluentNavigationItemConfiguration: NSObject {
+    public dynamic var accessoryView: UIView?
     /// An wide accessory view that can be shown as a subview of ShyHeaderView but doesn't have leading, trailing
     /// and bottom insets. So it can appear as being part of the content view but still contract and expand as part of
     /// the shy header.
-    var secondaryAccessoryView: UIView? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.secondaryAccessoryView) as? UIView
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.secondaryAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var secondaryAccessoryView: UIView?
 
     /// Defines an accessory shown after the title or subtitle in a navigation bar. When defined, this gives the indication that the title can be tapped to show additional information.
-    var titleAccessory: NavigationBarTitleAccessory? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.titleAccessory) as? NavigationBarTitleAccessory
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.titleAccessory, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var titleAccessory: NavigationBarTitleAccessory?
 
     /// An optional image to show in a navigation bar before the title. Ignored when `titleStyle == .largeLeading`.
-    var titleImage: UIImage? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.titleImage) as? UIImage
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.titleImage, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var titleImage: UIImage?
 
-    var topAccessoryView: UIView? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.topAccessoryView) as? UIView
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.topAccessoryView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var topAccessoryView: UIView?
 
-    var topAccessoryViewAttributes: NavigationBarTopAccessoryViewAttributes? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.topAccessoryViewAttributes) as? NavigationBarTopAccessoryViewAttributes
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.topAccessoryViewAttributes, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var topAccessoryViewAttributes: NavigationBarTopAccessoryViewAttributes?
 
-    var contentScrollView: UIScrollView? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.contentScrollView) as? UIScrollView
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.contentScrollView, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var contentScrollView: UIScrollView?
 
     /// The style to apply to a navigation bar as a whole. Defaults to `.default` if not specified.
-    var navigationBarStyle: NavigationBar.Style {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.navigationBarStyle) as? NavigationBar.Style ?? .default
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.navigationBarStyle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var navigationBarStyle: NavigationBar.Style = .default
 
-    var navigationBarShadow: NavigationBar.Shadow {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.navigationBarShadow) as? NavigationBar.Shadow ?? .automatic
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.navigationBarShadow, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var navigationBarShadow: NavigationBar.Shadow = .automatic
 
     /// An optional image to show on the trailing end of the navigation bar's subtitle.
-    var customSubtitleTrailingImage: UIImage? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.customSubtitleTrailingImage) as? UIImage
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.customSubtitleTrailingImage, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var customSubtitleTrailingImage: UIImage?
 
     /// The navigation item's subtitle that displays in the navigation bar.
-    @available(iOS, obsoleted: 26.0)
-    var subtitle: String? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.subtitle) as? String
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.subtitle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    @available(iOS, deprecated: 26.0, message: "Use the subtitle property on UINavigationItem directly.")
+    @available(visionOS, deprecated: 26.0, message: "Use the subtitle property on UINavigationItem directly.")
+    @available(macCatalyst, deprecated: 26.0, message: "Use the subtitle property on UINavigationItem directly.")
+    public dynamic var subtitle: String?
 
     /// The style in which the title text is displayed in a navigation bar. Defaults to `.system` if not specified.
-    var titleStyle: NavigationBar.TitleStyle {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.titleStyle) as? NavigationBar.TitleStyle ?? .system
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.titleStyle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var titleStyle: NavigationBar.TitleStyle = .system
 
     /// Determines whether the provided `titleImage` is used on the leading end of both the title and subtitle of the navigation bar.
-    var isTitleImageLeadingForTitleAndSubtitle: Bool {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.isTitleImageLeadingForTitleAndSubtitle) as? Bool ?? false
-        }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.isTitleImageLeadingForTitleAndSubtitle, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
+    public dynamic var isTitleImageLeadingForTitleAndSubtitle: Bool = false
 
     @available(*, deprecated, message: "Use `titleStyle` instead")
-    var usesLargeTitle: Bool {
+    public dynamic var usesLargeTitle: Bool {
         get {
             return titleStyle.usesLeadingAlignment
         }
@@ -164,7 +59,7 @@ import UIKit
         }
     }
 
-    func navigationBarColor(fluentTheme: FluentTheme) -> UIColor {
+    public func navigationBarColor(fluentTheme: FluentTheme) -> UIColor {
         if let customNavigationBarColor = customNavigationBarColor, navigationBarStyle == .custom {
             return customNavigationBarColor
         }
@@ -175,12 +70,22 @@ import UIKit
         return tokenSet[.backgroundColor].uiColor
     }
 
-    var customNavigationBarColor: UIColor? {
-        get {
-            return objc_getAssociatedObject(self, &AssociatedKeys.customNavigationBarColor) as? UIColor
+    public dynamic var customNavigationBarColor: UIColor?
+}
+
+@objc extension UINavigationItem {
+    /// The object used to store configuration information used by FluentUI when styling this `UINavigationItem`.
+    public dynamic var fluentConfiguration: FluentNavigationItemConfiguration {
+        var configuration = objc_getAssociatedObject(self, &Self.fluentNavigationItemKey) as? FluentNavigationItemConfiguration
+        if configuration == nil {
+            configuration = FluentNavigationItemConfiguration()
+            objc_setAssociatedObject(self, &Self.fluentNavigationItemKey, configuration, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
-        set {
-            objc_setAssociatedObject(self, &AssociatedKeys.customNavigationBarColor, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        guard let configuration else {
+            preconditionFailure("Unable to allocate FluentNavigationItem")
         }
+        return configuration
     }
+
+    private static var fluentNavigationItemKey: UInt8 = 0
 }

--- a/Sources/FluentUI_iOS/Components/Navigation/Views/AvatarTitleView.swift
+++ b/Sources/FluentUI_iOS/Components/Navigation/Views/AvatarTitleView.swift
@@ -332,17 +332,17 @@ class AvatarTitleView: UIView, TokenizedControl, TwoLineTitleViewDelegate {
     func update(with navigationItem: UINavigationItem) {
         hasLeftBarButtonItems = !(navigationItem.leftBarButtonItems?.isEmpty ?? true)
         titleButton.setTitle(navigationItem.title, for: .normal)
-        titleStyle = navigationItem.titleStyle
+        titleStyle = navigationItem.fluentConfiguration.titleStyle
         twoLineTitleView.setup(navigationItem: navigationItem)
 
         // Hide the avatar if TwoLineTitleView has a leading image for both title and subtitle.
-        if navigationItem.isTitleImageLeadingForTitleAndSubtitle {
+        if navigationItem.fluentConfiguration.isTitleImageLeadingForTitleAndSubtitle {
             showsProfileButton = false
         } else {
             updateProfileButtonVisibility()
         }
 
-        if navigationItem.titleAccessory == nil {
+        if navigationItem.fluentConfiguration.titleAccessory == nil {
             // Use default behavior of requesting an accessory expansion
             twoLineTitleView.delegate = self
         }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

Second pass at addressing #2177. In order to avoid potential conflicts and confusion, this breaking change removes all extended UINavigationItem properties and places them onto a single configuration object, the `FluentNavigationItemConfiguration` class. This removes the conflict with `subtitle`.

However, now that we know this new property is coming, this change also builds fallbacks to handle the existence of `UINavigationItem.subtitle`, and to prefer it to the existing Fluent value. This is done with a few changes:
* Marking `subtitle` deprecated on iOS/visionOS/macCatalyst 26+
* Adding observers for the new property when using a compiler version >=6.2 (which ships with the new iOS SDK)
* Configuring the navigation item using the appropriate property based on compiler version, preferring the system API over our own if possible.

### Verification

Confirmed expected behavior across iOS 18 and 26, using both Xcode 16.4 and 26.0b1.

<details>
<summary>Visual Verification</summary>

| iOS 17 | iOS 18 | iOS 26 | iOS 18 with iOS 26 SDK |
|---|---|---|---|
| ![iOS17](https://github.com/user-attachments/assets/15a4934e-ad8a-4805-9852-45da4f5bb447) | ![iOS18](https://github.com/user-attachments/assets/0fdb8844-a614-4dde-955b-9bed79d368b3) | ![iOS26](https://github.com/user-attachments/assets/567ee541-743b-42fb-be28-0d5b4e026063) | ![iOS18with26SDK](https://github.com/user-attachments/assets/3832cdd2-0791-4fa4-8372-cfcd4de343c9) |


</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2179)