### PR TITLE
[BottomSheetController] Update collapsedHeightInSafeArea for partial expansion state

### DIFF
--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -609,7 +609,9 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             updateDimmingViewAlpha()
             updateDimmingViewAccessibility()
         }
-        collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset(for: .collapsed)
+
+        let offset = targetExpansionState == .partial ? offset(for: .partial) : offset(for: .collapsed)
+        collapsedHeightInSafeArea = view.safeAreaLayoutGuide.layoutFrame.maxY - offset
 
         updateAppearance()
 


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

The `collapsedHeightInSafeArea` is always set using the sheet’s `.collapsed` state offset, which doesn't support sheets that open to the `.partial` state. This can cause UI that should show above the sheet to get hidden behind the sheet because safe area does not get updated correctly.

To fix this, if the `targetExpansionState` is `.partial`, calculate the offset using `.partial`, otherwise use `.collapsed`.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Validated that internal use cases are resolved with this change.

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| Screenshot or description before this change | Screenshot or description with this change |
</details>

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2273)