### PR TITLE
[Shimmer] Introduce ShimmerLineConfiguration to enable more control over ShimmerLineView

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -97,5 +97,55 @@ class ShimmerViewDemoController: DemoController {
         container.addArrangedSubview(shimmerViewLabel("Concealing style shimmer on an image: the gradient conceals its container view as it moves"))
         container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmeringImageView(.concealing))
+
+        // MARK: - Line Configs API Examples
+
+        container.addArrangedSubview(Separator())
+        container.addArrangedSubview(shimmerViewLabel("ShimmerLinesView with custom line configurations using factory methods"))
+        container.addArrangedSubview(Separator())
+        let customShimmerView1 = ShimmerLinesView(lineConfigs: [
+            .titleLine(),
+            .subtitleLine(),
+            .listItem(),
+            .listItem(),
+            .listItem()
+        ])
+        container.addArrangedSubview(customShimmerView1)
+
+        container.addArrangedSubview(Separator())
+        container.addArrangedSubview(shimmerViewLabel("Complex layout with title, subtitle, large content block, and list items"))
+        container.addArrangedSubview(Separator())
+        let complexPattern: [ShimmerLineConfig] = [
+            .titleLine(),
+            .subtitleLine(),
+            .contentBlock(height: 200),
+        ] + Array(repeating: .listItem(), count: 5)
+        let complexShimmerView = ShimmerLinesView(lineConfigs: complexPattern)
+        container.addArrangedSubview(complexShimmerView)
+
+        container.addArrangedSubview(Separator())
+        container.addArrangedSubview(shimmerViewLabel("Custom line configurations with specific heights and widths"))
+        container.addArrangedSubview(Separator())
+        let customConfigsView = ShimmerLinesView(lineConfigs: [
+            ShimmerLineConfig(height: 50, widthPercent: 0.9, cornerRadius: NSNumber(value: 10)),
+            ShimmerLineConfig(height: 30, widthPercent: 0.7, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfig(height: 40, widthPercent: 1.0, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfig(height: 35, widthPercent: 0.85, cornerRadius: NSNumber(value: 8))
+        ])
+        container.addArrangedSubview(customConfigsView)
+
+        container.addArrangedSubview(Separator())
+        container.addArrangedSubview(shimmerViewLabel("Mixed heights simulating a feed with varying content"))
+        container.addArrangedSubview(Separator())
+        let feedPattern: [ShimmerLineConfig] = [
+            ShimmerLineConfig(height: 60, widthPercent: 0.8, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfig(height: 150, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
+            ShimmerLineConfig(height: 40, widthPercent: 0.6, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfig(height: 60, widthPercent: 0.75, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfig(height: 120, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
+            ShimmerLineConfig(height: 40, widthPercent: 0.5, cornerRadius: NSNumber(value: 8))
+        ]
+        let feedShimmerView = ShimmerLinesView(lineConfigs: feedPattern)
+        container.addArrangedSubview(feedShimmerView)
     }
 }

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -101,14 +101,14 @@ class ShimmerViewDemoController: DemoController {
         // MARK: - Line Configs API Examples
 
         container.addArrangedSubview(Separator())
-        container.addArrangedSubview(shimmerViewLabel("ShimmerLinesView with custom line configurations using factory methods"))
+        container.addArrangedSubview(shimmerViewLabel("ShimmerLinesView with custom line configurations"))
         container.addArrangedSubview(Separator())
         let customShimmerView1 = ShimmerLinesView(lineConfigs: [
-            .titleLine(),
-            .subtitleLine(),
-            .listItem(),
-            .listItem(),
-            .listItem()
+            ShimmerLineConfig(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfig(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10)),
+            ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8))
         ])
         container.addArrangedSubview(customShimmerView1)
 
@@ -116,10 +116,13 @@ class ShimmerViewDemoController: DemoController {
         container.addArrangedSubview(shimmerViewLabel("Complex layout with title, subtitle, large content block, and list items"))
         container.addArrangedSubview(Separator())
         let complexPattern: [ShimmerLineConfig] = [
-            .titleLine(),
-            .subtitleLine(),
-            .contentBlock(height: 200),
-        ] + Array(repeating: .listItem(), count: 5)
+            ShimmerLineConfig(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfig(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10)),
+            ShimmerLineConfig(height: 200, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
+        ] + Array(
+            repeating: ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
+            count: 5
+        )
         let complexShimmerView = ShimmerLinesView(lineConfigs: complexPattern)
         container.addArrangedSubview(complexShimmerView)
 

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift
@@ -104,23 +104,23 @@ class ShimmerViewDemoController: DemoController {
         container.addArrangedSubview(shimmerViewLabel("ShimmerLinesView with custom line configurations"))
         container.addArrangedSubview(Separator())
         let customShimmerView1 = ShimmerLinesView(lineConfigs: [
-            ShimmerLineConfig(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12)),
-            ShimmerLineConfig(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10)),
-            ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
-            ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
-            ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8))
+            ShimmerLineConfiguration(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfiguration(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10)),
+            ShimmerLineConfiguration(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfiguration(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfiguration(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8))
         ])
         container.addArrangedSubview(customShimmerView1)
 
         container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmerViewLabel("Complex layout with title, subtitle, large content block, and list items"))
         container.addArrangedSubview(Separator())
-        let complexPattern: [ShimmerLineConfig] = [
-            ShimmerLineConfig(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12)),
-            ShimmerLineConfig(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10)),
-            ShimmerLineConfig(height: 200, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
+        let complexPattern: [ShimmerLineConfiguration] = [
+            ShimmerLineConfiguration(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfiguration(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10)),
+            ShimmerLineConfiguration(height: 200, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
         ] + Array(
-            repeating: ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
+            repeating: ShimmerLineConfiguration(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8)),
             count: 5
         )
         let complexShimmerView = ShimmerLinesView(lineConfigs: complexPattern)
@@ -130,23 +130,23 @@ class ShimmerViewDemoController: DemoController {
         container.addArrangedSubview(shimmerViewLabel("Custom line configurations with specific heights and widths"))
         container.addArrangedSubview(Separator())
         let customConfigsView = ShimmerLinesView(lineConfigs: [
-            ShimmerLineConfig(height: 50, widthPercent: 0.9, cornerRadius: NSNumber(value: 10)),
-            ShimmerLineConfig(height: 30, widthPercent: 0.7, cornerRadius: NSNumber(value: 8)),
-            ShimmerLineConfig(height: 40, widthPercent: 1.0, cornerRadius: NSNumber(value: 12)),
-            ShimmerLineConfig(height: 35, widthPercent: 0.85, cornerRadius: NSNumber(value: 8))
+            ShimmerLineConfiguration(height: 50, widthPercent: 0.9, cornerRadius: NSNumber(value: 10)),
+            ShimmerLineConfiguration(height: 30, widthPercent: 0.7, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfiguration(height: 40, widthPercent: 1.0, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfiguration(height: 35, widthPercent: 0.85, cornerRadius: NSNumber(value: 8))
         ])
         container.addArrangedSubview(customConfigsView)
 
         container.addArrangedSubview(Separator())
         container.addArrangedSubview(shimmerViewLabel("Mixed heights simulating a feed with varying content"))
         container.addArrangedSubview(Separator())
-        let feedPattern: [ShimmerLineConfig] = [
-            ShimmerLineConfig(height: 60, widthPercent: 0.8, cornerRadius: NSNumber(value: 12)),
-            ShimmerLineConfig(height: 150, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
-            ShimmerLineConfig(height: 40, widthPercent: 0.6, cornerRadius: NSNumber(value: 8)),
-            ShimmerLineConfig(height: 60, widthPercent: 0.75, cornerRadius: NSNumber(value: 12)),
-            ShimmerLineConfig(height: 120, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
-            ShimmerLineConfig(height: 40, widthPercent: 0.5, cornerRadius: NSNumber(value: 8))
+        let feedPattern: [ShimmerLineConfiguration] = [
+            ShimmerLineConfiguration(height: 60, widthPercent: 0.8, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfiguration(height: 150, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
+            ShimmerLineConfiguration(height: 40, widthPercent: 0.6, cornerRadius: NSNumber(value: 8)),
+            ShimmerLineConfiguration(height: 60, widthPercent: 0.75, cornerRadius: NSNumber(value: 12)),
+            ShimmerLineConfiguration(height: 120, widthPercent: 1.0, cornerRadius: NSNumber(value: 16)),
+            ShimmerLineConfiguration(height: 40, widthPercent: 0.5, cornerRadius: NSNumber(value: 8))
         ]
         let feedShimmerView = ShimmerLinesView(lineConfigs: feedPattern)
         container.addArrangedSubview(feedShimmerView)

--- a/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLineConfig.swift
+++ b/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLineConfig.swift
@@ -32,38 +32,4 @@ public class ShimmerLineConfig: NSObject {
         self.cornerRadius = cornerRadius
         super.init()
     }
-
-    // MARK: - Convenience Factory Methods
-
-    /// Creates a configuration for a standard title line.
-    /// - Returns: Configuration with height 64pt, 85% width, 12pt corner radius.
-    @objc public static func titleLine() -> ShimmerLineConfig {
-        ShimmerLineConfig(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12))
-    }
-
-    /// Creates a configuration for a subtitle line.
-    /// - Returns: Configuration with height 40pt, 55% width, 10pt corner radius.
-    @objc public static func subtitleLine() -> ShimmerLineConfig {
-        ShimmerLineConfig(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10))
-    }
-
-    /// Creates a configuration for a large content block.
-    /// - Parameter height: Height of the content block. Default is 400pt.
-    /// - Returns: Configuration with specified height, full width, 16pt corner radius.
-    @objc public static func contentBlock(height: CGFloat = 400) -> ShimmerLineConfig {
-        ShimmerLineConfig(height: height, widthPercent: 1.0, cornerRadius: NSNumber(value: 16))
-    }
-
-    /// Creates a configuration for a standard list item.
-    /// - Returns: Configuration with height 36pt, full width, 8pt corner radius.
-    @objc public static func listItem() -> ShimmerLineConfig {
-        ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8))
-    }
-
-    /// Creates a configuration for a standard row with default token height.
-    /// - Parameter widthPercent: Horizontal fill percentage (0.0 to 1.0). Default is 0.85.
-    /// - Returns: Configuration with token-based height, specified width, default corner radius.
-    @objc public static func standardRow(widthPercent: CGFloat = 0.85) -> ShimmerLineConfig {
-        ShimmerLineConfig(height: 44, widthPercent: widthPercent, cornerRadius: nil)
-    }
 }

--- a/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLineConfig.swift
+++ b/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLineConfig.swift
@@ -1,0 +1,69 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import UIKit
+
+/// Configuration for a single shimmer line, defining its visual appearance.
+@objc(MSFShimmerLineConfig)
+public class ShimmerLineConfig: NSObject {
+    /// Height of the line in points.
+    @objc public let height: CGFloat
+
+    /// Horizontal fill percentage (0.0 to 1.0) determining how much of the available width the line should occupy.
+    @objc public let widthPercent: CGFloat
+
+    /// Corner radius for the line. If nil, uses the default from the token set.
+    @objc public let cornerRadius: NSNumber?
+
+    /// Creates a shimmer line configuration.
+    /// - Parameters:
+    ///   - height: Height of the line in points.
+    ///   - widthPercent: Horizontal fill percentage (0.0 to 1.0). Default is 1.0 (full width).
+    ///   - cornerRadius: Corner radius for the line. Pass nil to use default from token set.
+    @objc public init(
+        height: CGFloat,
+        widthPercent: CGFloat = 1.0,
+        cornerRadius: NSNumber? = nil
+    ) {
+        self.height = height
+        self.widthPercent = max(0.0, min(1.0, widthPercent))
+        self.cornerRadius = cornerRadius
+        super.init()
+    }
+
+    // MARK: - Convenience Factory Methods
+
+    /// Creates a configuration for a standard title line.
+    /// - Returns: Configuration with height 64pt, 85% width, 12pt corner radius.
+    @objc public static func titleLine() -> ShimmerLineConfig {
+        ShimmerLineConfig(height: 64, widthPercent: 0.85, cornerRadius: NSNumber(value: 12))
+    }
+
+    /// Creates a configuration for a subtitle line.
+    /// - Returns: Configuration with height 40pt, 55% width, 10pt corner radius.
+    @objc public static func subtitleLine() -> ShimmerLineConfig {
+        ShimmerLineConfig(height: 40, widthPercent: 0.55, cornerRadius: NSNumber(value: 10))
+    }
+
+    /// Creates a configuration for a large content block.
+    /// - Parameter height: Height of the content block. Default is 400pt.
+    /// - Returns: Configuration with specified height, full width, 16pt corner radius.
+    @objc public static func contentBlock(height: CGFloat = 400) -> ShimmerLineConfig {
+        ShimmerLineConfig(height: height, widthPercent: 1.0, cornerRadius: NSNumber(value: 16))
+    }
+
+    /// Creates a configuration for a standard list item.
+    /// - Returns: Configuration with height 36pt, full width, 8pt corner radius.
+    @objc public static func listItem() -> ShimmerLineConfig {
+        ShimmerLineConfig(height: 36, widthPercent: 1.0, cornerRadius: NSNumber(value: 8))
+    }
+
+    /// Creates a configuration for a standard row with default token height.
+    /// - Parameter widthPercent: Horizontal fill percentage (0.0 to 1.0). Default is 0.85.
+    /// - Returns: Configuration with token-based height, specified width, default corner radius.
+    @objc public static func standardRow(widthPercent: CGFloat = 0.85) -> ShimmerLineConfig {
+        ShimmerLineConfig(height: 44, widthPercent: widthPercent, cornerRadius: nil)
+    }
+}

--- a/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLineConfiguration.swift
+++ b/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLineConfiguration.swift
@@ -6,8 +6,8 @@
 import UIKit
 
 /// Configuration for a single shimmer line, defining its visual appearance.
-@objc(MSFShimmerLineConfig)
-public class ShimmerLineConfig: NSObject {
+@objc(MSFShimmerLineConfiguration)
+public class ShimmerLineConfiguration: NSObject {
     /// Height of the line in points.
     @objc public let height: CGFloat
 

--- a/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLinesView.swift
+++ b/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLinesView.swift
@@ -22,7 +22,7 @@ open class ShimmerLinesView: ShimmerView {
 
     /// Array of line configurations defining each shimmer line's appearance.
     /// When set, this takes precedence over `lineCount`, `firstLineFillPercent`, and `lastLineFillPercent`.
-    @objc open var lineConfigs: [ShimmerLineConfig]? = nil {
+    @objc open var lineConfigs: [ShimmerLineConfiguration]? = nil {
         didSet {
             setNeedsLayout()
         }
@@ -67,7 +67,7 @@ open class ShimmerLinesView: ShimmerView {
     ///   - lineSpacing: Optional custom spacing between lines in points. If nil, uses default token spacing.
     ///   - animationSynchronizer: Optional synchronizer to coordinate animations across multiple shimmer views.
     @objc public convenience init(
-        lineConfigs: [ShimmerLineConfig]? = nil,
+        lineConfigs: [ShimmerLineConfiguration]? = nil,
         lineSpacing: NSNumber? = nil,
         animationSynchronizer: AnimationSynchronizerProtocol? = nil
     ) {

--- a/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLinesView.swift
+++ b/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLinesView.swift
@@ -126,18 +126,18 @@ open class ShimmerLinesView: ShimmerView {
         let spacing: CGFloat = lineSpacing.map { CGFloat(truncating: $0) } ?? tokenSet[.labelSpacing].float
 
         // Use line configs mode if available
+        let height: CGFloat
         if let configs = lineConfigs {
-            let totalHeight = configs.enumerated().reduce(0) { total, element in
+            height = configs.enumerated().reduce(0) { total, element in
                 let (index, config) = element
                 let lineSpacing = index > 0 ? spacing : 0
                 return total + config.height + lineSpacing
             }
-            return CGSize(width: size.width, height: totalHeight)
         } else {
             let desiredLineCount = CGFloat(lineCount(for: size.height))
-            let height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * spacing
-            return CGSize(width: size.width, height: height)
+            height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * spacing
         }
+        return CGSize(width: size.width, height: height)
     }
 
     open override var intrinsicContentSize: CGSize {

--- a/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLinesView.swift
+++ b/Sources/FluentUI_iOS/Components/Shimmer/ShimmerLinesView.swift
@@ -10,17 +10,33 @@ import UIKit
 
 /**
  Specialized ShimmerView that shows 1 or more shimmering lines.
+
+ The view supports two modes of configuration:
+ 1.  Use `lineConfigs` to define individual line heights, widths, and corner radii
+ 2. Use `lineCount`, `firstLineFillPercent`, and `lastLineFillPercent` for uniform line heights
+
+ When `lineConfigs` is set, it takes precedence over the `lineCount` and other properties.
  */
 @objc(MSFShimmerLinesView)
 open class ShimmerLinesView: ShimmerView {
 
+    /// Array of line configurations defining each shimmer line's appearance.
+    /// When set, this takes precedence over `lineCount`, `firstLineFillPercent`, and `lastLineFillPercent`.
+    @objc open var lineConfigs: [ShimmerLineConfig]? = nil {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
     /// Number of lines that will shimmer in this view. Use 0 if the number of lines should fill the available space.
+    /// Note: This property is ignored when `lineConfigs` is set.
     @objc open var lineCount: Int = 3 {
         didSet {
             setNeedsLayout()
         }
     }
     /// The percent the first line (if 2+ lines) should fill the available horizontal space
+    /// Note: This property is ignored when `lineConfigs` is set.
     @objc open var firstLineFillPercent: CGFloat = 0.94 {
         didSet {
             setNeedsLayout()
@@ -28,31 +44,74 @@ open class ShimmerLinesView: ShimmerView {
     }
 
     /// The percent the last line should fill the available horizontal space.
+    /// Note: This property is ignored when `lineConfigs` is set.
     @objc open var lastLineFillPercent: CGFloat = 0.6 {
         didSet {
             setNeedsLayout()
         }
     }
 
+    /// Custom spacing between lines in points. If nil, uses the default token spacing (typically 12pt).
+    /// Set this to customize the vertical spacing between shimmer lines.
+    @objc open var lineSpacing: NSNumber? {
+        didSet {
+            setNeedsLayout()
+        }
+    }
+
+    // MARK: - Initializers
+
+    /// Creates a ShimmerLinesView with specific line configurations.
+    /// - Parameters:
+    ///   - lineConfigs: Optional array of line configurations defining each line's appearance.
+    ///   - lineSpacing: Optional custom spacing between lines in points. If nil, uses default token spacing.
+    ///   - animationSynchronizer: Optional synchronizer to coordinate animations across multiple shimmer views.
+    @objc public convenience init(
+        lineConfigs: [ShimmerLineConfig]? = nil,
+        lineSpacing: NSNumber? = nil,
+        animationSynchronizer: AnimationSynchronizerProtocol? = nil
+    ) {
+        self.init(containerView: nil, excludedViews: [], animationSynchronizer: animationSynchronizer)
+        self.lineConfigs = lineConfigs
+        self.lineSpacing = lineSpacing
+    }
+
     open override func layoutSubviews() {
         super.layoutSubviews()
 
         var currentTop: CGFloat = 0
-        for (index, linelayer) in viewCoverLayers.enumerated() {
-            let fillPercent: CGFloat = {
-                if index == 0 && viewCoverLayers.count > 2 {
-                    return firstLineFillPercent
-                } else if index == viewCoverLayers.count - 1 {
-                    return lastLineFillPercent
-                } else {
-                    return 1
-                }
-            }()
 
-            let labelHeight = tokenSet[.labelHeight].float
-            linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: labelHeight)
+        // Get spacing value (custom or token-based)
+        let spacing: CGFloat = lineSpacing.map { CGFloat(truncating: $0) } ?? tokenSet[.labelSpacing].float
 
-            currentTop += labelHeight + tokenSet[.labelSpacing].float
+        // Use line configs mode if available
+        if let configs = lineConfigs {
+            for (index, linelayer) in viewCoverLayers.enumerated() {
+                guard index < configs.count else { break }
+
+                let config = configs[index]
+                let lineWidth = config.widthPercent * frame.width
+                linelayer.frame = CGRect(x: 0, y: currentTop, width: lineWidth, height: config.height)
+
+                currentTop += config.height + spacing
+            }
+        } else {
+            for (index, linelayer) in viewCoverLayers.enumerated() {
+                let fillPercent: CGFloat = {
+                    if index == 0 && viewCoverLayers.count > 2 {
+                        return firstLineFillPercent
+                    } else if index == viewCoverLayers.count - 1 {
+                        return lastLineFillPercent
+                    } else {
+                        return 1
+                    }
+                }()
+
+                let labelHeight = tokenSet[.labelHeight].float
+                linelayer.frame = CGRect(x: 0, y: currentTop, width: fillPercent * frame.width, height: labelHeight)
+
+                currentTop += labelHeight + spacing
+            }
         }
 
         shimmeringLayer.frame = CGRect(x: -tokenSet[.shimmerWidth].float, y: 0.0, width: frame.width + 2 * tokenSet[.shimmerWidth].float, height: frame.height)
@@ -63,9 +122,22 @@ open class ShimmerLinesView: ShimmerView {
     }
 
     open override func sizeThatFits(_ size: CGSize) -> CGSize {
-        let desiredLineCount = CGFloat(lineCount(for: size.height))
-        let height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * tokenSet[.labelSpacing].float
-        return CGSize(width: size.width, height: height)
+        // Get spacing value (custom or token-based)
+        let spacing: CGFloat = lineSpacing.map { CGFloat(truncating: $0) } ?? tokenSet[.labelSpacing].float
+
+        // Use line configs mode if available
+        if let configs = lineConfigs {
+            let totalHeight = configs.enumerated().reduce(0) { total, element in
+                let (index, config) = element
+                let lineSpacing = index > 0 ? spacing : 0
+                return total + config.height + lineSpacing
+            }
+            return CGSize(width: size.width, height: totalHeight)
+        } else {
+            let desiredLineCount = CGFloat(lineCount(for: size.height))
+            let height = desiredLineCount * tokenSet[.labelHeight].float + (desiredLineCount - 1) * spacing
+            return CGSize(width: size.width, height: height)
+        }
     }
 
     open override var intrinsicContentSize: CGSize {
@@ -74,16 +146,37 @@ open class ShimmerLinesView: ShimmerView {
 
     override func updateViewCoverLayers() {
         var newLineLayers = [CALayer]()
-        let desiredLineCount = lineCount(for: frame.height)
 
-        for i in 0..<desiredLineCount {
-            let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
-            lineLayer.cornerRadius = tokenSet[.labelCornerRadius].float >= 0 ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
-            lineLayer.backgroundColor = tokenSet[.tintColor].uiColor.cgColor
+        // Use line configs mode if available
+        if let configs = lineConfigs {
+            for i in 0..<configs.count {
+                let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
 
-            // Add layer
-            newLineLayers.append(lineLayer)
-            layer.addSublayer(lineLayer)
+                // Use config's corner radius if specified, otherwise use token
+                if let configCornerRadius = configs[i].cornerRadius {
+                    lineLayer.cornerRadius = CGFloat(truncating: configCornerRadius)
+                } else {
+                    lineLayer.cornerRadius = tokenSet[.labelCornerRadius].float >= 0 ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
+                }
+
+                lineLayer.backgroundColor = tokenSet[.tintColor].uiColor.cgColor
+
+                // Add layer
+                newLineLayers.append(lineLayer)
+                layer.addSublayer(lineLayer)
+            }
+        } else {
+            let desiredLineCount = lineCount(for: frame.height)
+
+            for i in 0..<desiredLineCount {
+                let lineLayer = i < viewCoverLayers.count ? viewCoverLayers[i] : CALayer()
+                lineLayer.cornerRadius = tokenSet[.labelCornerRadius].float >= 0 ? tokenSet[.labelCornerRadius].float : tokenSet[.cornerRadius].float
+                lineLayer.backgroundColor = tokenSet[.tintColor].uiColor.cgColor
+
+                // Add layer
+                newLineLayers.append(lineLayer)
+                layer.addSublayer(lineLayer)
+            }
         }
 
         Set(viewCoverLayers).subtracting(Set(newLineLayers)).forEach { $0.removeFromSuperlayer() }
@@ -93,9 +186,10 @@ open class ShimmerLinesView: ShimmerView {
 
     @objc private func lineCount(for availableHeight: CGFloat) -> Int {
         if lineCount == 0 {
-            let lineSpacing = tokenSet[.labelSpacing].float
+            // Get spacing value (custom or token-based)
+            let spacing: CGFloat = lineSpacing.map { CGFloat(truncating: $0) } ?? tokenSet[.labelSpacing].float
             // Deduce lines count based on available height.
-            return Int(floor((availableHeight + lineSpacing) / (tokenSet[.labelHeight].float + lineSpacing)))
+            return Int(floor((availableHeight + spacing) / (tokenSet[.labelHeight].float + spacing)))
         } else {
             // Hardcoded lines count.
             return lineCount


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [ ] macOS

### Description of changes

The existing `ShimmerLinesView` implementation does not allow for a Shimmer view that has lines with varying widths and heights. To enable this, I have created a `ShimmerLineConfiguration` class that defines the characteristics of a line and updated the `ShimmerLinesView` to take an optional array of `ShimmerLineConfiguration` objects that make up the shimmer view.

### Binary change

(how is our binary size impacted -- see https://github.com/microsoft/fluentui-apple/wiki/Size-Comparison)

### Verification

Validated in demo controller. Validated in internal use case.

<details>
<summary>Visual Verification</summary>

https://github.com/user-attachments/assets/d8a79309-5fc0-4d62-b585-365fee2110b0

</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2282)