### PR TITLE
Fix CommandBar background color

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -183,7 +183,6 @@ class CommandBarDemoController: DemoController {
         let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
         commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
-        commandBar.backgroundColor = view.fluentTheme.color(.background3)
         container.addArrangedSubview(commandBar)
         defaultCommandBar = commandBar
 
@@ -278,7 +277,6 @@ class CommandBarDemoController: DemoController {
 
         let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
         fixedButtonCommandBar.translatesAutoresizingMaskIntoConstraints = false
-        fixedButtonCommandBar.backgroundColor = view.fluentTheme.color(.background3)
         container.addArrangedSubview(fixedButtonCommandBar)
 
         container.addArrangedSubview(createLabelWithText("In Input Accessory View"))
@@ -525,6 +523,7 @@ extension CommandBarDemoController: DemoAppearanceDelegate {
 
     private var perControlOverrideCommandBarTokens: [CommandBarTokenSet.Tokens: ControlTokenValue] {
         return [
+            .backgroundColor: .uiColor { GlobalTokens.sharedColor(.purple, .tint40) },
             .itemBackgroundColorRest: .uiColor { GlobalTokens.sharedColor(.grape, .primary) }
         ]
     }

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -101,9 +101,11 @@ public class CommandBar: UIView, TokenizedControl {
         super.init(frame: .zero)
 
         configureHierarchy()
+        updateBackgroundColor()
 
         // Update appearance whenever `tokenSet` changes.
         tokenSet.registerOnUpdate(for: self) { [weak self] in
+            self?.updateBackgroundColor()
             self?.updateButtonTokens()
         }
     }
@@ -381,6 +383,10 @@ public class CommandBar: UIView, TokenizedControl {
         }
 
         containerMaskLayer.locations = locations.map { NSNumber(value: Float($0)) }
+    }
+
+    private func updateBackgroundColor() {
+        backgroundColor = tokenSet[.backgroundColor].uiColor
     }
 
     private func updateButtonTokens() {

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarButton.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarButton.swift
@@ -176,13 +176,6 @@ class CommandBarButton: UIButton {
             view.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
     }
-
-    private struct LayoutConstants {
-        static let contentEdgeInsets = UIEdgeInsets(top: 8.0,
-                                                    left: 10.0,
-                                                    bottom: 8.0,
-                                                    right: 10.0)
-    }
 }
 
 // MARK: CommandBarButton UIPointerInteractionDelegate

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
@@ -55,10 +55,7 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
         super.init { token, theme in
             switch token {
             case .backgroundColor:
-                return .uiColor {
-                    UIColor(light: GlobalTokens.neutralColor(.grey98),
-                            dark: GlobalTokens.neutralColor(.grey8))
-                }
+                return .uiColor { theme.color(.background2) }
 
             case .groupBorderRadius:
                 return .float { GlobalTokens.corner(.radius120) }


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

`CommandBar`'s `backgroundColor` was never being set (we externally set it in the demo controller). Update it to design's `background2`

While I'm here, delete unused `contentEdgeInsets`

### Verification

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1206" height="2622" alt="light before" src="https://github.com/user-attachments/assets/55941ff2-ad94-4b20-93de-504d70561f19" /> | <img width="1206" height="2622" alt="light after" src="https://github.com/user-attachments/assets/18dfdc1c-3776-4da3-b662-248916694743" /> |
| <img width="1206" height="2622" alt="dark before" src="https://github.com/user-attachments/assets/b878797c-c619-44dd-9f3b-c56297968c98" /> | <img width="1206" height="2622" alt="dark after" src="https://github.com/user-attachments/assets/eac161a3-b0f5-4f58-bd4a-53316789e8d1" /> |
| <img width="1206" height="2622" alt="override before" src="https://github.com/user-attachments/assets/00121c5b-f51d-4e93-b9c9-612c7267a408" /> | <img width="1206" height="2622" alt="override after" src="https://github.com/user-attachments/assets/670ab15f-f1d6-4531-98d3-38ce962359cd" /> |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)