### PR TITLE
Introduce an API to the Fluent Notification that draws attention to the notification

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -245,15 +245,12 @@ class NotificationViewDemoController: DemoController {
             notification.state.message = "Tap the buttons below to test bump animations"
             notification.state.title = "Bump Demo"
             notification.state.image = UIImage(named: "play-in-circle-24x24")
-            notification.state.actionButtonTitle = "Gentle"
+            notification.state.actionButtonTitle = "Bump"
+
             notification.state.actionButtonAction = { [weak notification] in
-                // Gentle bump: low intensity, longer duration
-                notification?.bumpWithIntensity(0.3, duration: 1.0, useDecreasingCurve: true)
+                notification?.bump()
             }
-            notification.state.messageButtonAction = { [weak notification] in
-                // Strong bump: high intensity, shorter duration
-                notification?.bumpWithIntensity(1.0, duration: 0.8, useDecreasingCurve: false)
-            }
+
             return notification
         }
     }

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -25,7 +25,7 @@ class NotificationViewDemoController: DemoController {
         case neutralToastWithOverriddenTokens
         case neutralToastWithGradientBackground
         case warningToastWithFlexibleWidth
-        case bumpDemo // Add this new case
+        case bumpDemo
 
         var displayText: String {
             switch self {

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -25,6 +25,7 @@ class NotificationViewDemoController: DemoController {
         case neutralToastWithOverriddenTokens
         case neutralToastWithGradientBackground
         case warningToastWithFlexibleWidth
+        case bumpDemo // Add this new case
 
         var displayText: String {
             switch self {
@@ -60,6 +61,8 @@ class NotificationViewDemoController: DemoController {
                 return "Neutral Toast With Gradient Background"
             case .warningToastWithFlexibleWidth:
                 return "Warning Toast With Flexible Width"
+            case .bumpDemo:
+                return "Bump Animation Demo"
             }
         }
     }
@@ -235,6 +238,21 @@ class NotificationViewDemoController: DemoController {
             notification.state.actionButtonAction = { [weak self] in
                 self?.showMessage("`Dismiss` tapped")
                 notification.hide()
+            }
+            return notification
+        case .bumpDemo:
+            let notification = MSFNotification(style: .primaryToast)
+            notification.state.message = "Tap the buttons below to test bump animations"
+            notification.state.title = "Bump Demo"
+            notification.state.image = UIImage(named: "play-in-circle-24x24")
+            notification.state.actionButtonTitle = "Gentle"
+            notification.state.actionButtonAction = { [weak notification] in
+                // Gentle bump: low intensity, longer duration
+                notification?.bumpWithIntensity(0.3, duration: 1.0, useDecreasingCurve: true)
+            }
+            notification.state.messageButtonAction = { [weak notification] in
+                // Strong bump: high intensity, shorter duration
+                notification?.bumpWithIntensity(1.0, duration: 0.8, useDecreasingCurve: false)
             }
             return notification
         }

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/NotificationViewDemoController.swift
@@ -242,13 +242,13 @@ class NotificationViewDemoController: DemoController {
             return notification
         case .bumpDemo:
             let notification = MSFNotification(style: .primaryToast)
-            notification.state.message = "Tap the buttons below to test bump animations"
+            notification.state.message = "Tap the button to test bump animations"
             notification.state.title = "Bump Demo"
             notification.state.image = UIImage(named: "play-in-circle-24x24")
             notification.state.actionButtonTitle = "Bump"
 
             notification.state.actionButtonAction = { [weak notification] in
-                notification?.bump()
+                notification?.state.bump()
             }
 
             return notification

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -331,7 +331,7 @@ public struct FluentNotification: View, TokenizedControlView {
                 .onChange_iOS17(of: state.shouldPerformBump) { shouldBump in
                     if shouldBump {
                         state.shouldPerformBump = false
-                        preformBumpAnimated()
+                        performBumpAnimated()
                     }
                 }
                 .onTapGesture {
@@ -453,7 +453,7 @@ public struct FluentNotification: View, TokenizedControlView {
         }
     }
 
-    private func preformBumpAnimated() {
+    private func performBumpAnimated() {
         let style = state.style
 
         withAnimation(.interpolatingSpring(stiffness: style.animationSpringStiffness, damping: style.animationDampingForBump)) {

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -454,13 +454,14 @@ public struct FluentNotification: View, TokenizedControlView {
     }
 
     private func preformBumpAnimated() {
-        // Use the dedicated bump offset instead of bottomOffset
-        withAnimation(.interpolatingSpring(stiffness: state.style.animationSpringStiffness, damping: state.style.animationDampingForBump)) {
-            bumpVerticalOffset = state.style.offsetDistanceForBumpAnimation
+        let style = state.style
+
+        withAnimation(.interpolatingSpring(stiffness: style.animationSpringStiffness, damping: style.animationDampingForBump)) {
+            bumpVerticalOffset = style.offsetDistanceForBumpAnimation
         }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + state.style.bumpAnimationDelay) {
-            withAnimation(.interpolatingSpring(stiffness: state.style.animationSpringStiffness, damping: state.style.animationDampingForBump)) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + style.bumpAnimationDelay) {
+            withAnimation(.interpolatingSpring(stiffness: style.animationSpringStiffness, damping: style.animationDampingForBump)) {
                 bumpVerticalOffset = 0
             }
         }

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -67,6 +67,14 @@ import SwiftUI
     ///
     /// If this property is nil, then this notification will use the background color defined by its design tokens.
     var backgroundGradient: LinearGradientInfo? { get set }
+
+    /// Performs an animation emphasizing the notification.
+    /// The animation alternates between positive and negative rotations with decreasing intensity.
+    /// - Parameters:
+    ///   - intensity: Controls the maximum rotation angle. 1.0 corresponds to 10 degrees, scaling linearly.
+    ///   - duration: Total duration of the bump animation in seconds.
+    ///   - useDecreasingCurve: If true, uses a decreasing intensity curve. If false, uses even distribution.
+    @objc func bumpWithIntensity(_ intensity: CGFloat, duration: TimeInterval, useDecreasingCurve: Bool)
 }
 
 /// View that represents the Notification.
@@ -323,6 +331,12 @@ public struct FluentNotification: View, TokenizedControlView {
 #if os(visionOS)
                 .glassBackgroundEffect(in: RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
 #endif // os(visionOS)
+                .rotationEffect(.degrees(rotationAngle))
+                .onChange_iOS17(of: state.shouldPerformBump) { shouldBump in
+                    if shouldBump {
+                        performBumpAnimation()
+                    }
+                }
                 .onTapGesture {
                     if let messageAction = messageButtonAction {
                         isPresented = false
@@ -442,6 +456,61 @@ public struct FluentNotification: View, TokenizedControlView {
         }
     }
 
+    private func performBumpAnimation() {
+        let maxRotation = state.bumpIntensity * 10.0 // 1.0 intensity = 10 degrees
+        let duration = state.bumpDuration
+        let useDecreasingCurve = state.bumpUseDecreasingCurve
+        
+        // Calculate the 6 keyframe rotations (alternating positive/negative)
+        let rotations: [CGFloat] = {
+            if useDecreasingCurve {
+                // Decreasing intensity: 100%, 80%, 60%, 40%, 20%, 0%
+                return [
+                    maxRotation,           // +10° (or scaled)
+                    -maxRotation * 0.8,    // -8°
+                    maxRotation * 0.6,     // +6°
+                    -maxRotation * 0.4,    // -4°
+                    maxRotation * 0.2,     // +2°
+                    0                      // 0°
+                ]
+            } else {
+                // Even distribution
+                let step = maxRotation / 3.0
+                return [
+                    maxRotation,     // +max
+                    -maxRotation,    // -max
+                    step * 2,        // +2/3 max
+                    -step * 2,       // -2/3 max
+                    step,            // +1/3 max
+                    0                // 0
+                ]
+            }
+        }()
+        
+        // Perform the keyframe animation
+        state.bumpAnimationTask = Task {
+            let keyframeDuration = duration / 6.0
+            
+            for rotation in rotations {
+                guard !Task.isCancelled else { break }
+                
+                await MainActor.run {
+                    withAnimation(.easeOut(duration: keyframeDuration)) {
+                        rotationAngle = rotation
+                    }
+                }
+                
+                // Use nanoseconds for broader iOS compatibility
+                try? await Task.sleep(nanoseconds: UInt64(keyframeDuration * 1_000_000_000))
+            }
+            
+            // Reset the bump state
+            await MainActor.run {
+                state.shouldPerformBump = false
+            }
+        }
+    }
+
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
     @Binding private var isPresented: Bool
     @State private var bottomOffsetForDismissedState: CGFloat = 0
@@ -450,6 +519,7 @@ public struct FluentNotification: View, TokenizedControlView {
     @State private var attributedMessageSize: CGSize = CGSize()
     @State private var attributedTitleSize: CGSize = CGSize()
     @State private var opacity: CGFloat = 0
+    @State private var rotationAngle: CGFloat = 0
 
     // When true, the notification view will take up all proposed space
     // and automatically position itself within it.
@@ -495,6 +565,12 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
 
     /// Style to draw the control.
     @Published var style: MSFNotificationStyle
+
+    @Published var shouldPerformBump: Bool = false
+    @Published var bumpIntensity: CGFloat = 0.0
+    @Published var bumpDuration: TimeInterval = 0.0
+    @Published var bumpUseDecreasingCurve: Bool = true
+    var bumpAnimationTask: Task<Void, Never>?
 
     @objc convenience init(style: MSFNotificationStyle) {
         self.init(style: style,
@@ -549,4 +625,19 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
 
         super.init()
     }
+
+	@objc func bumpWithIntensity(_ intensity: CGFloat, duration: TimeInterval, useDecreasingCurve: Bool) {
+		// Cancel any existing bump animation
+		bumpAnimationTask?.cancel()
+
+		// Guard against overlapping animations
+		guard !shouldPerformBump else { return }
+
+		bumpIntensity = max(0.0, min(1.0, intensity)) // Clamp between 0 and 1
+		bumpDuration = max(0.1, duration) // Minimum duration of 0.1 seconds
+		bumpUseDecreasingCurve = useDecreasingCurve
+
+		// Start the bump animation
+		shouldPerformBump = true
+	}
 }

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -521,8 +521,8 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
     /// Style to draw the control.
     @Published var style: MSFNotificationStyle
 
+    /// Controls whether the bump animation should start
     @Published var shouldPerformBump: Bool = false
-    var bumpAnimationTask: Task<Void, Never>?
 
     @objc convenience init(style: MSFNotificationStyle) {
         self.init(style: style,

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -70,7 +70,7 @@ import SwiftUI
 
     /// Performs an animation emphasizing the notification.
     /// The animation alternates between upward and downward movements with spring physics.
-	func bump()
+    func bump()
 }
 
 /// View that represents the Notification.

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -70,7 +70,7 @@ import SwiftUI
 
     /// Performs an animation emphasizing the notification.
     /// The animation alternates between upward and downward movements with spring physics.
-    @objc func bump()
+	func bump()
 }
 
 /// View that represents the Notification.
@@ -523,7 +523,7 @@ class MSFNotificationStateImpl: ControlState, MSFNotificationState {
     @Published var style: MSFNotificationStyle
 
     /// Controls whether the bump animation should start
-    @Published var shouldPerformBump: Bool = false
+    @Published internal var shouldPerformBump: Bool = false
 
     @objc convenience init(style: MSFNotificationStyle) {
         self.init(style: style,

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -49,6 +49,16 @@ import UIKit
         return notification.state
     }
 
+    // Add this method to expose the bump functionality
+    /// Performs a gentle rotation animation on the notification with 6 keyframes.
+    /// - Parameters:
+    ///   - intensity: Controls the maximum rotation angle. 1.0 corresponds to 10 degrees, scaling linearly.
+    ///   - duration: Total duration of the bump animation in seconds.
+    ///   - useDecreasingCurve: If true, uses a decreasing intensity curve. If false, uses even distribution.
+    @objc public func bumpWithIntensity(_ intensity: CGFloat, duration: TimeInterval, useDecreasingCurve: Bool) {
+        state.bumpWithIntensity(intensity, duration: duration, useDecreasingCurve: useDecreasingCurve)
+    }
+
     public var tokenSet: NotificationTokenSet {
         return notification.tokenSet
     }

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -49,14 +49,9 @@ import UIKit
         return notification.state
     }
 
-    // Add this method to expose the bump functionality
-    /// Performs a gentle rotation animation on the notification with 6 keyframes.
-    /// - Parameters:
-    ///   - intensity: Controls the maximum rotation angle. 1.0 corresponds to 10 degrees, scaling linearly.
-    ///   - duration: Total duration of the bump animation in seconds.
-    ///   - useDecreasingCurve: If true, uses a decreasing intensity curve. If false, uses even distribution.
-    @objc public func bumpWithIntensity(_ intensity: CGFloat, duration: TimeInterval, useDecreasingCurve: Bool) {
-        state.bumpWithIntensity(intensity, duration: duration, useDecreasingCurve: useDecreasingCurve)
+    // 
+    @objc public func bump() {
+        state.bump()
     }
 
     public var tokenSet: NotificationTokenSet {

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -49,10 +49,6 @@ import UIKit
         return notification.state
     }
 
-    @objc public func bump() {
-        state.bump()
-    }
-
     public var tokenSet: NotificationTokenSet {
         return notification.tokenSet
     }

--- a/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/MSFNotification.swift
@@ -49,7 +49,6 @@ import UIKit
         return notification.state
     }
 
-    // 
     @objc public func bump() {
         state.bump()
     }

--- a/Sources/FluentUI_iOS/Components/Notification/NotificationTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/NotificationTokenSet.swift
@@ -48,6 +48,10 @@ import UIKit
     var animationDurationForShow: TimeInterval { return isToast ? Constants.animationDurationForShowToast : Constants.animationDurationForShowBar }
     var animationDurationForHide: TimeInterval { return Constants.animationDurationForHide }
     var animationDampingRatio: CGFloat { return isToast ? Constants.animationDampingRatioForToast : 1 }
+    var animationDampingForBump: CGFloat { return Constants.animationDampingForBump }
+    var offsetDistanceForBumpAnimation: CGFloat { return Constants.offsetDistanceForBump }
+    var animationSpringStiffness: CGFloat { return Constants.animationSpringStiffness }
+    var bumpAnimationDelay: CGFloat { return CGFloat(Constants.bumpAnimationDelay) }
 
     var needsFullWidth: Bool { return !isToast }
     var needsSeparator: Bool { return  self == .primaryOutlineBar }
@@ -60,6 +64,10 @@ import UIKit
         static let animationDurationForShowBar: TimeInterval = 0.3
         static let animationDurationForHide: TimeInterval = 0.25
         static let animationDampingRatioForToast: CGFloat = 0.5
+        static let animationDampingForBump: CGFloat = 8
+        static let offsetDistanceForBump: CGFloat = 25
+        static let animationSpringStiffness: CGFloat = 300
+        static let bumpAnimationDelay: TimeInterval = 0.15
     }
 }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [x] visionOS

### Description of changes
Added in a bump API to the notification that preforms a bouncy animation to highlight the notification while it is presented. This is done using 2 spring animations. We animate to some offset and then animated using a spring animation back to the origin point with enouch velocity that it animates past the point.

Implemented a demo of this in the demo controller

### Verification
Validated using the demo controller that the animation runs an looks smooth without causing issues to the dismiss animation. 

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Did not exist | ![Simulator Screen Recording - iPad Pro 13-inch (M4) - 2025-07-22 at 15 52 24](https://github.com/user-attachments/assets/b9fbd65d-c48a-4eab-b302-7cf89bde5285) |
</details>

### Pull request checklist

This PR has considered:
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure 
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2193)