### PR TITLE
Visual updates to message bar macOS

### DIFF
--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestMessageBarController.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestMessageBarController.swift
@@ -9,16 +9,29 @@ import SwiftUI
 
 /// Test view controller for the MessageBar class
 class TestMessageBarController: NSViewController {
+	private let stackingView = MessageBarStackHostingView()
+
 	override func viewDidLoad() {
-		let stackingView = MessageBarStackHostingView()
 		stackingView.translatesAutoresizingMaskIntoConstraints = false
 
 		view.addSubview(stackingView)
+
+		let toggleButton = NSButton(
+			title: "Draw top divider",
+			target: self,
+			action: #selector(toggleDrawsTopDivider(_:))
+		)
+		toggleButton.setButtonType(.switch)
+		toggleButton.state = .on
+		toggleButton.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(toggleButton)
 
 		view.addConstraints([
 			view.leadingAnchor.constraint(equalTo: stackingView.leadingAnchor),
 			view.trailingAnchor.constraint(equalTo: stackingView.trailingAnchor),
 			view.topAnchor.constraint(equalTo: stackingView.topAnchor),
+			toggleButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
+			toggleButton.topAnchor.constraint(equalTo: stackingView.bottomAnchor, constant: 16),
 		])
 
 		for ii in 0..<3 {
@@ -41,5 +54,9 @@ class TestMessageBarController: NSViewController {
 			stackingView.showBar(barID: ii)
 		}
 		stackingView.updateLayout()
+	}
+
+	@objc private func toggleDrawsTopDivider(_ sender: NSButton) {
+		stackingView.drawsTopDivider = (sender.state == .on)
 	}
 }

--- a/Sources/FluentUI_macOS/Components/MessageBar/MessageBar.swift
+++ b/Sources/FluentUI_macOS/Components/MessageBar/MessageBar.swift
@@ -33,11 +33,6 @@ public struct MessageBar: View, TokenizedControlView {
 		.padding([.horizontal], GlobalTokens.spacing(.size120))
 		.frame(height: GlobalTokens.spacing(.size280))
 		.background(tokenSet[.backgroundColor].color)
-		.overlay(alignment: .top) {
-			Rectangle()
-				.fill(tokenSet[.dividerColor].color)
-				.frame(height: 1.0)
-		}
 	}
 
 	@ViewBuilder

--- a/Sources/FluentUI_macOS/Components/MessageBar/MessageBarStack.swift
+++ b/Sources/FluentUI_macOS/Components/MessageBar/MessageBarStack.swift
@@ -19,6 +19,11 @@ public class MessageBarStackViewModel: ObservableObject {
 
 	@Published public var bars: [BarItem] = []
 
+	/// When `true`, the stack draws a 1pt divider line above the topmost visible
+	/// bar. Inter-bar dividers between adjacent visible bars are always drawn.
+	/// Defaults to `true`.
+	@Published public var drawsTopDivider: Bool = true
+
 	public var targetContentHeight: CGFloat {
 		let visibleCount = bars.filter { $0.isVisible }.count
 		return CGFloat(visibleCount) * MessageBar.fixedHeight
@@ -29,10 +34,22 @@ public struct MessageBarStack: View {
 	@ObservedObject public var viewModel: MessageBarStackViewModel
 
 	public var body: some View {
+		let visibleBars = viewModel.bars.filter { $0.isVisible }
 		VStack(spacing: 0) {
-			ForEach(viewModel.bars.filter { $0.isVisible }) { bar in
+			ForEach(Array(visibleBars.enumerated()), id: \.element.id) { index, bar in
 				MessageBar(bar.configuration)
+					.overlay(alignment: .top) {
+						// Inter-bar dividers are drawn unconditionally; the topmost
+						// bar's divider is gated on `drawsTopDivider`.
+						if index > 0 || viewModel.drawsTopDivider {
+							Rectangle()
+								.fill(tokenSet[.dividerColor].color)
+								.frame(height: 1.0)
+						}
+					}
 			}
 		}
 	}
+
+	private let tokenSet: MessageBarTokenSet = .init()
 }

--- a/Sources/FluentUI_macOS/Components/MessageBar/MessageBarStackHostingView.swift
+++ b/Sources/FluentUI_macOS/Components/MessageBar/MessageBarStackHostingView.swift
@@ -109,6 +109,14 @@ public final class MessageBarStackHostingView: ControlHostingView {
 		viewModel.bars.removeAll { $0.id == barID }
 	}
 
+	/// Controls whether the stack draws its 1pt divider above the topmost visible
+	/// bar. Inter-bar dividers between adjacent visible bars are always drawn.
+	/// Defaults to `true`.
+	@objc public var drawsTopDivider: Bool {
+		get { viewModel.drawsTopDivider }
+		set { viewModel.drawsTopDivider = newValue }
+	}
+
 	private var heightConstraint: NSLayoutConstraint?
 	private let viewModel: MessageBarStackViewModel
 }

--- a/Sources/FluentUI_macOS/Components/MessageBar/MessageBarTokenSet.swift
+++ b/Sources/FluentUI_macOS/Components/MessageBar/MessageBarTokenSet.swift
@@ -9,7 +9,8 @@ public enum MessageBarToken: Int, TokenSetKey {
 	/// The background color of the `MessageBar`.
 	case backgroundColor
 
-	/// The color of the 1pt divider line at the top of the `MessageBar`.
+	/// The color of the 1pt divider line drawn between, and optionally above,
+	/// the `MessageBar`s in a `MessageBarStack`.
 	case dividerColor
 
 	/// The font used for the title of the `MessageBar`.


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

Updated macOS Message Bar appearance, including the ability to remove the top border of the `MessageBarStack` (useful when it's the only view in a given visual stack).

### Verification

Checked the appearance of the bars in the demo app, with and without top border.

<details>
<summary>Visual Verification</summary>

| With                                       | Without                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1012" height="644" alt="Screenshot 2026-06-08 at 8 44 38 PM" src="https://github.com/user-attachments/assets/132cc0da-3127-460f-b97a-bb0be76e68fc" /> | <img width="1012" height="644" alt="Screenshot 2026-06-08 at 8 44 36 PM" src="https://github.com/user-attachments/assets/46fb86ff-57e1-4847-a6ea-0ffd1db5de43" /> |

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2272)