### PR TITLE
[Bottom Sheet] Merge duplicate detents + other fixes

### DIFF
--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -409,20 +409,18 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     ///   - animated: Indicates if the change should be animated. The default value is `true`.
     ///   - completion: Closure to be called when the state change completes.
     @objc public func presentSheet(expandedState: BottomSheetExpansionState, animated: Bool = true, completion: ((_ isFinished: Bool) -> Void)? = nil) {
-        let finishedState: BottomSheetExpansionState
-        let collapsedOrExpanded: BottomSheetExpansionState = supportsCollapsedState ? .collapsed : .expanded
-
-        switch expandedState {
-        case .collapsed:
-            finishedState = collapsedOrExpanded
-        case .expanded:
-            finishedState = isExpandable ? .expanded : collapsedOrExpanded
-        case .partial:
-            finishedState = isExpandable && supportsPartialState ? .partial : collapsedOrExpanded
-        // Safe fallback for any invalid target states
-        default:
-            finishedState = collapsedOrExpanded
-        }
+        let finishedState: BottomSheetExpansionState =
+            switch expandedState {
+            case .expanded where isExpandable:
+                .expanded
+            case .partial where isExpandable && supportsPartialState:
+                .partial
+            case .collapsed where supportsCollapsedState:
+                .collapsed
+            default:
+                // Requested state isn't supported; fall back to collapsed if available, otherwise expanded.
+                supportsCollapsedState ? .collapsed : .expanded
+            }
 
         if isViewLoaded {
             move(to: finishedState, animated: animated, allowUnhiding: true) { finalPosition in
@@ -601,7 +599,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 bottomSheetView.frame = sheetFrame(offset: offset(for: .expanded))
                 handleCompletedStateChange(to: .expanded, interaction: .noUserAction)
             } else {
-            bottomSheetView.frame = sheetFrame(offset: offset(for: currentExpansionState))
+                bottomSheetView.frame = sheetFrame(offset: offset(for: currentExpansionState))
             }
             updateSheetLayoutGuideTopConstraint()
             updateExpandedContentAlpha()
@@ -1161,13 +1159,16 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                       shouldNotifyDelegate: Bool = true,
                       allowUnhiding: Bool = false,
                       completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
+        guard targetExpansionState == .hidden || !isHiddenOrHiding || allowUnhiding else {
+            return
+        }
+
         var targetExpansionState = targetExpansionState
         if targetExpansionState == .partial && !supportsPartialState {
             targetExpansionState = currentExpansionState == .expanded ? .collapsed : .expanded
         }
-
-        guard targetExpansionState == .hidden || !isHiddenOrHiding || allowUnhiding else {
-            return
+        if targetExpansionState == .collapsed && !supportsCollapsedState {
+            targetExpansionState = .expanded
         }
 
         completeAnimationsIfNeeded()

--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -410,17 +410,18 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     ///   - completion: Closure to be called when the state change completes.
     @objc public func presentSheet(expandedState: BottomSheetExpansionState, animated: Bool = true, completion: ((_ isFinished: Bool) -> Void)? = nil) {
         let finishedState: BottomSheetExpansionState
+        let collapsedOrExpanded: BottomSheetExpansionState = supportsCollapsedState ? .collapsed : .expanded
 
         switch expandedState {
         case .collapsed:
-            finishedState = .collapsed
+            finishedState = collapsedOrExpanded
         case .expanded:
-            finishedState = isExpandable ? .expanded : .collapsed
+            finishedState = isExpandable ? .expanded : collapsedOrExpanded
         case .partial:
-            finishedState = isExpandable && supportsPartialExpansion ? .partial : .collapsed
+            finishedState = isExpandable && supportsPartialState ? .partial : collapsedOrExpanded
         // Safe fallback for any invalid target states
         default:
-            finishedState = .collapsed
+            finishedState = collapsedOrExpanded
         }
 
         if isViewLoaded {
@@ -497,7 +498,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         // If we are animating to one of the affected states, we need to retarget the animation.
         if targetExpansionState == .collapsed || (currentExpansionState == .collapsed && targetExpansionState == nil) {
             move(to: .collapsed)
-        } else if supportsPartialExpansion && (targetExpansionState == .partial || (currentExpansionState == .partial && targetExpansionState == nil)) {
+        } else if supportsPartialState && (targetExpansionState == .partial || (currentExpansionState == .partial && targetExpansionState == nil)) {
             move(to: .partial)
         }
     }
@@ -592,7 +593,16 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         // In the transitioning state a pan gesture or an animator temporarily owns the sheet frame updates,
         // so to avoid interfering we won't update the frame here.
         if currentExpansionState != .transitioning {
+            let needsRepositionToExpanded = isExpandable && (
+                (currentExpansionState == .partial && !supportsPartialState)
+                || (currentExpansionState == .collapsed && !supportsCollapsedState)
+            )
+            if needsRepositionToExpanded {
+                bottomSheetView.frame = sheetFrame(offset: offset(for: .expanded))
+                handleCompletedStateChange(to: .expanded, interaction: .noUserAction)
+            } else {
             bottomSheetView.frame = sheetFrame(offset: offset(for: currentExpansionState))
+            }
             updateSheetLayoutGuideTopConstraint()
             updateExpandedContentAlpha()
             updateDimmingViewAlpha()
@@ -857,11 +867,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     private func nextExpansionStateForResizingHandleTap(with currentExpansionState: BottomSheetExpansionState) -> BottomSheetExpansionState? {
         return switch currentExpansionState {
         case .collapsed:
-            supportsPartialExpansion ? .partial : .expanded
+            supportsPartialState ? .partial : .expanded
         case .partial:
             .expanded
         case .expanded:
-            allowsResizingHandleTapToHide ? .hidden : .collapsed
+            allowsResizingHandleTapToHide ? .hidden : supportsCollapsedState ? .collapsed : nil
         default:
             nil
         }
@@ -870,7 +880,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     private func updateExpandedContentAlpha() {
         let currentOffset = currentSheetVerticalOffset
         let collapsedOffset = offset(for: .collapsed)
-        let expandedOffset = supportsPartialExpansion ? offset(for: .partial) : offset(for: .expanded)
+        let expandedOffset = supportsPartialState ? offset(for: .partial) : offset(for: .expanded)
 
         var targetAlpha: CGFloat = 1.0
         if shouldHideCollapsedContent && !isHeightRestricted {
@@ -916,7 +926,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
             let currentOffset = currentSheetVerticalOffset
             let highestDimmedOffset = offset(for: .expanded)
-            let lowestUndimmedOffset = offset(for: isHeightRestricted ? .hidden : supportsPartialExpansion ? .partial : .collapsed)
+            let lowestUndimmedOffset = offset(for: isHeightRestricted ? .hidden : supportsPartialState ? .partial : .collapsed)
 
             if currentOffset <= highestDimmedOffset {
                 targetAlpha = 1.0
@@ -1111,8 +1121,8 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             // With a low velocity, we should snap to the closest state.
             let eligibleStates: [BottomSheetExpansionState?] = [
                 .expanded,
-                .collapsed,
-                supportsPartialExpansion ? .partial : nil,
+                supportsCollapsedState ? .collapsed : nil,
+                supportsPartialState ? .partial : nil,
                 allowsSwipeToHide ? .hidden : nil
             ]
 
@@ -1128,7 +1138,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             if currentSheetVerticalOffset > offset(for: .collapsed) && allowsSwipeToHide {
                 targetState = velocity > 0 ? .hidden : .collapsed
             } else {
-                if supportsPartialExpansion {
+                if supportsPartialState {
                     if velocity > 0 {
                         // Swiping down
                         targetState = currentSheetVerticalOffset > offset(for: .partial) ? .collapsed : .partial
@@ -1137,7 +1147,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                         targetState = currentSheetVerticalOffset > offset(for: .partial) ? .partial : .expanded
                     }
                 } else {
-                    targetState = velocity > 0 ? .collapsed : .expanded
+                    targetState = velocity > 0 && supportsCollapsedState ? .collapsed : .expanded
                 }
             }
         }
@@ -1151,6 +1161,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                       shouldNotifyDelegate: Bool = true,
                       allowUnhiding: Bool = false,
                       completion: ((UIViewAnimatingPosition) -> Void)? = nil) {
+        var targetExpansionState = targetExpansionState
+        if targetExpansionState == .partial && !supportsPartialState {
+            targetExpansionState = currentExpansionState == .expanded ? .collapsed : .expanded
+        }
+
         guard targetExpansionState == .hidden || !isHiddenOrHiding || allowUnhiding else {
             return
         }
@@ -1320,7 +1335,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 // Same here, in height restricted scenarios we want to utilize the space.
                 offset = minOffset
             } else {
-                offset = view.bounds.maxY - (resolvedDynamicSheetHeights?.partialHeight ?? collapsedSheetHeight)
+                offset = view.bounds.maxY - (partialSheetHeight ?? collapsedSheetHeight)
             }
         case .expanded:
             offset = minOffset
@@ -1425,6 +1440,15 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         return min(idealHeight, maxSheetHeight)
     }
 
+    // Height of the sheet in partial state, or nil if partial expansion is not supported.
+    private var partialSheetHeight: CGFloat? {
+        guard let partialHeight = resolvedDynamicSheetHeights?.partialHeight else {
+            return nil
+        }
+        let idealHeight = partialHeight + view.safeAreaInsets.bottom
+        return max(collapsedSheetHeight, min(idealHeight, maxSheetHeight))
+    }
+
     // Maximum total sheet height including parts outside of the safe area.
     private var maxSheetHeight: CGFloat {
         let maxHeight: CGFloat
@@ -1491,8 +1515,18 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         maxSheetHeight - collapsedSheetHeight < Constants.heightRestrictedThreshold
     }
 
-    private var supportsPartialExpansion: Bool {
-        partialHeightResolver != nil
+    private var supportsCollapsedState: Bool {
+        !(isHeightRestricted && isExpandable)
+    }
+
+    private var supportsPartialState: Bool {
+        guard supportsCollapsedState, let partialHeight = partialSheetHeight else {
+            return false
+        }
+        let threshold = Constants.partialDetentMergeThreshold
+        let distinctFromCollapsed = abs(partialHeight - collapsedSheetHeight) > threshold
+        let distinctFromExpanded = abs(partialHeight - expandedSheetHeight) > threshold
+        return distinctFromCollapsed && distinctFromExpanded
     }
 
     private var currentSheetVerticalOffset: CGFloat {
@@ -1536,6 +1570,10 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         // When the difference in collapsed height and max sheet height is less than this,
         // we go into height restricted mode which skips the collapsed state and adjusts dimming.
         static let heightRestrictedThreshold: CGFloat = 50
+
+        // When partial height is within this threshold of collapsed or expanded height,
+        // partial is considered redundant and is skipped as a distinct detent.
+        static let partialDetentMergeThreshold: CGFloat = 50
 
         struct Spring {
             // Spring used in slow swipes - no oscillation
@@ -1606,7 +1644,7 @@ extension BottomSheetController: UIGestureRecognizerDelegate {
             shouldBegin = abs(velocity.y) > abs(velocity.x)
         } else if let scrollView = hostedScrollView {
             let sheetOffset = currentSheetVerticalOffset
-            let targetOffset = offset(for: supportsPartialExpansion ? .partial : .expanded)
+            let targetOffset = offset(for: supportsPartialState ? .partial : .expanded)
             let isSufficientlyExpanded = sheetOffset <= targetOffset
 
             // If we're sufficiently expanded, we give the scroll view an opportunity to take over.


### PR DESCRIPTION
1. We saw a bug where the partial detent height wasn't accounting for bottom safe area.

2. While fixing that, I noticed we have a lot of bugs around detent availability in restricted height scenarios. Dynamic height resolvers can produce a partial height effectively equal to collapsed or expanded. This caused invisible state cycling on handle taps, incorrect pan snapping, and meaningless delegate notifications.

Add supportsCollapsedState and supportsPartialState computed properties that gate detent availability. Partial is skipped when its height is within a merge threshold of collapsed or expanded. Collapsed is skipped when the sheet is height-restricted. Layout changes that invalidate the current detent reposition the sheet to expanded with delegate notification.

### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2254)