### PR TITLE
Fix Command Bar Title Compression

### DIFF
--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarButton.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarButton.swift
@@ -107,7 +107,7 @@ class CommandBarButton: UIButton {
         configuration?.image = item.iconImage
 
         if item.title != nil {
-            setContentHuggingPriority(.defaultLow, for: .horizontal)
+            setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         }
 
         if let font = item.titleFont {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
Fixed truncation logic in CommandBar by switching from low contentHuggingPriority to low contentCompressionResistancePriority. We want compression resistance because we want titles to shrink before we try and push other buttons off the screen.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
Validated in test app that titles shrink correctly.


### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2268)