### PR TITLE
Handle resizing handle taps for partial state

### DIFF
--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -728,18 +728,38 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     }
 
     @objc private func handleResizingHandleViewTap(_ sender: UITapGestureRecognizer) {
-        move(to: isExpanded ? .collapsed : .expanded, interaction: .resizingHandleTap)
+        guard let nextState = nextExpansionStateForResizingHandleTap(with: currentExpansionState) else {
+            return
+        }
+        move(to: nextState, interaction: .resizingHandleTap)
     }
 
     private func updateResizingHandleViewAccessibility(for state: BottomSheetExpansionState) {
-        if state == .expanded {
+        guard let nextState = nextExpansionStateForResizingHandleTap(with: state) else {
+            return
+        }
+
+        if nextState == .collapsed {
             resizingHandleView.accessibilityLabel = handleCollapseCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.CollapseSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Collapse".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Expanded".localized
-        } else if state == .collapsed || state == .partial {
+        } else {
             resizingHandleView.accessibilityLabel = handleExpandCustomAccessibilityLabel ?? "Accessibility.BottomSheet.ResizingHandle.Label.ExpandSheet".localized
             resizingHandleView.accessibilityHint = "Accessibility.Drawer.ResizingHandle.Hint.Expand".localized
             resizingHandleView.accessibilityValue = "Accessibility.Drawer.ResizingHandle.Value.Collapsed".localized
+        }
+    }
+
+    private func nextExpansionStateForResizingHandleTap(with currentExpansionState: BottomSheetExpansionState) -> BottomSheetExpansionState? {
+        return switch currentExpansionState {
+        case .collapsed:
+            supportsPartialExpansion ? .partial : .expanded
+        case .partial:
+            .expanded
+        case .expanded:
+            .collapsed
+        default:
+            nil
         }
     }
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Currently a11y users have no way to reach the partially expanded state using the resizing handle taps. Let's make sure we cycle through all of them. The behavior is analogous to system sheets.

I factored out the next state determination to avoid duplicating logic between the tap handler and `updateResizingHandleViewAccessibility`.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Manual testing in demo app + a11y inspector.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2190)