### PR TITLE
Glassify Bottom Commanding Controller

### DIFF
--- a/Sources/FluentUI_iOS/Components/BottomCommanding/BottomCommandingTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/BottomCommanding/BottomCommandingTokenSet.swift
@@ -56,13 +56,25 @@ public enum BottomCommandingToken: Int, TokenSetKey {
 }
 
 public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingToken> {
-    init() {
-        super.init { token, theme in
+    init(style: @escaping () -> BottomCommandingControllerStyle) {
+        self.style = style
+        super.init { [style] token, theme in
             switch token {
             case .backgroundColor:
-                return .uiColor { theme.color(.background2) }
+                return .uiColor {
+                    switch style() {
+                    case .primary:
+                        return theme.color(.background2)
+                    case .glass:
+                        return .clear
+                    }
+                }
             case .cornerRadius:
-                return .float { GlobalTokens.corner(.radius120) }
+                if #available(iOS 26, *) {
+                    return .float { BottomSheetTokenSet.cornerRadius }
+                } else {
+                    return .float { GlobalTokens.corner(.radius120) }
+                }
             case .heroDisabledColor:
                 return .uiColor { theme.color(.foregroundDisabled1) }
             case .heroLabelFont:
@@ -92,10 +104,11 @@ public class BottomCommandingTokenSet: ControlTokenSet<BottomCommandingToken> {
             }
         }
     }
+
+    var style: () -> BottomCommandingControllerStyle
 }
 
 extension BottomCommandingTokenSet {
-    static let bottomBarTopSpacing: CGFloat = GlobalTokens.spacing(.size200)
     static let gridSpacing: CGFloat = GlobalTokens.spacing(.size80)
     static let tabVerticalPadding: CGFloat = GlobalTokens.spacing(.size80)
     static let tabHorizontalPadding: CGFloat = GlobalTokens.spacing(.size160)

--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetTokenSet.swift
@@ -23,15 +23,21 @@ public enum BottomSheetToken: Int, TokenSetKey {
 }
 
 public class BottomSheetTokenSet: ControlTokenSet<BottomSheetToken> {
-    init() {
-        super.init { token, theme in
+    init(style: @escaping () -> BottomSheetControllerStyle) {
+        self.style = style
+        super.init { [style] token, theme in
             switch token {
             case .backgroundColor:
-                return .uiColor { UIColor(light: theme.color(.background2).light,
-                                          dark: theme.color(.background2).dark)
+                return .uiColor {
+                    switch style() {
+                    case .primary:
+                        return theme.color(.background2)
+                    case .glass:
+                        return .clear
+                    }
                 }
             case .cornerRadius:
-                if #available(iOS 19, *) {
+                if #available(iOS 26, *) {
                     return .float { BottomSheetTokenSet.cornerRadius }
                 } else {
                     return .float { GlobalTokens.corner(.radius120) }
@@ -43,6 +49,8 @@ public class BottomSheetTokenSet: ControlTokenSet<BottomSheetToken> {
             }
         }
     }
+
+    var style: () -> BottomSheetControllerStyle
 }
 
 // MARK: Constants


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Glassify `BottomCommandingController`. We already glassified it when it was a sheet, update it for when it's a bottom bar as well. On iOS 26, use `UIGlassEffect`. On lower OSs, use `UIBlurEffect` for a fake glass look.
- New `BottomCommandingControllerStyle` that's just an alias
- Apply background color to `UIGlassEffect` only
  - No way to tint `UIBlurEffect`
- Use new `UICornerConfiguration` on iOS 26
  - Manually update `CALayer` on lower OSs

### Verification
<details>
<summary>Visual Verification</summary>

| Primary                                       | UIBlurEffect                                      | UIGlassEffect                                      |
|----------------------------------------------|--------------------------------------------|--------------------------------------------|
| <img width="1294" height="1082" alt="bar" src="https://github.com/user-attachments/assets/927b2f7e-2657-4eca-b523-d87239e68ee7" /> | <img width="1306" height="1079" alt="bar 18" src="https://github.com/user-attachments/assets/b0ba8ec7-55dd-45a8-b59b-ed8a2adad66a" /> | <img width="1304" height="1082" alt="bar 26" src="https://github.com/user-attachments/assets/0a076404-a000-48b7-a648-bdde3f0f06d0" /> |
| <img width="752" height="1121" alt="commanding sheet" src="https://github.com/user-attachments/assets/b95eea45-50e7-4aa9-b901-14247a518070" /> | <img width="751" height="1115" alt="commanding sheet 18" src="https://github.com/user-attachments/assets/b94efc5c-d791-434c-8a83-200812b74494" /> | <img width="875" height="1110" alt="commanding sheet 26" src="https://github.com/user-attachments/assets/aa500a8d-001c-4e89-83ed-29f94faf2460" /> |
| <img width="2752" height="2064" alt="sheet" src="https://github.com/user-attachments/assets/edefae8b-d01a-43ec-9833-ef5a725192f4" /> | <img width="2752" height="2064" alt="sheet 18" src="https://github.com/user-attachments/assets/eaaeb18b-423e-4cb3-a861-49e5416c1238" /> | <img width="2752" height="2064" alt="sheet 26" src="https://github.com/user-attachments/assets/aac78a40-710d-4848-96f0-e044fdbf054b" /> |
| <img width="751" height="1114" alt="commanding sheet token" src="https://github.com/user-attachments/assets/5d9fe968-a689-4417-b05a-676ae75e811f" /> | <img width="750" height="1113" alt="commanding sheet token 18" src="https://github.com/user-attachments/assets/6c0cc36b-fba3-41a6-a1ce-010bbb487e9d" /> | <img width="1272" height="1096" alt="commanding sheet token 26" src="https://github.com/user-attachments/assets/20b398da-3c93-4718-80e1-2ee65926e739" /> |
| <img width="1299" height="1101" alt="bar token" src="https://github.com/user-attachments/assets/b61003ed-9969-4bef-8e5e-c255d4215559" /> | <img width="1302" height="1102" alt="bar token 18" src="https://github.com/user-attachments/assets/a82bda6f-3a98-41a6-b58d-c35fc61fbf74" /> | <img width="1272" height="1096" alt="commanding sheet token 26" src="https://github.com/user-attachments/assets/467c92fc-d97b-44c1-81f2-f2342f1cf5ec" /> |
| <img width="2752" height="2064" alt="sheet token" src="https://github.com/user-attachments/assets/b77e00d5-2b09-42c4-983b-6d6d4db669a3" /> | <img width="2752" height="2064" alt="sheet token 18" src="https://github.com/user-attachments/assets/056a7c4b-e47e-47a8-b9cb-37da1780f369" /> | <img width="2752" height="2064" alt="sheet token 26" src="https://github.com/user-attachments/assets/4c8e365c-3407-42c3-b8bb-18cd5996e8b7" /> |

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)