### PR TITLE
[macOS] Improving Objective-C support on macOS

### DIFF
--- a/Sources/FluentUI_common/Core/Theme/Tokens/GlobalTokens.swift
+++ b/Sources/FluentUI_common/Core/Theme/Tokens/GlobalTokens.swift
@@ -1654,8 +1654,8 @@ public class GlobalTokens: NSObject {
     }
 
     // MARK: - FontSize
-
-    public enum FontSizeToken: CaseIterable, Hashable {
+    @objc(MSFGlobalTokensFontSize)
+    public enum FontSizeToken: Int, CaseIterable, Hashable {
         case size100
         case size200
         case size300
@@ -1666,13 +1666,15 @@ public class GlobalTokens: NSObject {
         case size800
         case size900
     }
+    @objc(fontSizeForToken:)
     public static func fontSize(_ token: FontSizeToken) -> CGFloat {
         return platformGlobalTokenProvider.fontSize(for: token)
     }
 
     // MARK: - FontWeight
 
-    public enum FontWeightToken: CaseIterable, Hashable {
+    @objc(MSFGlobalTokensFontWeight)
+    public enum FontWeightToken: Int, CaseIterable, Hashable {
         case regular
         case medium
         case semibold
@@ -1693,7 +1695,8 @@ public class GlobalTokens: NSObject {
 
     // MARK: - IconSize
 
-    public enum IconSizeToken: CaseIterable, Hashable {
+    @objc(MSFGlobalTokensIconSize)
+    public enum IconSizeToken: Int, CaseIterable, Hashable {
         case size100
         case size120
         case size160
@@ -1704,6 +1707,7 @@ public class GlobalTokens: NSObject {
         case size400
         case size480
     }
+    @objc(iconSizeForToken:)
     public static func icon(_ token: IconSizeToken) -> CGFloat {
         switch token {
         case .size100:
@@ -1729,7 +1733,8 @@ public class GlobalTokens: NSObject {
 
     // MARK: - Spacing
 
-    public enum SpacingToken: CaseIterable, Hashable {
+    @objc(MSFGlobalTokensSpacing)
+    public enum SpacingToken: Int, CaseIterable, Hashable {
         case sizeNone
         case size20
         case size40
@@ -1748,6 +1753,7 @@ public class GlobalTokens: NSObject {
         case size520
         case size560
     }
+    @objc(spacingForToken:)
     public static func spacing(_ token: SpacingToken) -> CGFloat {
         switch token {
         case .sizeNone:
@@ -1789,15 +1795,18 @@ public class GlobalTokens: NSObject {
 
     // MARK: - BorderRadius
 
-    public enum CornerRadiusToken: CaseIterable, Hashable {
+    @objc(MSFGlobalTokensCornerRadius)
+    public enum CornerRadiusToken: Int, CaseIterable, Hashable {
         case radiusNone
         case radius20
         case radius40
         case radius60
         case radius80
         case radius120
+        case radius160
         case radiusCircular
     }
+    @objc(cornerRadiusForToken:)
     public static func corner(_ token: CornerRadiusToken) -> CGFloat {
         switch token {
         case .radiusNone:
@@ -1812,6 +1821,8 @@ public class GlobalTokens: NSObject {
             return 8
         case .radius120:
             return 12
+        case .radius160:
+            return 16
         case .radiusCircular:
             return 9999
         }
@@ -1819,7 +1830,8 @@ public class GlobalTokens: NSObject {
 
     // MARK: - BorderSize
 
-    public enum StrokeWidthToken: CaseIterable, Hashable {
+    @objc(MSFGlobalTokensStrokeWidthToken)
+    public enum StrokeWidthToken: Int, CaseIterable, Hashable {
         case widthNone
         case width05
         case width10
@@ -1829,6 +1841,7 @@ public class GlobalTokens: NSObject {
         case width40
         case width60
     }
+    @objc(strokeWidthForToken:)
     public static func stroke(_ token: StrokeWidthToken) -> CGFloat {
         switch token {
         case .widthNone:

--- a/Sources/FluentUI_macOS/Theme/FluentTheme+AppKit.swift
+++ b/Sources/FluentUI_macOS/Theme/FluentTheme+AppKit.swift
@@ -11,6 +11,17 @@ import SwiftUI
 
 public extension FluentTheme {
 
+    /// Returns the color value for the given token.
+    ///
+    /// - Parameter token: The `ColorsTokens` value to be retrieved.
+    /// - Returns: A `UIColor` for the given token.
+    @objc(colorForToken:)
+    func nsColor(_ token: ColorToken) -> NSColor {
+        let dynamicColor = dynamicColor(token)
+        return NSColor(light: NSColor(dynamicColor.light),
+                       dark: dynamicColor.dark.map { NSColor($0) })
+    }
+
     /// Returns the font value for the given token.
     ///
     /// - Parameter token: The `TypographyTokens` value to be retrieved.

--- a/Sources/FluentUI_macOS/Theme/Tokens/GlobalTokens+AppKit.swift
+++ b/Sources/FluentUI_macOS/Theme/Tokens/GlobalTokens+AppKit.swift
@@ -1,0 +1,33 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#if canImport(FluentUI_common)
+import FluentUI_common
+#endif
+import AppKit
+
+public extension GlobalTokens {
+
+    // MARK: - BrandColor
+
+    @objc(colorForBrandColorToken:)
+    static func brandColor(_ token: BrandColorToken) -> NSColor {
+        return NSColor(GlobalTokens.brandSwiftUIColor(token))
+    }
+
+    // MARK: - NeutralColor
+
+    @objc(colorForNeutralColorToken:)
+    static func neutralColor(_ token: NeutralColorToken) -> NSColor {
+        return NSColor(GlobalTokens.neutralSwiftUIColor(token))
+    }
+
+    // MARK: - SharedColor
+
+    @objc(colorForSharedColorSet:token:)
+    static func sharedColor(_ sharedColor: SharedColorSet, _ token: SharedColorToken) -> NSColor {
+        return NSColor(GlobalTokens.sharedSwiftUIColor(sharedColor, token))
+    }
+}

--- a/Sources/FluentUI_macOS/Theme/Tokens/ShadowInfo+AppKit.swift
+++ b/Sources/FluentUI_macOS/Theme/Tokens/ShadowInfo+AppKit.swift
@@ -1,0 +1,22 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+#if canImport(FluentUI_common)
+import FluentUI_common
+#endif
+import SwiftUI
+import AppKit
+
+public extension ShadowInfo {
+    /// Creates an NSShadow from the `key` elements of this instance.
+    @objc var keyShadow: NSShadow {
+        let dropShadow = NSShadow()
+        dropShadow.shadowColor = NSColor(keyColor)
+        // NSShadow offsets are inverted from our global values
+        dropShadow.shadowOffset = CGSizeMake(-xKey, -yKey)
+        dropShadow.shadowBlurRadius = keyBlur
+        return dropShadow
+    }
+}


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

This change is aimed to help AppKit-heavy apps better utilize FluentUI.

Changes:
* Add Objective-C support to as much of `GlobalTokens` as possible.
* Improve `NSColor` support for existing tokens.
* Add built-in `NSShadow` support for our `ShadowInfo` class.

### Verification

Tested locally in an Objective-C app

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)