### PR TITLE
[iOS][BottomSheetController] Fix issues with corner radius and shadow when glass is enabled

### DIFF
--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -677,17 +677,16 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             // Otherwise the view will mask its own shadow.
             shadowInfo.applyShadow(to: bottomSheetView, parentController: self)
         case .glass:
-            // TODO: This code block can be removed once iOS 18 support is dropped and the project only supports iOS 26+
-            if #unavailable(iOS 26), let bottomSheetView = bottomSheetView as? UIVisualEffectView, bottomSheetView.effect is UIBlurEffect {
+            if isViewLoaded {
                 // The current Fluent Shadow implementation in `applyShadow(to:)` adds extra CALayers with shadow properties
                 // and relies on the target UIView having an opaque backgroundColor — the shadow visibility depends on its opacity.
                 // This breaks down when using a UIVisualEffectView with a UIBlurEffect, since setting a backgroundColor would interfere
                 // with blur sampling and defeat its purpose. In such cases, we bypass `applyShadow(to:)` and apply the shadow tokens
-                // directly to the UIVisualEffectView’s primary layer, ensuring shadows render correctly without disrupting the blur effect.
-                bottomSheetView.layer.shadowColor   = BottomSheetTokenSet.blurEffectShadowColor
-                bottomSheetView.layer.shadowOpacity = BottomSheetTokenSet.blurEffectShadowOpacity
-                bottomSheetView.layer.shadowOffset  = BottomSheetTokenSet.blurEffectShadowOffset
-                bottomSheetView.layer.shadowRadius  = BottomSheetTokenSet.blurEffectShadowRadius
+                // directly to the view's primary layer, ensuring shadows render correctly without disrupting the blur effect.
+                view.layer.shadowColor   = BottomSheetTokenSet.blurEffectShadowColor
+                view.layer.shadowOpacity = BottomSheetTokenSet.blurEffectShadowOpacity
+                view.layer.shadowOffset  = BottomSheetTokenSet.blurEffectShadowOffset
+                view.layer.shadowRadius  = BottomSheetTokenSet.blurEffectShadowRadius
             }
         }
     }
@@ -826,6 +825,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         let effectView = UIVisualEffectView()
         effectView.effect = makeGlassEffect(wantsGlass: true)
         effectView.cornerConfiguration = .corners(radius: UICornerRadius.fixed(tokenSet[.cornerRadius].float))
+        effectView.layer.masksToBounds = true
         return effectView
   }
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes

A couple of issues have come up since the [previous change](https://github.com/microsoft/fluentui-apple/pull/2277) which improved iOS 26+ glass support for the BottomSheetController.

1. The corner radius is not visible - The `effectView` was a missing a call to set its layer's `masksToBounds` property to `true`. Adding this call fixes the issue.
2. The shadow is missing from the edge of the sheet - Initially it appeared that the shadow applied to the bottom sheet did not work well with glass support. However, after more investigation and an ask to add it back, it was discovered that we were having issues because the shadow was being applied to the wrong layer. To fix the issue, we need to apply the shadow on the bottom sheet's parent view layer.

### Binary change

n/a

### Verification

- Validated in demo controllers
- Validated in internal use cases

<details>
<summary>Visual Verification</summary>

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-23 at 10 21 37" src="https://github.com/user-attachments/assets/60176c48-8a0c-40f4-bcc7-161af47ee691" />

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2278)