### PR TITLE
[CommandBar] Add Glass Styling Support

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -159,6 +159,7 @@ class CommandBarDemoController: DemoController {
 
     var defaultCommandBar: CommandBar?
     var animateCommandBarDelegateEvents: Bool = false
+    var isGlassStyle: Bool = true
 
     lazy var textField: UITextField = {
         let textField = UITextField()
@@ -180,7 +181,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("Default"))
 
-        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+		let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
         commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
         container.addArrangedSubview(commandBar)
@@ -269,13 +270,21 @@ class CommandBarDemoController: DemoController {
         commandBarDelegateEventAnimationView.addArrangedSubview(commandBarDelegateEventAnimationSwitch)
         itemCustomizationContainer.addArrangedSubview(commandBarDelegateEventAnimationView)
 
+        let glassStyleStackView = createHorizontalStackView()
+        glassStyleStackView.addArrangedSubview(createLabelWithText("Glass Style"))
+        let glassStyleSwitch = BrandedSwitch()
+        glassStyleSwitch.isOn = isGlassStyle
+        glassStyleSwitch.addTarget(self, action: #selector(glassStyleValueChanged), for: .valueChanged)
+        glassStyleStackView.addArrangedSubview(glassStyleSwitch)
+        itemCustomizationContainer.addArrangedSubview(glassStyleStackView)
+
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
         container.addArrangedSubview(itemCustomizationContainer)
 
         container.addArrangedSubview(createLabelWithText("With Fixed Button"))
 
-        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+		let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
         fixedButtonCommandBar.translatesAutoresizingMaskIntoConstraints = false
         container.addArrangedSubview(fixedButtonCommandBar)
 
@@ -293,7 +302,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(textFieldContainer)
 
-        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
+		let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]],style: .glass)
         accessoryCommandBar.translatesAutoresizingMaskIntoConstraints = false
 #if os(iOS)
         textField.inputAccessoryView = accessoryCommandBar
@@ -468,6 +477,23 @@ class CommandBarDemoController: DemoController {
 
     @objc func animateCommandBarDelegateEventsValueChanged(sender: UISwitch!) {
         animateCommandBarDelegateEvents = sender.isOn
+    }
+
+    @objc func glassStyleValueChanged(sender: UISwitch!) {
+        isGlassStyle = sender.isOn
+        guard let commandBar = defaultCommandBar,
+              let stackView = commandBar.superview as? UIStackView,
+              let index = stackView.arrangedSubviews.firstIndex(of: commandBar) else {
+            return
+        }
+        let newCommandBar = CommandBar(itemGroups: createItemGroups(),
+                                       leadingItemGroups: [[newItem(for: .keyboard)]],
+                                       style: isGlassStyle ? .glass : .primary)
+        newCommandBar.delegate = self
+        newCommandBar.translatesAutoresizingMaskIntoConstraints = false
+        commandBar.removeFromSuperview()
+        stackView.insertArrangedSubview(newCommandBar, at: index)
+        defaultCommandBar = newCommandBar
     }
 
     @objc func refreshDefaultBarItems(sender: UIButton!) {

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -159,7 +159,6 @@ class CommandBarDemoController: DemoController {
 
     var defaultCommandBar: CommandBar?
     var animateCommandBarDelegateEvents: Bool = false
-    var isGlassStyle: Bool = true
 
     lazy var textField: UITextField = {
         let textField = UITextField()
@@ -181,7 +180,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("Default"))
 
-		let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
+        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
         commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
         container.addArrangedSubview(commandBar)
@@ -270,21 +269,13 @@ class CommandBarDemoController: DemoController {
         commandBarDelegateEventAnimationView.addArrangedSubview(commandBarDelegateEventAnimationSwitch)
         itemCustomizationContainer.addArrangedSubview(commandBarDelegateEventAnimationView)
 
-        let glassStyleStackView = createHorizontalStackView()
-        glassStyleStackView.addArrangedSubview(createLabelWithText("Glass Style"))
-        let glassStyleSwitch = BrandedSwitch()
-        glassStyleSwitch.isOn = isGlassStyle
-        glassStyleSwitch.addTarget(self, action: #selector(glassStyleValueChanged), for: .valueChanged)
-        glassStyleStackView.addArrangedSubview(glassStyleSwitch)
-        itemCustomizationContainer.addArrangedSubview(glassStyleStackView)
-
         itemCustomizationContainer.addArrangedSubview(UIView()) //Spacer
 
         container.addArrangedSubview(itemCustomizationContainer)
 
         container.addArrangedSubview(createLabelWithText("With Fixed Button"))
 
-		let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
+        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
         fixedButtonCommandBar.translatesAutoresizingMaskIntoConstraints = false
         container.addArrangedSubview(fixedButtonCommandBar)
 
@@ -302,7 +293,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(textFieldContainer)
 
-		let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]],style: .glass)
+        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
         accessoryCommandBar.translatesAutoresizingMaskIntoConstraints = false
 #if os(iOS)
         textField.inputAccessoryView = accessoryCommandBar
@@ -477,23 +468,6 @@ class CommandBarDemoController: DemoController {
 
     @objc func animateCommandBarDelegateEventsValueChanged(sender: UISwitch!) {
         animateCommandBarDelegateEvents = sender.isOn
-    }
-
-    @objc func glassStyleValueChanged(sender: UISwitch!) {
-        isGlassStyle = sender.isOn
-        guard let commandBar = defaultCommandBar,
-              let stackView = commandBar.superview as? UIStackView,
-              let index = stackView.arrangedSubviews.firstIndex(of: commandBar) else {
-            return
-        }
-        let newCommandBar = CommandBar(itemGroups: createItemGroups(),
-                                       leadingItemGroups: [[newItem(for: .keyboard)]],
-                                       style: isGlassStyle ? .glass : .primary)
-        newCommandBar.delegate = self
-        newCommandBar.translatesAutoresizingMaskIntoConstraints = false
-        commandBar.removeFromSuperview()
-        stackView.insertArrangedSubview(newCommandBar, at: index)
-        defaultCommandBar = newCommandBar
     }
 
     @objc func refreshDefaultBarItems(sender: UIButton!) {

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -180,7 +180,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("Default"))
 
-        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]])
+        let commandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
         commandBar.delegate = self
         commandBar.translatesAutoresizingMaskIntoConstraints = false
         container.addArrangedSubview(commandBar)
@@ -275,7 +275,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(createLabelWithText("With Fixed Button"))
 
-        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]])
+        let fixedButtonCommandBar = CommandBar(itemGroups: createItemGroups(), leadingItemGroups: [[newItem(for: .copy)]], trailingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
         fixedButtonCommandBar.translatesAutoresizingMaskIntoConstraints = false
         container.addArrangedSubview(fixedButtonCommandBar)
 
@@ -293,7 +293,7 @@ class CommandBarDemoController: DemoController {
 
         container.addArrangedSubview(textFieldContainer)
 
-        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]])
+        let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
         accessoryCommandBar.translatesAutoresizingMaskIntoConstraints = false
 #if os(iOS)
         textField.inputAccessoryView = accessoryCommandBar

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -78,10 +78,21 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
                   trailingItemGroups: trailingItems)
     }
 
+    @objc public convenience init(itemGroups: [CommandBarItemGroup],
+                                  leadingItemGroups: [CommandBarItemGroup]? = nil,
+                                  trailingItemGroups: [CommandBarItemGroup]? = nil) {
+        self.init(itemGroups: itemGroups,
+                  leadingItemGroups: leadingItemGroups,
+                  trailingItemGroups: trailingItemGroups,
+                  style: .primary)
+    }
+
     @objc public init(itemGroups: [CommandBarItemGroup],
                       leadingItemGroups: [CommandBarItemGroup]? = nil,
-                      trailingItemGroups: [CommandBarItemGroup]? = nil) {
-        self.tokenSet = CommandBarTokenSet()
+                      trailingItemGroups: [CommandBarItemGroup]? = nil,
+                      style: CommandBarStyle) {
+        self.style = style
+        self.tokenSet = CommandBarTokenSet(style: { style })
 
         leadingCommandGroupsView = CommandBarCommandGroupsView(itemGroups: leadingItemGroups,
                                                                buttonsPersistSelection: false,
@@ -104,6 +115,9 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         super.init(frame: .zero)
 
         configureHierarchy()
+        if style == .glass {
+            setupGlassBackground()
+        }
         updateBackgroundColor()
         updateShadow()
 
@@ -159,6 +173,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
 
         updateShadow()
         updateScrollViewShadow()
+        updateCornerRadius()
     }
 
 #if DEBUG
@@ -190,6 +205,9 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
 
     public typealias TokenSetKeyType = CommandBarTokenSet.Tokens
     public var tokenSet: CommandBarTokenSet
+
+    /// The visual style of the CommandBar.
+    public let style: CommandBarStyle
 
     /// Items shown in the center of the CommandBar
     @objc public var itemGroups: [CommandBarItemGroup] {
@@ -245,6 +263,8 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     public weak var delegate: CommandBarDelegate?
 
     // MARK: - Private properties
+
+    private var glassEffectView: UIVisualEffectView?
 
     /// Container UIStackView that holds the leading, main and trailing views
     private var commandBarContainerStackView: UIStackView
@@ -424,18 +444,97 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 
     private func updateShadow() {
-        let shadowInfo = tokenSet[.shadow].shadowInfo
-        shadowInfo.applyShadow(to: self)
+        switch style {
+        case .primary:
+            let shadowInfo = tokenSet[.shadow].shadowInfo
+            shadowInfo.applyShadow(to: self)
+        case .glass:
+            layer.shadowColor   = UIColor.black.cgColor
+            layer.shadowOpacity = 0.25
+            layer.shadowOffset  = CGSize(width: 0, height: -2)
+            layer.shadowRadius  = 8
+        }
     }
 
     private func updateBackgroundColor() {
-        backgroundColor = tokenSet[.backgroundColor].uiColor
+        switch style {
+        case .primary:
+            backgroundColor = tokenSet[.backgroundColor].uiColor
+        case .glass:
+            backgroundColor = .clear
+#if !os(visionOS)
+            if #available(iOS 26, *), let effectView = glassEffectView {
+                let glassEffect = UIGlassEffect(style: .regular)
+                glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
+                effectView.effect = glassEffect
+            }
+#endif
+        }
     }
 
     private func updateButtonTokens() {
         leadingCommandGroupsView.updateButtonsShown()
         mainCommandGroupsView.updateButtonsShown()
         trailingCommandGroupsView.updateButtonsShown()
+    }
+
+    private func setupGlassBackground() {
+        var effectView: UIVisualEffectView
+#if os(visionOS)
+        effectView = getBlurEffectView()
+#else
+        if #available(iOS 26, *) {
+            effectView = getGlassEffectView()
+        } else {
+            effectView = getBlurEffectView()
+        }
+#endif
+        effectView.translatesAutoresizingMaskIntoConstraints = false
+        commandBarContainerStackView.insertSubview(effectView, at: 0)
+        pinEffectView(effectView, to: commandBarContainerStackView)
+        commandBarContainerStackView.backgroundColor = .clear
+        glassEffectView = effectView
+    }
+
+#if !os(visionOS)
+    @available(iOS 26, *)
+    private func getGlassEffectView() -> UIVisualEffectView {
+        let effectView = UIVisualEffectView()
+        let glassEffect = UIGlassEffect(style: .regular)
+        glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
+        effectView.effect = glassEffect
+        return effectView
+    }
+#endif // !os(visionOS)
+
+    private func getBlurEffectView() -> UIVisualEffectView {
+        let effectView = UIVisualEffectView()
+        effectView.effect = UIBlurEffect(style: .systemMaterial)
+        effectView.layer.masksToBounds = true
+        return effectView
+    }
+
+    private func updateCornerRadius() {
+        guard style == .glass, let effectView = glassEffectView else { return }
+        let cornerRadius = bounds.height / 2
+#if !os(visionOS)
+        if #available(iOS 26, *) {
+            effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))
+        } else {
+            effectView.layer.cornerRadius = cornerRadius
+        }
+#else
+        effectView.layer.cornerRadius = cornerRadius
+#endif
+    }
+
+    private func pinEffectView(_ view: UIView, to container: UIView) {
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: container.topAnchor),
+            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
+        ])
     }
 
     /// Updates the provided `CommandBarCommandGroupsView` with the `items` array and marks the view as needing a layout

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -488,7 +488,17 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 
     private func setupGlassBackground() {
-        let effectView = makeEffectView()
+        let effectView = UIVisualEffectView()
+        effectView.effect = UIBlurEffect(style: .systemMaterial)
+        effectView.layer.masksToBounds = true
+#if !os(visionOS)
+        if #available(iOS 26, *) {
+            let glassEffect = UIGlassEffect(style: .regular)
+            glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
+            effectView.effect = glassEffect
+            effectView.layer.masksToBounds = false
+        }
+#endif
         effectView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(effectView)
         NSLayoutConstraint.activate([
@@ -508,23 +518,6 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         ])
 
         glassEffectView = effectView
-    }
-
-    private func makeEffectView() -> UIVisualEffectView {
-        let effectView = UIVisualEffectView()
-        effectView.effect = UIBlurEffect(style: .systemMaterial)
-        effectView.layer.masksToBounds = true
-
-#if !os(visionOS)
-        if #available(iOS 26, *) {
-            let glassEffect = UIGlassEffect(style: .regular)
-            glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
-            effectView.effect = glassEffect
-            effectView.layer.masksToBounds = false
-        }
-#endif
-
-        return effectView
     }
 
     private func updateCornerRadius() {

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -488,16 +488,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 
     private func setupGlassBackground() {
-        var effectView: UIVisualEffectView
-#if os(visionOS)
-        effectView = makeBlurEffectView()
-#else
-        if #available(iOS 26, *) {
-            effectView = makeGlassEffectView()
-        } else {
-            effectView = makeBlurEffectView()
-        }
-#endif
+        let effectView = makeEffectView()
         effectView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(effectView)
         NSLayoutConstraint.activate([
@@ -519,21 +510,20 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         glassEffectView = effectView
     }
 
-#if !os(visionOS)
-    @available(iOS 26, *)
-    private func makeGlassEffectView() -> UIVisualEffectView {
-        let effectView = UIVisualEffectView()
-        let glassEffect = UIGlassEffect(style: .regular)
-        glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
-        effectView.effect = glassEffect
-        return effectView
-    }
-#endif // !os(visionOS)
-
-    private func makeBlurEffectView() -> UIVisualEffectView {
+    private func makeEffectView() -> UIVisualEffectView {
         let effectView = UIVisualEffectView()
         effectView.effect = UIBlurEffect(style: .systemMaterial)
         effectView.layer.masksToBounds = true
+
+#if !os(visionOS)
+        if #available(iOS 26, *) {
+            let glassEffect = UIGlassEffect(style: .regular)
+            glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
+            effectView.effect = glassEffect
+            effectView.layer.masksToBounds = false
+        }
+#endif
+
         return effectView
     }
 

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -115,9 +115,11 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         super.init(frame: .zero)
 
         configureHierarchy()
+
         if style == .glass {
             setupGlassBackground()
         }
+
         updateBackgroundColor()
         updateShadow()
 
@@ -449,10 +451,10 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
             let shadowInfo = tokenSet[.shadow].shadowInfo
             shadowInfo.applyShadow(to: self)
         case .glass:
-            layer.shadowColor   = UIColor.black.cgColor
-            layer.shadowOpacity = 0.25
-            layer.shadowOffset  = CGSize(width: 0, height: -2)
-            layer.shadowRadius  = 8
+            layer.shadowColor   = CommandBarTokenSet.glassEffectShadowColor
+            layer.shadowOpacity = CommandBarTokenSet.glassEffectShadowOpacity
+            layer.shadowOffset  = CommandBarTokenSet.glassEffectShadowOffset
+            layer.shadowRadius  = CommandBarTokenSet.glassEffectShadowRadius
         }
     }
 
@@ -491,7 +493,12 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
 #endif
         effectView.translatesAutoresizingMaskIntoConstraints = false
         commandBarContainerStackView.insertSubview(effectView, at: 0)
-        pinEffectView(effectView, to: commandBarContainerStackView)
+        NSLayoutConstraint.activate([
+            effectView.topAnchor.constraint(equalTo: commandBarContainerStackView.topAnchor),
+            effectView.leadingAnchor.constraint(equalTo: commandBarContainerStackView.leadingAnchor),
+            effectView.bottomAnchor.constraint(equalTo: commandBarContainerStackView.bottomAnchor),
+            effectView.trailingAnchor.constraint(equalTo: commandBarContainerStackView.trailingAnchor)
+        ])
         commandBarContainerStackView.backgroundColor = .clear
         glassEffectView = effectView
     }
@@ -515,26 +522,15 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 
     private func updateCornerRadius() {
-        guard style == .glass, let effectView = glassEffectView else { return }
-        let cornerRadius = bounds.height / 2
-#if !os(visionOS)
-        if #available(iOS 26, *) {
-            effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))
-        } else {
-            effectView.layer.cornerRadius = cornerRadius
-        }
-#else
-        effectView.layer.cornerRadius = cornerRadius
-#endif
-    }
+        if style == .glass, let effectView = glassEffectView {
+            let cornerRadius = bounds.height / 2
 
-    private func pinEffectView(_ view: UIView, to container: UIView) {
-        NSLayoutConstraint.activate([
-            view.topAnchor.constraint(equalTo: container.topAnchor),
-            view.leadingAnchor.constraint(equalTo: container.leadingAnchor),
-            view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
-            view.trailingAnchor.constraint(equalTo: container.trailingAnchor)
-        ])
+            if #available(iOS 26, visionOS 26, *) {
+                effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))
+            } else {
+                effectView.layer.cornerRadius = cornerRadius
+            }
+        }
     }
 
     /// Updates the provided `CommandBarCommandGroupsView` with the `items` array and marks the view as needing a layout

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -168,9 +168,6 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     public override func layoutSubviews() {
         super.layoutSubviews()
 
-        let cornerRadius = commandBarContainerStackView.bounds.height / 2
-        layer.cornerRadius = cornerRadius
-        commandBarContainerStackView.layer.cornerRadius = cornerRadius
         commandBarContainerStackView.layoutIfNeeded()
 
         updateShadow()
@@ -346,8 +343,6 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         leadingCommandGroupsView.isHidden = leadingCommandGroupsView.itemGroups.isEmpty
         trailingCommandGroupsView.isHidden = trailingCommandGroupsView.itemGroups.isEmpty
 
-        addSubview(commandBarContainerStackView)
-
         commandBarContainerStackView.addArrangedSubview(leadingCommandGroupsView)
         commandBarContainerStackView.addArrangedSubview(containerView)
         commandBarContainerStackView.addArrangedSubview(trailingCommandGroupsView)
@@ -356,12 +351,15 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         updateViewHierarchy()
         updateMainCommandGroupsViewConstraints()
 
-        NSLayoutConstraint.activate([
-            commandBarContainerStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            commandBarContainerStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            commandBarContainerStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-            commandBarContainerStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
-        ])
+        if style == .primary {
+            addSubview(commandBarContainerStackView)
+            NSLayoutConstraint.activate([
+                commandBarContainerStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+                commandBarContainerStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+                commandBarContainerStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+                commandBarContainerStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+            ])
+        }
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
@@ -451,10 +449,19 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
             let shadowInfo = tokenSet[.shadow].shadowInfo
             shadowInfo.applyShadow(to: self)
         case .glass:
+#if !os(visionOS)
+            if #unavailable(iOS 26) {
+                layer.shadowColor   = CommandBarTokenSet.glassEffectShadowColor
+                layer.shadowOpacity = CommandBarTokenSet.glassEffectShadowOpacity
+                layer.shadowOffset  = CommandBarTokenSet.glassEffectShadowOffset
+                layer.shadowRadius  = CommandBarTokenSet.glassEffectShadowRadius
+            }
+#else
             layer.shadowColor   = CommandBarTokenSet.glassEffectShadowColor
             layer.shadowOpacity = CommandBarTokenSet.glassEffectShadowOpacity
             layer.shadowOffset  = CommandBarTokenSet.glassEffectShadowOffset
             layer.shadowRadius  = CommandBarTokenSet.glassEffectShadowRadius
+#endif
         }
     }
 
@@ -483,29 +490,38 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     private func setupGlassBackground() {
         var effectView: UIVisualEffectView
 #if os(visionOS)
-        effectView = getBlurEffectView()
+        effectView = makeBlurEffectView()
 #else
         if #available(iOS 26, *) {
-            effectView = getGlassEffectView()
+            effectView = makeGlassEffectView()
         } else {
-            effectView = getBlurEffectView()
+            effectView = makeBlurEffectView()
         }
 #endif
         effectView.translatesAutoresizingMaskIntoConstraints = false
-        commandBarContainerStackView.insertSubview(effectView, at: 0)
+        addSubview(effectView)
         NSLayoutConstraint.activate([
-            effectView.topAnchor.constraint(equalTo: commandBarContainerStackView.topAnchor),
-            effectView.leadingAnchor.constraint(equalTo: commandBarContainerStackView.leadingAnchor),
-            effectView.bottomAnchor.constraint(equalTo: commandBarContainerStackView.bottomAnchor),
-            effectView.trailingAnchor.constraint(equalTo: commandBarContainerStackView.trailingAnchor)
+            effectView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            effectView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            effectView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            effectView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
         ])
-        commandBarContainerStackView.backgroundColor = .clear
+
+        let contentView = effectView.contentView
+        contentView.addSubview(commandBarContainerStackView)
+        NSLayoutConstraint.activate([
+            commandBarContainerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            commandBarContainerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            commandBarContainerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            commandBarContainerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+        ])
+
         glassEffectView = effectView
     }
 
 #if !os(visionOS)
     @available(iOS 26, *)
-    private func getGlassEffectView() -> UIVisualEffectView {
+    private func makeGlassEffectView() -> UIVisualEffectView {
         let effectView = UIVisualEffectView()
         let glassEffect = UIGlassEffect(style: .regular)
         glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
@@ -514,7 +530,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 #endif // !os(visionOS)
 
-    private func getBlurEffectView() -> UIVisualEffectView {
+    private func makeBlurEffectView() -> UIVisualEffectView {
         let effectView = UIVisualEffectView()
         effectView.effect = UIBlurEffect(style: .systemMaterial)
         effectView.layer.masksToBounds = true
@@ -522,9 +538,11 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     }
 
     private func updateCornerRadius() {
-        if style == .glass, let effectView = glassEffectView {
-            let cornerRadius = commandBarContainerStackView.bounds.height / 2
+        let cornerRadius = commandBarContainerStackView.bounds.height / 2
+        layer.cornerRadius = cornerRadius
+        commandBarContainerStackView.layer.cornerRadius = cornerRadius
 
+        if style == .glass, let effectView = glassEffectView {
             if #available(iOS 26, visionOS 26, *) {
                 effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))
             } else {

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -115,11 +115,6 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         super.init(frame: .zero)
 
         configureHierarchy()
-
-        if style == .glass {
-            setupGlassBackground()
-        }
-
         updateBackgroundColor()
         updateShadow()
 
@@ -351,15 +346,41 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         updateViewHierarchy()
         updateMainCommandGroupsViewConstraints()
 
-        if style == .primary {
-            addSubview(commandBarContainerStackView)
+        let rootView: UIView
+        switch style {
+        case .primary:
+            rootView = commandBarContainerStackView
+        case .glass:
+            let effectView = UIVisualEffectView()
+            effectView.effect = UIBlurEffect(style: .systemMaterial)
+            effectView.layer.masksToBounds = true
+#if !os(visionOS)
+            if #available(iOS 26, *) {
+                let glassEffect = UIGlassEffect(style: .regular)
+                glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
+                effectView.effect = glassEffect
+                effectView.layer.masksToBounds = false
+            }
+#endif
+            effectView.translatesAutoresizingMaskIntoConstraints = false
+            let contentView = effectView.contentView
+            contentView.addSubview(commandBarContainerStackView)
             NSLayoutConstraint.activate([
-                commandBarContainerStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-                commandBarContainerStackView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-                commandBarContainerStackView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-                commandBarContainerStackView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+                commandBarContainerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
+                commandBarContainerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                commandBarContainerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+                commandBarContainerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
             ])
+            glassEffectView = effectView
+            rootView = effectView
         }
+        addSubview(rootView)
+        NSLayoutConstraint.activate([
+            rootView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            rootView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
+            rootView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
+            rootView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+        ])
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {
             // Flip the scroll view to invert scrolling direction. Flip its content back because it's already in RTL.
@@ -485,39 +506,6 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         leadingCommandGroupsView.updateButtonsShown()
         mainCommandGroupsView.updateButtonsShown()
         trailingCommandGroupsView.updateButtonsShown()
-    }
-
-    private func setupGlassBackground() {
-        let effectView = UIVisualEffectView()
-        effectView.effect = UIBlurEffect(style: .systemMaterial)
-        effectView.layer.masksToBounds = true
-#if !os(visionOS)
-        if #available(iOS 26, *) {
-            let glassEffect = UIGlassEffect(style: .regular)
-            glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
-            effectView.effect = glassEffect
-            effectView.layer.masksToBounds = false
-        }
-#endif
-        effectView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(effectView)
-        NSLayoutConstraint.activate([
-            effectView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            effectView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            effectView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-            effectView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
-        ])
-
-        let contentView = effectView.contentView
-        contentView.addSubview(commandBarContainerStackView)
-        NSLayoutConstraint.activate([
-            commandBarContainerStackView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            commandBarContainerStackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-            commandBarContainerStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
-            commandBarContainerStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
-        ])
-
-        glassEffectView = effectView
     }
 
     private func updateCornerRadius() {

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -472,10 +472,10 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         case .glass:
             backgroundColor = .clear
 #if !os(visionOS)
-            if #available(iOS 26, *), let effectView = glassEffectView {
+            if #available(iOS 26, *), let glassEffectView {
                 let glassEffect = UIGlassEffect(style: .regular)
                 glassEffect.tintColor = tokenSet[.backgroundColor].uiColor
-                effectView.effect = glassEffect
+                glassEffectView.effect = glassEffect
             }
 #endif
         }
@@ -542,11 +542,11 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         layer.cornerRadius = cornerRadius
         commandBarContainerStackView.layer.cornerRadius = cornerRadius
 
-        if style == .glass, let effectView = glassEffectView {
+        if style == .glass, let glassEffectView {
             if #available(iOS 26, visionOS 26, *) {
-                effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))
+                glassEffectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))
             } else {
-                effectView.layer.cornerRadius = cornerRadius
+                glassEffectView.layer.cornerRadius = cornerRadius
             }
         }
     }

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -168,7 +168,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
     public override func layoutSubviews() {
         super.layoutSubviews()
 
-        let cornerRadius = bounds.height / 2
+        let cornerRadius = commandBarContainerStackView.bounds.height / 2
         layer.cornerRadius = cornerRadius
         commandBarContainerStackView.layer.cornerRadius = cornerRadius
         commandBarContainerStackView.layoutIfNeeded()
@@ -523,7 +523,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
 
     private func updateCornerRadius() {
         if style == .glass, let effectView = glassEffectView {
-            let cornerRadius = bounds.height / 2
+            let cornerRadius = commandBarContainerStackView.bounds.height / 2
 
             if #available(iOS 26, visionOS 26, *) {
                 effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(cornerRadius))

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
@@ -8,6 +8,15 @@ import FluentUI_common
 #endif
 import UIKit
 
+@objc(MSFCommandBarStyle)
+public enum CommandBarStyle: Int {
+    /// Default style — solid background color.
+    case primary
+
+    /// Glass material background (UIGlassEffect on iOS 26+, UIBlurEffect on earlier).
+    case glass
+}
+
 public enum CommandBarToken: Int, TokenSetKey {
     /// The background color of the Command Bar.
     case backgroundColor
@@ -57,11 +66,19 @@ public enum CommandBarToken: Int, TokenSetKey {
 
 /// Design token set for the `CommandBar` control.
 public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
-    init() {
-        super.init { token, theme in
+    init(style: @escaping () -> CommandBarStyle) {
+        self.style = style
+        super.init { [style] token, theme in
             switch token {
             case .backgroundColor:
-                return .uiColor { theme.color(.background2) }
+                return .uiColor {
+                    switch style() {
+                    case .primary:
+                        return theme.color(.background2)
+                    case .glass:
+                        return .clear
+                    }
+                }
 
             case .cornerRadius:
                 return .float { GlobalTokens.corner(.radius120) }
@@ -107,6 +124,8 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
             }
         }
     }
+
+    var style: () -> CommandBarStyle
 }
 
 // MARK: - Constants

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
@@ -132,7 +132,7 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
 extension CommandBarTokenSet {
     static let glassEffectShadowColor: CGColor = UIColor.black.cgColor
     static let glassEffectShadowOpacity: Float = 0.25
-    static let glassEffectShadowOffset: CGSize = CGSize(width: 0, height: -2)
+    static let glassEffectShadowOffset: CGSize = CGSize(width: 0, height: 2)
     static let glassEffectShadowRadius: CGFloat = 8
 }
 

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
@@ -128,6 +128,14 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
     var style: () -> CommandBarStyle
 }
 
+// MARK: Constants
+extension CommandBarTokenSet {
+    static let glassEffectShadowColor: CGColor = UIColor.black.cgColor
+    static let glassEffectShadowOpacity: Float = 0.25
+    static let glassEffectShadowOffset: CGSize = CGSize(width: 0, height: -2)
+    static let glassEffectShadowRadius: CGFloat = 8
+}
+
 // MARK: - Constants
 
 extension CommandBarTokenSet {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes
Introduces a new CommmandBarStyle  .primary and .glass  to style the CommandBar using UIGlassEffect on iOS26 and UIBlurEffect on older OS. The styling also adjust the shadows to match the glass style.


Change also includes a minor bug fix to the corner radius calculation so we get full half circles in command bars that try and layout below the safe area which previously could be seen in the DemoController Accessaory Input View when the soft keyboard was not showing

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/14f73e8a-46d2-4381-830b-926313524dcb" /> | <img width="1320" height="2868" alt="image" src="https://github.com/user-attachments/assets/9b5c1be3-0156-4fee-977c-cf7d34897ff1" />  |
</details>

### Pull request checklist

This PR has considered:
- [X] iOS supported versions (all major versions greater than or equal current target deployment version)
- [X] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [X] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2267)