### PR TITLE
[cherry-pick][main_0.34] Fix Mac Catalyst build (#2184)

### DIFF
--- a/Sources/FluentUI_common/Core/Extensions/NSColor+Extensions.swift
+++ b/Sources/FluentUI_common/Core/Extensions/NSColor+Extensions.swift
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 
 extension NSColor {

--- a/Sources/FluentUI_iOS/Core/Extensions/UIFont+Extensions.swift
+++ b/Sources/FluentUI_iOS/Core/Extensions/UIFont+Extensions.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import UIKit
 
 public extension Font {
-    static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> Font {
+    static func fluent(_ fontInfo: FluentFontInfo, shouldScale: Bool = true) -> Font {
         // SwiftUI Font is missing some of the ease of construction available in UIFont.
         // So just leverage the logic there to create the equivalent SwiftUI font.
         let uiFont = UIFont.fluent(fontInfo, shouldScale: shouldScale)
@@ -19,11 +19,11 @@ public extension Font {
 }
 
 extension UIFont {
-    @objc public static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true) -> UIFont {
+    @objc public static func fluent(_ fontInfo: FluentFontInfo, shouldScale: Bool = true) -> UIFont {
         return fluent(fontInfo, shouldScale: shouldScale, contentSizeCategory: nil)
     }
 
-    @objc public static func fluent(_ fontInfo: FontInfo, shouldScale: Bool = true, contentSizeCategory: UIContentSizeCategory?) -> UIFont {
+    @objc public static func fluent(_ fontInfo: FluentFontInfo, shouldScale: Bool = true, contentSizeCategory: UIContentSizeCategory?) -> UIFont {
         let traitCollection: UITraitCollection?
         if let contentSizeCategory = contentSizeCategory {
             traitCollection = .init(preferredContentSizeCategory: contentSizeCategory)

--- a/Sources/FluentUI_iOS/Core/Theme/FluentTheme+iOS.swift
+++ b/Sources/FluentUI_iOS/Core/Theme/FluentTheme+iOS.swift
@@ -315,7 +315,7 @@ extension FluentTheme: PlatformThemeProviding {
     /// - Parameters:
     ///   - token: The `TypographyToken` whose font should be provided.
     /// - Returns: The font value for this token.
-    public static func platformTypographyValue(_ token: FluentTheme.TypographyToken) -> FontInfo {
+    public static func platformTypographyValue(_ token: FluentTheme.TypographyToken) -> FluentFontInfo {
         switch token {
         case .display:
             return .init(size: GlobalTokens.fontSize(.size900),


### PR DESCRIPTION
Cherry-pick of 61269898101f21cdf992f67bd0cad9adb06a851c into `main_0.34`

Original notes follow:

### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

After some of the changes in the `0.34.0` release to move `FluentTheme` into the common layer, it's no longer possible to build `FluentUI` for Mac Catalyst. The changes are relatively simple to get things building again.

**Add a target environment check to `NSColor+Extensions`**
- Simply checking if we can import AppKit is not sufficient since the framework can be imported, but `NSColor` is unavailable on Catalyst.

**Use `FluentFontInfo` type alias**
- Since Catalyst has access to `ApplicationServices.FontInfo`, the reference to `FontInfo` in the iOS target is ambiguous. Using the type alias resolves this ambiguity.

### Binary change

N/A, should have no impact on iOS binary size.

### Verification

Swift package for `FluentUI` was built for iOS, visionOS, macOS, and macOS (Catalyst). I confirmed that the package builds properly for all supported platforms listed in the package definition.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2184)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2185)