### PR TITLE
Remove onChange_iOS17

### DIFF
--- a/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
+++ b/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
@@ -13,20 +13,6 @@ public extension View {
     func applyFluentShadow(shadowInfo: ShadowInfo) -> some View {
         modifier(ShadowModifier(shadowInfo: shadowInfo))
     }
-
-    /// Abstracts away differences in pre-iOS 17 `onChange(of:perform:)` versus post-iOS 17 `onChange(of:_:)`.
-    ///
-    /// This function will be removed once FluentUI moves to iOS 17 as a minimum target.
-    /// - Parameters:
-    ///   - value: The value to check against when determining whether to run the closure.
-    ///   - action: A closure to run when the value changes.
-    /// - Returns: A view that fires an action when the specified value changes.
-    @available(*, deprecated, message: "Please use the native onChange(of:_:) method instead.")
-    func onChange_iOS17<V>(of value: V, _ action: @escaping (V) -> Void) -> some View where V: Equatable {
-        return self.onChange(of: value) { _, newValue in
-            return action(newValue)
-        }
-    }
 }
 
 /// ViewModifier that applies both shadows from a ShadowInfo


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

`onChange_iOS17` has been deprecated for a while and ready to be deleted.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2263)