### PR TITLE
Remove force unwrap in CardTransitionAnimator

### DIFF
--- a/Sources/FluentUI_iOS/Components/Presenters/CardTransitionAnimator.swift
+++ b/Sources/FluentUI_iOS/Components/Presenters/CardTransitionAnimator.swift
@@ -75,7 +75,13 @@ class CardTransitionAnimator: NSObject {
     }
 
     private func present(withTransitionContext transitionContext: UIViewControllerContextTransitioning, completion: @escaping (Bool) -> Void) {
-        let presentedView = transitionContext.view(forKey: UITransitionContextViewKey.to)!
+        // `view(forKey:)` can return nil when the transition is torn down before it runs
+        // (e.g. the presentation is interrupted by the app being backgrounded). Bail out
+        // safely instead of force-unwrapping, which would trap (EXC_BREAKPOINT).
+        guard let presentedView = transitionContext.view(forKey: UITransitionContextViewKey.to) else {
+            completion(true)
+            return
+        }
         let containerView = transitionContext.containerView
 
         // Animation start state
@@ -101,7 +107,13 @@ class CardTransitionAnimator: NSObject {
     }
 
     private func dismiss(withTransitionContext transitionContext: UIViewControllerContextTransitioning, completion: @escaping (Bool) -> Void) {
-        let presentedView = transitionContext.view(forKey: UITransitionContextViewKey.from)!
+        // `view(forKey:)` can return nil when the transition is torn down before it runs
+        // (e.g. the dismissal is interrupted by the app being backgrounded). Bail out
+        // safely instead of force-unwrapping, which would trap (EXC_BREAKPOINT).
+        guard let presentedView = transitionContext.view(forKey: UITransitionContextViewKey.from) else {
+            completion(true)
+            return
+        }
         let containerView = transitionContext.containerView
 
         // Animation start state


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [ ] visionOS
- [ ] macOS

### Description of changes

Remove the force unwraps in the `CardTransitionAnimator` which were causing crashes. The `view(forKey:)` call can return `nil` when the transition is torn down before it runs. Force unwrapping the `nil` value causes the crash.

### Binary change

N/A

### Verification

Change was validated with internal use cases.

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2283)