### PR TITLE
Add more brand tokens for mac ColorProviding

### DIFF
--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestColorProvider.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestColorProvider.swift
@@ -22,8 +22,12 @@ class TestColorProvider: ColorProviding {
 	var brandBackground2: NSColor = (NSColor(named: "Colors/DemoBrandBackground2Color"))!
 	var brandBackground2Hover: NSColor = (NSColor(named: "Colors/DemoBrandBackground2HoverColor"))!
 	var brandBackground2Pressed: NSColor = (NSColor(named: "Colors/DemoBrandBackground2PressedColor"))!
+	var brandBackgroundTint: NSColor = (NSColor(named: "Colors/DemoBrandBackground2Color"))!
 
 	var brandForeground1: NSColor = (NSColor(named: "Colors/DemoBrandForeground1Color"))!
+	var brandForegroundTint: NSColor = (NSColor(named: "Colors/DemoBrandForeground1Color"))!
+
+	var brandStroke1: NSColor = (NSColor(named: "Colors/DemoBrandBackground1Color"))!
 
 	var primary: NSColor = (NSColor(named: "Colors/DemoPrimaryColor"))!
 	var primaryShade10: NSColor = (NSColor(named: "Colors/DemoPrimaryShade10Color"))!

--- a/Sources/FluentUI_macOS/Core/ColorProviding.swift
+++ b/Sources/FluentUI_macOS/Core/ColorProviding.swift
@@ -26,10 +26,16 @@ public protocol ColorProviding {
 	@objc var brandBackground2: NSColor { get }
 	@objc var brandBackground2Hover: NSColor { get }
 	@objc var brandBackground2Pressed: NSColor { get }
+	@objc var brandBackgroundTint: NSColor { get }
 
 	// MARK: - Brand Foreground Colors
 
 	@objc var brandForeground1: NSColor { get }
+	@objc var brandForegroundTint: NSColor { get }
+
+	// MARK: - Brand Stroke Colors
+
+	@objc var brandStroke1: NSColor { get }
 
 	// MARK: - Legacy Brand Colors (kept for backward compatibility)
 
@@ -55,7 +61,10 @@ func brandColorOverrides(provider: ColorProviding) -> [FluentTheme.ColorToken: C
 	brandColors[.brandBackground2] = Color(provider.brandBackground2)
 	brandColors[.brandBackground2Hover] = Color(provider.brandBackground2Hover)
 	brandColors[.brandBackground2Pressed] = Color(provider.brandBackground2Pressed)
+	brandColors[.brandBackgroundTint] = Color(provider.brandBackgroundTint)
 	brandColors[.brandForeground1] = Color(provider.brandForeground1)
+	brandColors[.brandForegroundTint] = Color(provider.brandForegroundTint)
+	brandColors[.brandStroke1] = Color(provider.brandStroke1)
 
 	return brandColors
 }


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

This PR adds brandBackgroundTint, brandForegroundTint, and brandStroke1 color tokens to the mac ColorProviding protocol. These tokens already exist on iOS so they're just being mirrored.

### Verification

Build passes.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2274)