### PR TITLE
[cherry-pick] Remove -warnings-as-errors in SPM package (#2181)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,10 @@ let macOSPlatforms: [Platform] = [.macOS]
 
 let swiftSettings: [SwiftSetting] = [
     .unsafeFlags([
-        "-warnings-as-errors"
+        // Per https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810
+        // Having this flag enabled in a sub-package causes conflicts with the
+        // automatic "-suppress-warnings" flag added by Xcode.
+        //"-warnings-as-errors"
     ])
 ]
 


### PR DESCRIPTION
Cherry-pick of #2181. Notes below:

### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

Per https://forums.swift.org/t/warnings-as-errors-in-sub-packages/70810: Having this flag enabled in a sub-package causes conflicts with the automatic "-suppress-warnings" flag added by Xcode.

### Verification

Builds and runs still, including as sub-package

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2181)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2182)