### PR TITLE
[Xcode 27] Capture state as weak before any uses

### DIFF
--- a/Sources/FluentUI_iOS/Components/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/Sources/FluentUI_iOS/Components/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -101,13 +101,14 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
         tokenSet.update(fluentTheme)
         return SwiftUI.ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 0) {
-                ForEach(state.buttons, id: \.self) { buttonState in
-                    PersonaButton(state: buttonState) { [weak state] in
-                        guard let strongState = state,
-                              let index = strongState.buttons.firstIndex(of: buttonState) else {
-                            return
+                if let strongState = state {
+                    ForEach(strongState.buttons, id: \.self) { buttonState in
+                        PersonaButton(state: buttonState) {
+                            guard let index = strongState.buttons.firstIndex(of: buttonState) else {
+                                return
+                            }
+                            strongState.onTapAction?(buttonState, index)
                         }
-                        strongState.onTapAction?(buttonState, index)
                     }
                 }
             }

--- a/Sources/FluentUI_iOS/Components/PersonaButtonCarousel/PersonaButtonCarousel.swift
+++ b/Sources/FluentUI_iOS/Components/PersonaButtonCarousel/PersonaButtonCarousel.swift
@@ -100,7 +100,7 @@ public struct PersonaButtonCarousel: View, TokenizedControlView {
     public var body: some View {
         tokenSet.update(fluentTheme)
         return SwiftUI.ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 0) {
+            HStack(spacing: 0) { [weak state] in
                 if let strongState = state {
                     ForEach(strongState.buttons, id: \.self) { buttonState in
                         PersonaButton(state: buttonState) {


### PR DESCRIPTION
The code was capturing state as weak after already using it, and Xcode 27 now complains of the mixed strong and weak usage. Move the capture up to the HStack itself rather than in the ForEach of the stack's buttons, and use it appropriately inside.

### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

(a summary of the changes made, often organized by file)

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

(how the change was tested, including both manual and automated tests)

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2271)