### PR TITLE
Bump version to 0.36

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Info.plist
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.35.0</string>
+	<string>1.36.0</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -26,7 +26,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>137.35.0</string>
+	<string>137.36.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UIApplicationSceneManifest</key>

--- a/Demos/FluentUIDemo_macOS/FluentUITestApp/FluentUITestApp-Info.plist
+++ b/Demos/FluentUIDemo_macOS/FluentUITestApp/FluentUITestApp-Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 	<key>CFBundleVersion</key>
-	<string>62.35.0</string>
+	<string>62.36.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersion</key>

--- a/MicrosoftFluentUI.podspec
+++ b/MicrosoftFluentUI.podspec
@@ -9,7 +9,7 @@ resources_dir = 'Resources'
 
 Pod::Spec.new do |s|
   s.name             = 'MicrosoftFluentUI'
-  s.version          = '0.35.0'
+  s.version          = '0.36.0'
   s.summary          = 'Fluent UI is a set of reusable UI controls and tools'
   s.homepage         = "https://www.microsoft.com/design/fluent/#/"
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/Sources/FluentUI_iOS/Resources/Version.plist
+++ b/Sources/FluentUI_iOS/Resources/Version.plist
@@ -3,8 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleShortVersionString</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 </dict>
 </plist>

--- a/Sources/FluentUI_macOS/FluentUI-Info.plist
+++ b/Sources/FluentUI_macOS/FluentUI-Info.plist
@@ -15,8 +15,8 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.35.0</string>
+	<string>0.36.0</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

Bumping version to 0.36
- #2226 
- #2227 
- #2229 
- #2228 
- #2230
- #2232
- #2233 
- #2234 
- #2235 
- #2237 
- #2236 
- #2240
- #2243 
- #2242 
- #2244 
- #2246 
- #2245
- #2247 
- #2248 
- #2239
- #2249 
- #2250
- #2251 
- #2252 
- #2255 
- #2256 
- #2257 
- #2258 
- #2259 
- #2261
- #2262 
- #2263 
- #2264 
- #2265 
- #2266 
- #2267 
- #2260 
- #2268 
- #2269 
- #2231 
- #2272 
- #2271 
- #2270 
- #2274 
- #2273 
- #2275

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2276)