### PR TITLE
[iOS BottomSheetController] Fix logic that creates/updates the bottomSheetView accessibilityIdentifier

### DIFF
--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -126,11 +126,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 }
 
 #if DEBUG
-                if isExpandable {
-                    bottomSheetView.accessibilityIdentifier?.append(", a resizing handle")
-                } else {
-                    bottomSheetView.accessibilityIdentifier = bottomSheetView.accessibilityIdentifier?.replacingOccurrences(of: ", a resizing handle", with: "")
-                }
+                bottomSheetView.accessibilityIdentifier = bottomSheetViewAccessibilityIdentifierForState()
 #endif
             }
         }
@@ -269,11 +265,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             view.setNeedsLayout()
 
 #if DEBUG
-                if shouldAlwaysFillWidth {
-                    bottomSheetView.accessibilityIdentifier?.append(", filled width")
-                } else {
-                    bottomSheetView.accessibilityIdentifier = bottomSheetView.accessibilityIdentifier?.replacingOccurrences(of: ", filled width", with: "")
-                }
+            bottomSheetView.accessibilityIdentifier = bottomSheetViewAccessibilityIdentifierForState()
 #endif
         }
     }
@@ -715,7 +707,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         ])
 
 #if DEBUG
-        bottomSheetView.accessibilityIdentifier = "Bottom Sheet View"
+        bottomSheetView.accessibilityIdentifier = bottomSheetViewAccessibilityIdentifierForState()
 #endif
 
         return bottomSheetView
@@ -780,11 +772,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         expandedContentView.alpha = targetAlpha
 
 #if DEBUG
-        if targetAlpha == 1.0 {
-            bottomSheetView.accessibilityIdentifier?.append(", an expanded content view")
-        } else {
-            bottomSheetView.accessibilityIdentifier = bottomSheetView.accessibilityIdentifier?.replacingOccurrences(of: ", an expanded content view", with: "")
-        }
+        bottomSheetView.accessibilityIdentifier = bottomSheetViewAccessibilityIdentifierForState()
 #endif
     }
 
@@ -855,6 +843,23 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             dimmingView.accessibilityFrame = view.frame.inset(by: margins)
             view.accessibilityViewIsModal = true
         }
+    }
+
+    private func bottomSheetViewAccessibilityIdentifierForState() -> String? {
+        var accessibilityIdentifier: String? = nil
+    #if DEBUG
+        accessibilityIdentifier = "Bottom Sheet View"
+        if expandedContentView.alpha == 1.0 {
+            accessibilityIdentifier?.append(", an expanded content view")
+        }
+        if isExpandable {
+            accessibilityIdentifier?.append(", a resizing handle")
+        }
+        if shouldAlwaysFillWidth {
+            accessibilityIdentifier?.append(", filled width")
+        }
+    #endif
+        return accessibilityIdentifier
     }
 
     private func updateSheetLayoutGuideTopConstraint() {

--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -845,22 +845,21 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         }
     }
 
+#if DEBUG
     private func bottomSheetViewAccessibilityIdentifierForState() -> String? {
-        var accessibilityIdentifier: String? = nil
-    #if DEBUG
-        accessibilityIdentifier = "Bottom Sheet View"
+        var accessibilityIdentifier = "Bottom Sheet View"
         if expandedContentView.alpha == 1.0 {
-            accessibilityIdentifier?.append(", an expanded content view")
+            accessibilityIdentifier.append(", an expanded content view")
         }
         if isExpandable {
-            accessibilityIdentifier?.append(", a resizing handle")
+            accessibilityIdentifier.append(", a resizing handle")
         }
         if shouldAlwaysFillWidth {
-            accessibilityIdentifier?.append(", filled width")
+            accessibilityIdentifier.append(", filled width")
         }
-    #endif
         return accessibilityIdentifier
     }
+#endif
 
     private func updateSheetLayoutGuideTopConstraint() {
         if sheetLayoutGuideTopConstraint.constant != currentSheetVerticalOffset {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

I observed that `bottomSheetView`'s `accessibilityIdentifier` was incorrect when the sheet entered the expanded state. The root cause is that the methods which append strings to the identifier can be invoked multiple times without checking whether the substring already exists, which leads to the incorrect identifier.

<img width="218" height="124" alt="Screenshot 2025-09-18 at 2 15 47 PM" src="https://github.com/user-attachments/assets/c927e442-a6ee-4b10-8553-1e6e3aae9d7d" />

**Fix:**
- A private method `bottomSheetViewAccessibilityIdentifierForState` that performs the necessary state checks and returns the correct `accessibilityIdentifier` for `bottomSheetView`.
- Replace every place that previously appended substrings to `bottomSheetView.accessibilityIdentifier` with a call to `bottomSheetViewAccessibilityIdentifier`

### Binary change

NA

### Verification

I valided using the debugger that the bottomSheetView accessibilityIdentifier is set correctly for each of the different states.

I validated that the `BottomSheetControllerTest` XCUI tests pass with the changes in place.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| 
<img width="218" height="124" alt="Screenshot 2025-09-18 at 2 15 47 PM" src="https://github.com/user-attachments/assets/c335ed0c-ad0a-456e-a3f1-a2d9ade4aa57" /> | <img width="201" height="48" alt="Screenshot 2025-09-18 at 2 27 31 PM" src="https://github.com/user-attachments/assets/5dbab297-7264-43fd-84ce-b46c76b02a7e" /> |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)