### PR TITLE
[Command Bar] Update Command Bar Styling to Latest Designs

### DIFF
--- a/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/CommandBar/CommandBarTokenSet.swift
@@ -81,7 +81,7 @@ public class CommandBarTokenSet: ControlTokenSet<CommandBarToken> {
                 }
 
             case .cornerRadius:
-                return .float { GlobalTokens.corner(.radius120) }
+                return .float { GlobalTokens.corner(.radius160) }
 
             case .itemBackgroundColorRest:
                 return .uiColor { .clear }
@@ -146,7 +146,7 @@ extension CommandBarTokenSet {
     static let groupInterspaceWide: CGFloat = GlobalTokens.spacing(.size160)
 
     /// The spacing between each Command Bar Item.
-    static let itemInterspace: CGFloat = GlobalTokens.spacing(.size20)
+    static let itemInterspace: CGFloat = GlobalTokens.spacing(.size40)
 
     /// The buffer spacing left/right of each Command Bar Group.
     static let leftRightBuffer: CGFloat = GlobalTokens.spacing(.size20)
@@ -158,9 +158,9 @@ extension CommandBarTokenSet {
     static let barInsets: CGFloat = GlobalTokens.spacing(.size40)
 
     /// The edge inset values for the Command Bar Button.
-    static let buttonContentInsets = NSDirectionalEdgeInsets(top: 8.0,
+    static let buttonContentInsets = NSDirectionalEdgeInsets(top: 4.0,
                                                        leading: 10.0,
-                                                       bottom: 8.0,
+                                                       bottom: 4.0,
                                                        trailing: 10.0)
 
     /// The padding between the Command Bar Button image and title.


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes
Series of adjustments to the Command Bar to adjust styling to latest designs
- Decrease button corner radius 
- Decrease top and bottom padding around icons of bottoms
- Increase spacing between buttons in the same group

### Verification
Validated in Demo App that style matches design

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/40b579b8-e5ec-4d13-88fd-6c1d11464da7" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/7aa5548a-23b8-4a1e-8eba-c79b0c863431" /> |
</details>

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2275)