### PR TITLE
[iOS] Fix warning in iOS 17

### DIFF
--- a/Sources/FluentUI_iOS/Components/TableView/TableViewCell.swift
+++ b/Sources/FluentUI_iOS/Components/TableView/TableViewCell.swift
@@ -1040,7 +1040,7 @@ open class TableViewCell: UITableViewCell, TokenizedControl {
             }
             if let customSwitch = customAccessoryView as? UISwitch {
                 if isEnabled && customSwitch.isEnabled {
-                    var allowOSHint = accessibilityTraits.contains(.toggleButton)
+                    let allowOSHint = accessibilityTraits.contains(.toggleButton)
                     return allowOSHint ? super.accessibilityHint : "Accessibility.TableViewCell.Switch.Hint".localized
                 } else {
                     return nil


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

#2211 caused a new warning, which our current tooling does not catch. That should be fixed, but in the meantime this at least fixes the warning.

### Verification

Code builds with no warnings.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2214)