### PR TITLE
[CommandBar] Removed safe area checking from command bar

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/CommandBarDemoController.swift
@@ -296,7 +296,16 @@ class CommandBarDemoController: DemoController {
         let accessoryCommandBar = CommandBar(itemGroups: createItemGroups(), trailingItemGroups: [[newItem(for: .keyboard)]], style: .glass)
         accessoryCommandBar.translatesAutoresizingMaskIntoConstraints = false
 #if os(iOS)
-        textField.inputAccessoryView = accessoryCommandBar
+        let accessoryInputView = UIView()
+        accessoryInputView.autoresizingMask = .flexibleHeight
+        accessoryInputView.addSubview(accessoryCommandBar)
+        NSLayoutConstraint.activate([
+            accessoryCommandBar.topAnchor.constraint(equalTo: accessoryInputView.topAnchor),
+            accessoryCommandBar.leadingAnchor.constraint(equalTo: accessoryInputView.leadingAnchor),
+            accessoryCommandBar.trailingAnchor.constraint(equalTo: accessoryInputView.trailingAnchor),
+            accessoryCommandBar.bottomAnchor.constraint(equalTo: accessoryInputView.safeAreaLayoutGuide.bottomAnchor)
+        ])
+        textField.inputAccessoryView = accessoryInputView
 #endif
     }
 

--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBar.swift
@@ -110,6 +110,7 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         commandBarContainerStackView.axis = .horizontal
         commandBarContainerStackView.translatesAutoresizingMaskIntoConstraints = false
         commandBarContainerStackView.isLayoutMarginsRelativeArrangement = true
+		commandBarContainerStackView.insetsLayoutMarginsFromSafeArea = false
         commandBarContainerStackView.clipsToBounds = true
 
         super.init(frame: .zero)
@@ -376,10 +377,10 @@ public class CommandBar: UIView, Shadowable, TokenizedControl {
         }
         addSubview(rootView)
         NSLayoutConstraint.activate([
-            rootView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
-            rootView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor),
-            rootView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
-            rootView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor)
+            rootView.topAnchor.constraint(equalTo: topAnchor),
+            rootView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            rootView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            rootView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ])
 
         if UIView.userInterfaceLayoutDirection(for: semanticContentAttribute) == .rightToLeft {


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes
Update the command bar to not make any adjustments internally to layout according to safe area. It should not be the responsibility of the command bar to know about the safe area. It internally should just layout its views as instructed by whoever owns it. The owner of the Command Bar should instead layout the Command Bar to stay out of the safe area. This is needed because currently clients have no way to position the Command Bar inside the unsafe area if they wanted to do something like animate the command bar into its position in the safe area.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification
Confirmed that the command bar buttons do not get squished when animating in from the unsafe area into the safe area.

<details>
<summary>Visual Verification</summary>
No change

</details>

### Pull request checklist

This PR has considered:
- [X] Internationalization and Right to Left layouts
- [X] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [X] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2270)