### PR TITLE
Add fluentGlassEffect modifier

### DIFF
--- a/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
+++ b/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
@@ -13,6 +13,28 @@ public extension View {
     func applyFluentShadow(shadowInfo: ShadowInfo) -> some View {
         modifier(ShadowModifier(shadowInfo: shadowInfo))
     }
+
+    /// Backwards compatible wrapper of the iOS26+ .glassEffect modifier
+    /// - On iOS 26 / macOS 26 and newer: applies `glassEffect()`.
+    /// - On older OSes and unsupported platforms: applies a background with `.regularMaterial` and `shadow08`, with the exception of older macOS versions where no background is applied
+    /// - Parameters:
+    ///   - interactive: Whether the glass effect should be interactive.
+    ///   - tint: The tint color to apply to the glass effect.
+    ///   - shape: The shape to apply the glass effect to.
+    /// - Returns: The modified view with the glass effect applied.
+    @ViewBuilder func fluentGlassEffect<T>(
+        interactive: Bool = false,
+        tint: Color? = nil,
+        in shape: T = Capsule()
+    ) -> some View where T: Shape {
+        self.modifier(
+            FluentGlassEffectModifier(
+                interactive: interactive,
+                tint: tint,
+                shape: shape
+            )
+        )
+    }
 }
 
 /// ViewModifier that applies both shadows from a ShadowInfo
@@ -36,3 +58,34 @@ private struct ShadowModifier: ViewModifier {
     }
 }
 
+private struct FluentGlassEffectModifier<T: Shape>: ViewModifier {
+    @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
+
+    let interactive: Bool
+    let tint: Color?
+    let shape: T
+
+    func body(content: Content) -> some View {
+        #if os(visionOS) || compiler(<6.2)
+        content
+            .background(.regularMaterial, in: shape)
+            .applyFluentShadow(shadowInfo: fluentTheme.shadow(.shadow08))
+        #elseif os(macOS)
+        if #available(macOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(interactive).tint(tint), in: shape)
+        } else {
+            content  // don't add any background
+        }
+        #else
+        if #available(iOS 26, *) {
+            content
+                .glassEffect(.regular.interactive(interactive).tint(tint), in: shape)
+        } else {
+            content
+                .background(.regularMaterial, in: shape)
+                .applyFluentShadow(shadowInfo: fluentTheme.shadow(.shadow08))
+        }
+        #endif
+    }
+}


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

`glassEffect` is unavailable on OSs < 26 and vision. Add a convenience modifier `fluentGlassEffect`. On older OSes and unsupported platforms, apply a background with `.regularMaterial` and `shadow08`.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2266)