### PR TITLE
[ListItem] Add support for detailed content, address accessibility issue

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -180,8 +180,10 @@ struct ListItemDemoView: View {
                                                 }
                                             }
                                         }
-                                    },
-                                    action: !isTappable ? nil : {
+                                    }, detailedContent: {
+                                        Text("More Actions")
+                                            .frame(width: 200, height: 200)
+                                    }, action: !isTappable ? nil : {
                                         showingPrimaryAlert = true
                                     })
                 .backgroundStyleType(backgroundStyle)
@@ -191,9 +193,6 @@ struct ListItemDemoView: View {
                 .subtitleLineLimit(subtitleLineLimit)
                 .footerLineLimit(footerLineLimit)
                 .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-                .onAccessoryTapped {
-                    showingSecondaryAlert = true
-                }
             listItem
                 .overrideTokens($overrideTokens.wrappedValue ? listItemTokenOverrides : [:])
                 .disabled(isDisabled)

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -20,7 +20,7 @@ public struct ListItem<LeadingContent: View,
                        Title: StringProtocol,
                        Subtitle: StringProtocol,
                        Footer: StringProtocol,
-                       DetailButtonContent: View>: View {
+                       DetailedContent: View>: View {
 
     // MARK: Initializer
 
@@ -31,21 +31,21 @@ public struct ListItem<LeadingContent: View,
     ///   - footer: Text that appears as the third line of text
     ///   - leadingContent: The content that appears on the leading edge of the view
     ///   - trailingContent: The content that appears on the trailing edge of the view, next to the accessory type if provided
-    ///   - detailButtonContent: The content that appears in a sheet when the accessory detail button is tapped
+    ///   - detailedContent: The content that appears in a sheet when the accessory detail button is tapped
     ///   - action: The action to be dispatched by tapping on the `ListItem`
     public init(title: Title,
                 subtitle: Subtitle = String(),
                 footer: Footer = String(),
                 @ViewBuilder leadingContent: @escaping () -> LeadingContent,
                 @ViewBuilder trailingContent: @escaping () -> TrailingContent,
-                @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
+                @ViewBuilder detailedContent: @escaping () -> DetailedContent,
                 action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.leadingContent = leadingContent
         self.trailingContent = trailingContent
-        self.detailButtonContent = detailButtonContent
+        self.detailedContent = detailedContent
         self.action = action
     }
 
@@ -131,8 +131,8 @@ public struct ListItem<LeadingContent: View,
                                 onAccessoryTapped()
                             }
 
-                            if detailButtonContent != nil {
-                                showingDetailButtonContent = true
+                            if detailedContent != nil {
+                                showingDetailedContent = true
                             }
                         } label: {
                             image
@@ -146,9 +146,9 @@ public struct ListItem<LeadingContent: View,
                         .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
                         .accessibility(label: Text("Accessibility.TableViewCell.MoreActions.Label".localized))
                         .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
-                        .popover(isPresented: $showingDetailButtonContent, content: {
-                            if let detailButtonContent {
-                                detailButtonContent()
+                        .popover(isPresented: $showingDetailedContent, content: {
+                            if let detailedContent {
+                                detailedContent()
                             }
                         })
                     } else {
@@ -343,11 +343,11 @@ public struct ListItem<LeadingContent: View,
     @Environment(\.listStyle) private var listStyle: FluentListStyle
 
     /// If a popover with the content for the detail button is currently being displayed
-    @State private var showingDetailButtonContent: Bool = false
+    @State private var showingDetailedContent: Bool = false
 
     private var leadingContent: (() -> LeadingContent)?
     private var trailingContent: (() -> TrailingContent)?
-    private var detailButtonContent: (() -> DetailButtonContent)?
+    private var detailedContent: (() -> DetailedContent)?
     private var action: (() -> Void)?
 
     private let footer: Footer
@@ -396,7 +396,7 @@ private struct AccessibilityIdentifiers {
 
 // MARK: Additional Initializers
 
-public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, DetailButtonContent == EmptyView {
+public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, DetailedContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
@@ -412,17 +412,17 @@ public extension ListItem where LeadingContent == EmptyView, TrailingContent == 
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
-         @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
+         @ViewBuilder detailedContent: @escaping () -> DetailedContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
-        self.detailButtonContent = detailButtonContent
+        self.detailedContent = detailedContent
         self.action = action
     }
 }
 
-public extension ListItem where LeadingContent == EmptyView, DetailButtonContent == EmptyView {
+public extension ListItem where LeadingContent == EmptyView, DetailedContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
@@ -436,7 +436,7 @@ public extension ListItem where LeadingContent == EmptyView, DetailButtonContent
     }
 }
 
-public extension ListItem where TrailingContent == EmptyView, DetailButtonContent == EmptyView {
+public extension ListItem where TrailingContent == EmptyView, DetailedContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
@@ -455,13 +455,13 @@ public extension ListItem where TrailingContent == EmptyView {
          subtitle: Subtitle = String(),
          footer: Footer = String(),
          @ViewBuilder leadingContent: @escaping () -> LeadingContent,
-         @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
+         @ViewBuilder detailedContent: @escaping () -> DetailedContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.leadingContent = leadingContent
-        self.detailButtonContent = detailButtonContent
+        self.detailedContent = detailedContent
         self.action = action
     }
 }
@@ -471,18 +471,18 @@ public extension ListItem where LeadingContent == EmptyView {
          subtitle: Subtitle = String(),
          footer: Footer = String(),
          @ViewBuilder trailingContent: @escaping () -> TrailingContent,
-         @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
+         @ViewBuilder detailedContent: @escaping () -> DetailedContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.trailingContent = trailingContent
-        self.detailButtonContent = detailButtonContent
+        self.detailedContent = detailedContent
         self.action = action
     }
 }
 
-public extension ListItem where DetailButtonContent == EmptyView {
+public extension ListItem where DetailedContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
@@ -498,7 +498,7 @@ public extension ListItem where DetailButtonContent == EmptyView {
 }
 
 /// Provide defaults for generic types so static methods can be called without needing to specify them.
-public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, DetailButtonContent == EmptyView, Title == String, Subtitle == String, Footer == String {
+public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, DetailedContent == EmptyView, Title == String, Subtitle == String, Footer == String {
 
     /// The background color of `List` based on the style.
     /// - Parameter backgroundStyle: The background style of the `List`.

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -19,7 +19,8 @@ public struct ListItem<LeadingContent: View,
                        TrailingContent: View,
                        Title: StringProtocol,
                        Subtitle: StringProtocol,
-                       Footer: StringProtocol>: View {
+                       Footer: StringProtocol,
+                       DetailButtonContent: View>: View {
 
     // MARK: Initializer
 
@@ -30,18 +31,21 @@ public struct ListItem<LeadingContent: View,
     ///   - footer: Text that appears as the third line of text
     ///   - leadingContent: The content that appears on the leading edge of the view
     ///   - trailingContent: The content that appears on the trailing edge of the view, next to the accessory type if provided
+    ///   - detailButtonContent: The content that appears in a sheet when the accessory detail button is tapped
     ///   - action: The action to be dispatched by tapping on the `ListItem`
     public init(title: Title,
                 subtitle: Subtitle = String(),
                 footer: Footer = String(),
                 @ViewBuilder leadingContent: @escaping () -> LeadingContent,
                 @ViewBuilder trailingContent: @escaping () -> TrailingContent,
+                @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
                 action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
         self.leadingContent = leadingContent
         self.trailingContent = trailingContent
+        self.detailButtonContent = detailButtonContent
         self.action = action
     }
 
@@ -126,6 +130,10 @@ public struct ListItem<LeadingContent: View,
                             if let onAccessoryTapped = onAccessoryTapped {
                                 onAccessoryTapped()
                             }
+
+                            if detailButtonContent != nil {
+                                showingDetailButtonContent = true
+                            }
                         } label: {
                             image
                         }
@@ -138,6 +146,11 @@ public struct ListItem<LeadingContent: View,
                         .accessibilityIdentifier(AccessibilityIdentifiers.accessoryDetailButton)
                         .accessibility(label: Text("Accessibility.TableViewCell.MoreActions.Label".localized))
                         .accessibility(hint: Text("Accessibility.TableViewCell.MoreActions.Hint".localized))
+                        .popover(isPresented: $showingDetailButtonContent, content: {
+                            if let detailButtonContent {
+                                detailButtonContent()
+                            }
+                        })
                     } else {
                         image
                             .accessibilityHidden(true)
@@ -212,6 +225,7 @@ public struct ListItem<LeadingContent: View,
                 if let action = action {
                     SwiftUI.Button(action: action, label: {
                         innerContent
+                            .accessibilityElement(children: .combine)
                     })
                     .buttonStyle(ListItemButtonStyle(backgroundStyleType: backgroundStyleType, tokenSet: tokenSet))
                 } else {
@@ -328,8 +342,12 @@ public struct ListItem<LeadingContent: View,
     /// The style of the parent `FluentList`.
     @Environment(\.listStyle) private var listStyle: FluentListStyle
 
+    /// If a popover with the content for the detail button is currently being displayed
+    @State private var showingDetailButtonContent: Bool = false
+
     private var leadingContent: (() -> LeadingContent)?
     private var trailingContent: (() -> TrailingContent)?
+    private var detailButtonContent: (() -> DetailButtonContent)?
     private var action: (() -> Void)?
 
     private let footer: Footer
@@ -378,33 +396,33 @@ private struct AccessibilityIdentifiers {
 
 // MARK: Additional Initializers
 
+public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, DetailButtonContent == EmptyView {
+    init(title: Title,
+         subtitle: Subtitle = String(),
+         footer: Footer = String(),
+         action: (() -> Void)? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.footer = footer
+        self.action = action
+    }
+}
+
 public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.detailButtonContent = detailButtonContent
         self.action = action
     }
 }
 
-public extension ListItem where TrailingContent == EmptyView {
-    init(title: Title,
-         subtitle: Subtitle = String(),
-         footer: Footer = String(),
-         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
-         action: (() -> Void)? = nil) {
-        self.title = title
-        self.subtitle = subtitle
-        self.footer = footer
-        self.leadingContent = leadingContent
-        self.action = action
-    }
-}
-
-public extension ListItem where LeadingContent == EmptyView {
+public extension ListItem where LeadingContent == EmptyView, DetailButtonContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
@@ -418,8 +436,69 @@ public extension ListItem where LeadingContent == EmptyView {
     }
 }
 
+public extension ListItem where TrailingContent == EmptyView, DetailButtonContent == EmptyView {
+    init(title: Title,
+         subtitle: Subtitle = String(),
+         footer: Footer = String(),
+         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
+         action: (() -> Void)? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.footer = footer
+        self.leadingContent = leadingContent
+        self.action = action
+    }
+}
+
+public extension ListItem where TrailingContent == EmptyView {
+    init(title: Title,
+         subtitle: Subtitle = String(),
+         footer: Footer = String(),
+         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
+         @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
+         action: (() -> Void)? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.footer = footer
+        self.leadingContent = leadingContent
+        self.detailButtonContent = detailButtonContent
+        self.action = action
+    }
+}
+
+public extension ListItem where LeadingContent == EmptyView {
+    init(title: Title,
+         subtitle: Subtitle = String(),
+         footer: Footer = String(),
+         @ViewBuilder trailingContent: @escaping () -> TrailingContent,
+         @ViewBuilder detailButtonContent: @escaping () -> DetailButtonContent,
+         action: (() -> Void)? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.footer = footer
+        self.trailingContent = trailingContent
+        self.detailButtonContent = detailButtonContent
+        self.action = action
+    }
+}
+
+public extension ListItem where DetailButtonContent == EmptyView {
+    init(title: Title,
+         subtitle: Subtitle = String(),
+         footer: Footer = String(),
+         @ViewBuilder leadingContent: @escaping () -> LeadingContent,
+         @ViewBuilder trailingContent: @escaping () -> TrailingContent,
+         action: (() -> Void)? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.footer = footer
+        self.trailingContent = trailingContent
+        self.action = action
+    }
+}
+
 /// Provide defaults for generic types so static methods can be called without needing to specify them.
-public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, Title == String, Subtitle == String, Footer == String {
+public extension ListItem where LeadingContent == EmptyView, TrailingContent == EmptyView, DetailButtonContent == EmptyView, Title == String, Subtitle == String, Footer == String {
 
     /// The background color of `List` based on the style.
     /// - Parameter backgroundStyle: The background style of the `List`.


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

#### Detailed content support
To allow the use of generics for content that is displayed with the detailed button `...` is selected, adding the ability to pass that into the ListItem. The reasoning for this is that we need to correctly display a sheet from the button. To be able to do that we need to know the content to display in the sheet. This requires the client to pass in that view to ListItem. With using generics, we can achieve this to optimize for view layout instead of using `Any View` which would get redrawn more often.


#### Accessibility bug
When the List item is tappable, we aren't correctly grouping the accessibility elements. This makes it so the whole view gets correct focus in VoiceOver/full keyboard access, but provides the action to tap on the List item show up more than once. For example, in full keyboard access, when focused on a list item and pressing `tab + z` it shows a list of the sub actions that can be taken on the list item. Currently, that list of actions also includes the action that occurs when the list item is selected. This should not occur, it should only be sub actions, or in the case of List item, the content in the trailing view that has a tap gesture associated with it, like a button.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

<details>
<summary>Visual Verification</summary>

| Description                                       | Image                                      |
|----------------------------------------------|--------------------------------------------|
| The detailed content showing when it is provided | <img width="1077" height="776" alt="Screenshot 2025-07-18 at 1 26 20 PM" src="https://github.com/user-attachments/assets/527c268f-bff5-4fd7-8e94-eb746aa8894b" /> |
| The list item still gets correct VoiceOver focus | <img width="1143" height="724" alt="Screenshot 2025-07-18 at 1 26 11 PM" src="https://github.com/user-attachments/assets/4fcfa109-3996-4331-8e9a-b19b4f9698f5" /> |
| When `Tab+z` is pressed, only the sub actions are shown as options | <img width="1087" height="718" alt="Screenshot 2025-07-18 at 1 26 04 PM" src="https://github.com/user-attachments/assets/499c0587-1fea-4487-a567-58cf2bf96427" /> |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)