### PR TITLE
Exposed isScrollable

### DIFF
--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -225,7 +225,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 
     /// Whether or not the `CommandBar` is scrollable
-    public var isScrollable: Bool = true {
+    @objc public var isScrollable: Bool = true {
         didSet {
             updateViewHierarchy()
             updateMainCommandGroupsViewConstraints()


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes
Exposed the isScrollable property to objective c

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
Project builds

<details>
<summary>Visual Verification</summary>

N/A

</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2264)