### PR TITLE
Make CCB Truncate Button Text Before  Trying to Squish Buttons

### DIFF
--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarButton.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarButton.swift
@@ -106,6 +106,10 @@ class CommandBarButton: UIButton {
         configuration?.title = item.title
         configuration?.image = item.iconImage
 
+        if item.title != nil {
+            setContentHuggingPriority(.defaultLow, for: .horizontal)
+        }
+
         if let font = item.titleFont {
             let attributeContainer = AttributeContainer([NSAttributedString.Key.font: font])
             configuration?.attributedTitle?.setAttributes(attributeContainer)


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
This change makes it so titles in the CommandBar Buttons truncate before we start having to layout out buttons off the screen when the CommandBar is in a non scrollable mode.
To do this we set the content hugging priority of button with texts to be low leading to them getting truncated before buttons that do not have the capacity to be squished.

### Binary change
(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
Scrolling CommandBar had no behavioral changes.
Tested with a resizable view to see titles with text getting shrinked before other buttons.

<details>
<summary>Visual Verification</summary>
| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2265)