### PR TITLE
Rename common method to not sound iOS-specific

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/DemoAppearanceMenu.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/DemoAppearanceMenu.swift
@@ -68,22 +68,22 @@ struct DemoAppearanceMenu: View {
         })
 
         // Changes
-        .onChange_iOS17(of: configuration.userInterfaceStyle) { newValue in
+        .onChange_Compatibility(of: configuration.userInterfaceStyle) { newValue in
             configuration.onUserInterfaceStyleChanged?(newValue)
         }
-        .onChange_iOS17(of: configuration.windowTheme) { newValue in
+        .onChange_Compatibility(of: configuration.windowTheme) { newValue in
             configuration.onWindowThemeChanged?(newValue)
         }
-        .onChange_iOS17(of: configuration.appWideTheme) { newValue in
+        .onChange_Compatibility(of: configuration.appWideTheme) { newValue in
             configuration.onAppWideThemeChanged?(newValue)
         }
-        .onChange_iOS17(of: configuration.themeWideOverride) { newValue in
+        .onChange_Compatibility(of: configuration.themeWideOverride) { newValue in
             configuration.onThemeWideOverrideChanged?(newValue)
 
             // TODO: Still working through some issues with the theme-wide override tokens, so inform the user how to make it visible for now.
             showingThemeWideAlert = true
         }
-        .onChange_iOS17(of: configuration.perControlOverride) { newValue in
+        .onChange_Compatibility(of: configuration.perControlOverride) { newValue in
             configuration.onPerControlOverrideChanged?(newValue)
         }
 

--- a/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
+++ b/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
@@ -21,7 +21,7 @@ public extension View {
     ///   - value: The value to check against when determining whether to run the closure.
     ///   - action: A closure to run when the value changes.
     /// - Returns: A view that fires an action when the specified value changes.
-    func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
+    func onChange_Compatibility<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
 #if os(visionOS)
         // Known bug when using #available and self.onChange together in visionOS: it'll crash!
         // So for this OS, just use the new .onChange unconditionally.

--- a/Sources/FluentUI_iOS/Components/ActivityIndicator/ActivityIndicator.swift
+++ b/Sources/FluentUI_iOS/Components/ActivityIndicator/ActivityIndicator.swift
@@ -87,7 +87,7 @@ public struct ActivityIndicator: View, TokenizedControlView {
             }
             .opacity(!state.isAnimating && state.hidesWhenStopped ? 0 : 1)
             .rotationEffect(.degrees(rotationAngle), anchor: .center)
-            .onChange_iOS17(of: state.isAnimating) { newValue in
+            .onChange_Compatibility(of: state.isAnimating) { newValue in
                 newValue ? startAnimation() : stopAnimation()
             }
             .frame(width: side,

--- a/Sources/FluentUI_iOS/Components/AvatarGroup/AvatarGroup.swift
+++ b/Sources/FluentUI_iOS/Components/AvatarGroup/AvatarGroup.swift
@@ -197,7 +197,7 @@ public struct AvatarGroup: View, TokenizedControlView {
 
             avatar
                 .transition(.identity)
-                .onChange_iOS17(of: state.size) { size in
+                .onChange_Compatibility(of: state.size) { size in
                     avatar.state.size = size
                 }
             .padding(.trailing, (isLastDisplayed && !hasOverflow) ? 0 : isStackStyle ? stackPadding : interspace)

--- a/Sources/FluentUI_iOS/Components/HUD/HeadsUpDisplay.swift
+++ b/Sources/FluentUI_iOS/Components/HUD/HeadsUpDisplay.swift
@@ -104,7 +104,7 @@ public struct HeadsUpDisplay: View, TokenizedControlView {
                 .cornerRadius(tokenSet[.cornerRadius].float)
         )
         .contentShape(Rectangle())
-        .onChange_iOS17(of: isPresented) { present in
+        .onChange_Compatibility(of: isPresented) { present in
             if present {
                 presentAnimated()
             } else {

--- a/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
+++ b/Sources/FluentUI_iOS/Components/Notification/FluentNotification.swift
@@ -328,7 +328,7 @@ public struct FluentNotification: View, TokenizedControlView {
                 .glassBackgroundEffect(in: RoundedRectangle(cornerRadius: tokenSet[.cornerRadius].float))
 #endif // os(visionOS)
                 .offset(y: -bumpVerticalOffset)
-                .onChange_iOS17(of: state.shouldPerformBump) { shouldBump in
+                .onChange_Compatibility(of: state.shouldPerformBump) { shouldBump in
                     if shouldBump {
                         state.shouldPerformBump = false
                         performBumpAnimated()
@@ -360,7 +360,7 @@ public struct FluentNotification: View, TokenizedControlView {
                     notification
                         .frame(idealWidth: isFlexibleWidthToast ? innerContentsSize.width - horizontalPadding : calculatedNotificationWidth,
                                maxWidth: isFlexibleWidthToast ? proposedWidth : calculatedNotificationWidth, alignment: .center)
-                        .onChange_iOS17(of: isPresented) { newPresent in
+                        .onChange_Compatibility(of: isPresented) { newPresent in
                             if newPresent {
                                 presentAnimated()
                             } else {


### PR DESCRIPTION
The "onChange_iOS17" method is in common code and we'd like to use it in macOS components. Rename it to be non-iOS-specific.

### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Renamed onChange_iOS17 to onChange_Compatibility.

### Binary change

Trivial increase in size based on the method name.

### Verification

Verified builds.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2196)