### PR TITLE
[ListItem] Add titleTrailingAccessory

### DIFF
--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -153,7 +153,7 @@ struct ListItemDemoView: View {
 
         @ViewBuilder
         var listItem: some View {
-            let listItem = ListItem(title: title,
+            var listItem = ListItem(title: title,
                                     subtitle: showSubtitle ? subtitle : "",
                                     footer: showFooter ? footer : "",
                                     leadingContent: {
@@ -196,10 +196,9 @@ struct ListItemDemoView: View {
                 .subtitleLineLimit(subtitleLineLimit)
                 .footerLineLimit(footerLineLimit)
                 .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-            var demoListItem = showTitleTrailingAccessory
-                ? listItem.titleTrailingAccessory { Image(systemName: "star") }
-                : listItem
-            demoListItem
+                .titleTrailingAccessory(showTitleTrailingAccessory ? Image(systemName: "star.fill") : nil,
+                                        accessibilityLabel: "Star icon")
+            listItem
                 .overrideTokens($overrideTokens.wrappedValue ? listItemTokenOverrides : [:])
                 .disabled(isDisabled)
                 .alert("List Item tapped", isPresented: $showingPrimaryAlert) {

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -32,6 +32,7 @@ struct ListItemDemoView: View {
     @State var showSubtitle: Bool = false
     @State var showFooter: Bool = false
     @State var showLeadingContent: Bool = true
+    @State var showTitleTrailingAccessory: Bool = false
     @State var showTrailingContent: Bool = true
     @State var isTappable: Bool = true
     @State var isDisabled: Bool = false
@@ -76,6 +77,8 @@ struct ListItemDemoView: View {
                 .accessibilityIdentifier("footerSwitch")
             FluentUIDemoToggle(titleKey: "Show leading content", isOn: $showLeadingContent)
                 .accessibilityIdentifier("leadingContentSwitch")
+            FluentUIDemoToggle(titleKey: "Show title trailing accessory", isOn: $showTitleTrailingAccessory)
+                .accessibilityIdentifier("titleTrailingAccessorySwitch")
             FluentUIDemoToggle(titleKey: "Show trailing content", isOn: $showTrailingContent)
                 .accessibilityIdentifier("trailingContentSwitch")
             FluentUIDemoToggle(titleKey: "Tappable", isOn: $isTappable)
@@ -110,7 +113,6 @@ struct ListItemDemoView: View {
                 Text(".plain").tag(FluentListStyle.plain)
                 Text(".insetGrouped").tag(FluentListStyle.insetGrouped)
                 Text(".inset").tag(FluentListStyle.inset)
-                Text(".glass").tag(FluentListStyle.glass)
             }
         }
 
@@ -151,7 +153,7 @@ struct ListItemDemoView: View {
 
         @ViewBuilder
         var listItem: some View {
-            var listItem = ListItem(title: title,
+            let listItem = ListItem(title: title,
                                     subtitle: showSubtitle ? subtitle : "",
                                     footer: showFooter ? footer : "",
                                     leadingContent: {
@@ -194,7 +196,10 @@ struct ListItemDemoView: View {
                 .subtitleLineLimit(subtitleLineLimit)
                 .footerLineLimit(footerLineLimit)
                 .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-            listItem
+            let demoListItem = showTitleTrailingAccessory
+                ? listItem.titleTrailingAccessory { Image(systemName: "lock.fill") }
+                : listItem
+            demoListItem
                 .overrideTokens($overrideTokens.wrappedValue ? listItemTokenOverrides : [:])
                 .disabled(isDisabled)
                 .alert("List Item tapped", isPresented: $showingPrimaryAlert) {

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -157,6 +157,8 @@ struct ListItemDemoView: View {
             var listItem = ListItem(title: title,
                                     subtitle: showSubtitle ? subtitle : "",
                                     footer: showFooter ? footer : "",
+                                    titleTrailingAccessory: showTitleTrailingAccessory ? Image(systemName: "star.fill") : nil,
+                                    titleTrailingAccessoryAccessibilityLabel: "Star icon",
                                     leadingContent: {
                                         if showLeadingContent {
                                             leadingContent
@@ -197,8 +199,6 @@ struct ListItemDemoView: View {
                 .subtitleLineLimit(subtitleLineLimit)
                 .footerLineLimit(footerLineLimit)
                 .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-                .titleTrailingAccessory(showTitleTrailingAccessory ? Image(systemName: "star.fill") : nil,
-                                        accessibilityLabel: "Star icon")
             listItem
                 .overrideTokens($overrideTokens.wrappedValue ? listItemTokenOverrides : [:])
                 .disabled(isDisabled)

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -196,8 +196,8 @@ struct ListItemDemoView: View {
                 .subtitleLineLimit(subtitleLineLimit)
                 .footerLineLimit(footerLineLimit)
                 .combineTrailingContentAccessibilityElement(trailingContentFocusableElementCount < 2)
-            let demoListItem = showTitleTrailingAccessory
-                ? listItem.titleTrailingAccessory { Image(systemName: "lock.fill") }
+            var demoListItem = showTitleTrailingAccessory
+                ? listItem.titleTrailingAccessory { Image(systemName: "star") }
                 : listItem
             demoListItem
                 .overrideTokens($overrideTokens.wrappedValue ? listItemTokenOverrides : [:])

--- a/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUI.Demo/Demos/ListItemDemoController_SwiftUI.swift
@@ -113,6 +113,7 @@ struct ListItemDemoView: View {
                 Text(".plain").tag(FluentListStyle.plain)
                 Text(".insetGrouped").tag(FluentListStyle.insetGrouped)
                 Text(".inset").tag(FluentListStyle.inset)
+                Text(".glass").tag(FluentListStyle.glass)
             }
         }
 

--- a/Demos/FluentUIDemo_iOS/FluentUIDemoTests/ListItemTest.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUIDemoTests/ListItemTest.swift
@@ -145,10 +145,10 @@ class ListItemTest: BaseTest {
 
         titleTrailingAccessorySwitch.tap()
         XCTAssert(accessoryElement.exists, "Title trailing accessory should appear when an image is passed in")
-        XCTAssert(accessoryElement.label == "Favorited", "Title trailing accessory should be described by its accessibility label")
+        XCTAssert(accessoryElement.label == "Star icon", "Title trailing accessory should be described by its accessibility label")
 
         let listItemElement: XCUIElement = app.buttons.containing(.staticText, identifier: "ListItemTitle").firstMatch
-        XCTAssert(listItemElement.label.contains("Favorited"),
+        XCTAssert(listItemElement.label.contains("Star icon"),
                   "Title trailing accessory should be announced as part of the list item, but was '\(listItemElement.label)'")
     }
 

--- a/Demos/FluentUIDemo_iOS/FluentUIDemoTests/ListItemTest.swift
+++ b/Demos/FluentUIDemo_iOS/FluentUIDemoTests/ListItemTest.swift
@@ -138,7 +138,25 @@ class ListItemTest: BaseTest {
         XCTAssert(accessoryButtonElement.isEnabled, "Accessory should have a tap target for .detailButton type")
     }
 
+    func testTitleTrailingAccessory() throws {
+        let accessoryElement: XCUIElement = app.images.matching(identifier: "ListItemTitleTrailingAccessory").firstMatch
+
+        XCTAssertFalse(accessoryElement.exists, "Title trailing accessory should not appear unless an image is passed in")
+
+        titleTrailingAccessorySwitch.tap()
+        XCTAssert(accessoryElement.exists, "Title trailing accessory should appear when an image is passed in")
+        XCTAssert(accessoryElement.label == "Favorited", "Title trailing accessory should be described by its accessibility label")
+
+        let listItemElement: XCUIElement = app.buttons.containing(.staticText, identifier: "ListItemTitle").firstMatch
+        XCTAssert(listItemElement.label.contains("Favorited"),
+                  "Title trailing accessory should be announced as part of the list item, but was '\(listItemElement.label)'")
+    }
+
     // MARK: Helper variables
+
+    var titleTrailingAccessorySwitch: XCUIElement {
+        app.switches.matching(identifier: "titleTrailingAccessorySwitch").switches.firstMatch
+    }
 
     var showSubtitleSwitch: XCUIElement {
         app.switches.matching(identifier: "subtitleSwitch").switches.firstMatch

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -50,13 +50,24 @@ public struct ListItem<LeadingContent: View,
 
         @ViewBuilder
         var titleView: some View {
-            Text(title)
+            let titleView = Text(title)
                 .foregroundColor(Color(uiColor: tokenSet[.titleColor].uiColor))
                 .font(Font(tokenSet[.titleFont].uiFont))
                 .frame(minHeight: ListItemTokenSet.titleHeight)
                 .lineLimit(titleLineLimit)
                 .truncationMode(titleTruncationMode)
                 .accessibilityIdentifier(AccessibilityIdentifiers.title)
+
+            if let titleTrailingAccessory {
+                HStack(spacing: 0) {
+                    titleView
+                    titleTrailingAccessory()
+                        .padding(.leading, ListItemTokenSet.titleTrailingAccessorySpacing)
+                        .accessibilityIdentifier(AccessibilityIdentifiers.titleTrailingAccessory)
+                }
+            } else {
+                titleView
+            }
         }
 
         @ViewBuilder
@@ -314,6 +325,10 @@ public struct ListItem<LeadingContent: View,
     /// Whether or not the `TrailingContent` should be combined or be a separate accessibility element.
     var combineTrailingContentAccessibilityElement: Bool = true
 
+    /// Content that appears immediately after the `title` text, rather than against the trailing edge of the view.
+    /// Type-erased so that adding this slot does not change `ListItem`'s generic signature.
+    var titleTrailingAccessory: (() -> AnyView)?
+
     // MARK: Private variables
 
     /// The background styling of the `ListItem`.
@@ -386,6 +401,7 @@ private struct AccessibilityIdentifiers {
     static let subtitle: String = "ListItemSubtitle"
     static let footer: String = "ListItemFooter"
     static let leadingContent: String = "ListItemLeadingContent"
+    static let titleTrailingAccessory: String = "ListItemTitleTrailingAccessory"
     static let trailingContent: String = "ListItemTrailingContent"
     static let accessoryImage: String = "ListItemAccessoryImage"
     static let accessoryDetailButton: String = "ListItemAccessoryDetailButton"

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -325,8 +325,7 @@ public struct ListItem<LeadingContent: View,
     /// Whether or not the `TrailingContent` should be combined or be a separate accessibility element.
     var combineTrailingContentAccessibilityElement: Bool = true
 
-    /// Content that appears immediately after the `title` text, rather than against the trailing edge of the view.
-    /// Type-erased so that adding this slot does not change `ListItem`'s generic signature.
+    /// Content that appears immediately trailing the `title` text.
     var titleTrailingAccessory: (() -> AnyView)?
 
     // MARK: Private variables

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -53,27 +53,21 @@ public struct ListItem<LeadingContent: View,
             let titleColor = Color(uiColor: tokenSet[.titleColor].uiColor)
             let titleFont = Font(tokenSet[.titleFont].uiFont)
             let titleText = Text(title)
-                .foregroundColor(titleColor)
-                .font(titleFont)
                 .frame(minHeight: ListItemTokenSet.titleHeight)
                 .lineLimit(titleLineLimit)
                 .truncationMode(titleTruncationMode)
                 .accessibilityIdentifier(AccessibilityIdentifiers.title)
 
-            if let titleTrailingAccessory {
-                HStack(spacing: ListItemTokenSet.titleTrailingAccessorySpacing) {
-                    titleText
+            HStack(spacing: ListItemTokenSet.titleTrailingAccessorySpacing) {
+                titleText
+                if let titleTrailingAccessory {
                     titleTrailingAccessory
-                        .modifyIf(titleTrailingAccessoryAccessibilityLabel != nil, { accessory in
-                            accessory.accessibilityLabel(Text(titleTrailingAccessoryAccessibilityLabel ?? ""))
-                        })
+                        .accessibilityLabel(Text(titleTrailingAccessoryAccessibilityLabel ?? ""))
                         .accessibilityIdentifier(AccessibilityIdentifiers.titleTrailingAccessory)
                 }
-                .foregroundColor(titleColor)
-                .font(titleFont)
-            } else {
-                titleText
             }
+            .foregroundColor(titleColor)
+            .font(titleFont)
         }
 
         @ViewBuilder

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -50,23 +50,29 @@ public struct ListItem<LeadingContent: View,
 
         @ViewBuilder
         var titleView: some View {
-            let titleView = Text(title)
-                .foregroundColor(Color(uiColor: tokenSet[.titleColor].uiColor))
-                .font(Font(tokenSet[.titleFont].uiFont))
+            let titleColor = Color(uiColor: tokenSet[.titleColor].uiColor)
+            let titleFont = Font(tokenSet[.titleFont].uiFont)
+            let titleText = Text(title)
+                .foregroundColor(titleColor)
+                .font(titleFont)
                 .frame(minHeight: ListItemTokenSet.titleHeight)
                 .lineLimit(titleLineLimit)
                 .truncationMode(titleTruncationMode)
                 .accessibilityIdentifier(AccessibilityIdentifiers.title)
 
             if let titleTrailingAccessory {
-                HStack(spacing: 0) {
-                    titleView
-                    titleTrailingAccessory()
-                        .padding(.leading, ListItemTokenSet.titleTrailingAccessorySpacing)
+                HStack(spacing: ListItemTokenSet.titleTrailingAccessorySpacing) {
+                    titleText
+                    titleTrailingAccessory
+                        .modifyIf(titleTrailingAccessoryAccessibilityLabel != nil, { accessory in
+                            accessory.accessibilityLabel(Text(titleTrailingAccessoryAccessibilityLabel ?? ""))
+                        })
                         .accessibilityIdentifier(AccessibilityIdentifiers.titleTrailingAccessory)
                 }
+                .foregroundColor(titleColor)
+                .font(titleFont)
             } else {
-                titleView
+                titleText
             }
         }
 
@@ -325,8 +331,11 @@ public struct ListItem<LeadingContent: View,
     /// Whether or not the `TrailingContent` should be combined or be a separate accessibility element.
     var combineTrailingContentAccessibilityElement: Bool = true
 
-    /// Content that appears immediately trailing the `title` text.
-    var titleTrailingAccessory: (() -> AnyView)?
+    /// Image that appears immediately trailing the `title` text.
+    var titleTrailingAccessory: Image?
+
+    /// A localized description of `titleTrailingAccessory`, announced by VoiceOver after the `title`.
+    var titleTrailingAccessoryAccessibilityLabel: String?
 
     // MARK: Private variables
 

--- a/Sources/FluentUI_iOS/Components/List/ListItem.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItem.swift
@@ -23,6 +23,9 @@ public struct ListItem<LeadingContent: View,
     ///   - title: Text that appears as the first line of text
     ///   - subtitle: Text that appears as the second line of text
     ///   - footer: Text that appears as the third line of text
+    ///   - titleTrailingAccessory: Image that appears immediately trailing the `title` text
+    ///   - titleTrailingAccessoryAccessibilityLabel: A localized description of `titleTrailingAccessory`, announced by VoiceOver after
+    ///   the `title`. Leave this `nil` when the image is purely decorative, so that VoiceOver ignores it.
     ///   - leadingContent: The content that appears on the leading edge of the view
     ///   - trailingContent: The content that appears on the trailing edge of the view, next to the accessory type if provided
     ///   - detailedContent: The content that appears in a sheet when the accessory detail button is tapped
@@ -30,6 +33,8 @@ public struct ListItem<LeadingContent: View,
     public init(title: Title,
                 subtitle: Subtitle = String(),
                 footer: Footer = String(),
+                titleTrailingAccessory: Image? = nil,
+                titleTrailingAccessoryAccessibilityLabel: String? = nil,
                 @ViewBuilder leadingContent: @escaping () -> LeadingContent,
                 @ViewBuilder trailingContent: @escaping () -> TrailingContent,
                 @ViewBuilder detailedContent: @escaping () -> DetailedContent,
@@ -37,6 +42,8 @@ public struct ListItem<LeadingContent: View,
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.leadingContent = leadingContent
         self.trailingContent = trailingContent
         self.detailedContent = detailedContent
@@ -325,12 +332,6 @@ public struct ListItem<LeadingContent: View,
     /// Whether or not the `TrailingContent` should be combined or be a separate accessibility element.
     var combineTrailingContentAccessibilityElement: Bool = true
 
-    /// Image that appears immediately trailing the `title` text.
-    var titleTrailingAccessory: Image?
-
-    /// A localized description of `titleTrailingAccessory`, announced by VoiceOver after the `title`.
-    var titleTrailingAccessoryAccessibilityLabel: String?
-
     // MARK: Private variables
 
     /// The background styling of the `ListItem`.
@@ -367,6 +368,12 @@ public struct ListItem<LeadingContent: View,
     private let footer: Footer
     private let subtitle: Subtitle
     private let title: Title
+
+    /// Image that appears immediately trailing the `title` text.
+    private let titleTrailingAccessory: Image?
+
+    /// A localized description of `titleTrailingAccessory`, announced by VoiceOver after the `title`.
+    private let titleTrailingAccessoryAccessibilityLabel: String?
 
     private var tokenOverrides: [ListItemToken: ControlTokenValue]?
 }
@@ -415,10 +422,14 @@ public extension ListItem where LeadingContent == EmptyView, TrailingContent == 
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.action = action
     }
 }
@@ -427,11 +438,15 @@ public extension ListItem where LeadingContent == EmptyView, TrailingContent == 
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          @ViewBuilder detailedContent: @escaping () -> DetailedContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.detailedContent = detailedContent
         self.action = action
     }
@@ -441,11 +456,15 @@ public extension ListItem where LeadingContent == EmptyView, DetailedContent == 
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          @ViewBuilder trailingContent: @escaping () -> TrailingContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.trailingContent = trailingContent
         self.action = action
     }
@@ -455,11 +474,15 @@ public extension ListItem where TrailingContent == EmptyView, DetailedContent ==
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          @ViewBuilder leadingContent: @escaping () -> LeadingContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.leadingContent = leadingContent
         self.action = action
     }
@@ -469,12 +492,16 @@ public extension ListItem where TrailingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          @ViewBuilder leadingContent: @escaping () -> LeadingContent,
          @ViewBuilder detailedContent: @escaping () -> DetailedContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.leadingContent = leadingContent
         self.detailedContent = detailedContent
         self.action = action
@@ -485,12 +512,16 @@ public extension ListItem where LeadingContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          @ViewBuilder trailingContent: @escaping () -> TrailingContent,
          @ViewBuilder detailedContent: @escaping () -> DetailedContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.trailingContent = trailingContent
         self.detailedContent = detailedContent
         self.action = action
@@ -501,12 +532,16 @@ public extension ListItem where DetailedContent == EmptyView {
     init(title: Title,
          subtitle: Subtitle = String(),
          footer: Footer = String(),
+         titleTrailingAccessory: Image? = nil,
+         titleTrailingAccessoryAccessibilityLabel: String? = nil,
          @ViewBuilder leadingContent: @escaping () -> LeadingContent,
          @ViewBuilder trailingContent: @escaping () -> TrailingContent,
          action: (() -> Void)? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.footer = footer
+        self.titleTrailingAccessory = titleTrailingAccessory
+        self.titleTrailingAccessoryAccessibilityLabel = titleTrailingAccessoryAccessibilityLabel
         self.leadingContent = leadingContent
         self.trailingContent = trailingContent
         self.action = action

--- a/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
@@ -3,8 +3,6 @@
 //  Licensed under the MIT License.
 //
 
-import SwiftUI
-
 public extension ListItem {
 
     /// The accessory type for the `ListItem`.

--- a/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
@@ -25,12 +25,16 @@ public extension ListItem {
         return listItem
     }
 
-    /// Content that appears on the trailing edge of the `title` text.
-    /// - Parameter content: The content to display after the `title`.
+    /// Image that appears on the trailing edge of the `title` text.
+    /// - Parameters:
+    ///   - image: The image to display after the `title`.
+    ///   - accessibilityLabel: A localized description of the image, announced by VoiceOver after the `title`.
+    ///   Leave this `nil` when the image is purely decorative, so that VoiceOver ignores it.
     /// - Returns: The modified `ListItem` with the property set.
-    func titleTrailingAccessory<Content: View>(@ViewBuilder _ content: @escaping () -> Content) -> ListItem {
+    func titleTrailingAccessory(_ image: Image?, accessibilityLabel: String? = nil) -> ListItem {
         var listItem = self
-        listItem.titleTrailingAccessory = { AnyView(content()) }
+        listItem.titleTrailingAccessory = image
+        listItem.titleTrailingAccessoryAccessibilityLabel = accessibilityLabel
         return listItem
     }
 

--- a/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
@@ -25,8 +25,7 @@ public extension ListItem {
         return listItem
     }
 
-    /// Content that appears immediately after the `title` text, rather than against the trailing edge of the
-    /// view. Use `trailingContent` instead to place content against the trailing edge.
+    /// Content that appears on the trailing edge of the `title` text.
     /// - Parameter content: The content to display after the `title`.
     /// - Returns: The modified `ListItem` with the property set.
     func titleTrailingAccessory<Content: View>(@ViewBuilder _ content: @escaping () -> Content) -> ListItem {

--- a/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
@@ -25,15 +25,6 @@ public extension ListItem {
         return listItem
     }
 
-    /// The line limit for `title`.
-    /// - Parameter titleLineLimit: The  number of lines to display for the `title`.
-    /// - Returns: The modified `ListItem` with the property set.
-    func titleLineLimit(_ titleLineLimit: Int?) -> ListItem {
-        var listItem = self
-        listItem.titleLineLimit = titleLineLimit
-        return listItem
-    }
-
     /// Content that appears immediately after the `title` text, rather than against the trailing edge of the
     /// view. Use `trailingContent` instead to place content against the trailing edge.
     /// - Parameter content: The content to display after the `title`.
@@ -41,6 +32,15 @@ public extension ListItem {
     func titleTrailingAccessory<Content: View>(@ViewBuilder _ content: @escaping () -> Content) -> ListItem {
         var listItem = self
         listItem.titleTrailingAccessory = { AnyView(content()) }
+        return listItem
+    }
+
+    /// The line limit for `title`.
+    /// - Parameter titleLineLimit: The  number of lines to display for the `title`.
+    /// - Returns: The modified `ListItem` with the property set.
+    func titleLineLimit(_ titleLineLimit: Int?) -> ListItem {
+        var listItem = self
+        listItem.titleLineLimit = titleLineLimit
         return listItem
     }
 

--- a/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
@@ -25,19 +25,6 @@ public extension ListItem {
         return listItem
     }
 
-    /// Image that appears on the trailing edge of the `title` text.
-    /// - Parameters:
-    ///   - image: The image to display after the `title`.
-    ///   - accessibilityLabel: A localized description of the image, announced by VoiceOver after the `title`.
-    ///   Leave this `nil` when the image is purely decorative, so that VoiceOver ignores it.
-    /// - Returns: The modified `ListItem` with the property set.
-    func titleTrailingAccessory(_ image: Image?, accessibilityLabel: String? = nil) -> ListItem {
-        var listItem = self
-        listItem.titleTrailingAccessory = image
-        listItem.titleTrailingAccessoryAccessibilityLabel = accessibilityLabel
-        return listItem
-    }
-
     /// The line limit for `title`.
     /// - Parameter titleLineLimit: The  number of lines to display for the `title`.
     /// - Returns: The modified `ListItem` with the property set.

--- a/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
+++ b/Sources/FluentUI_iOS/Components/List/ListItemModifiers.swift
@@ -3,6 +3,8 @@
 //  Licensed under the MIT License.
 //
 
+import SwiftUI
+
 public extension ListItem {
 
     /// The accessory type for the `ListItem`.
@@ -29,6 +31,16 @@ public extension ListItem {
     func titleLineLimit(_ titleLineLimit: Int?) -> ListItem {
         var listItem = self
         listItem.titleLineLimit = titleLineLimit
+        return listItem
+    }
+
+    /// Content that appears immediately after the `title` text, rather than against the trailing edge of the
+    /// view. Use `trailingContent` instead to place content against the trailing edge.
+    /// - Parameter content: The content to display after the `title`.
+    /// - Returns: The modified `ListItem` with the property set.
+    func titleTrailingAccessory<Content: View>(@ViewBuilder _ content: @escaping () -> Content) -> ListItem {
+        var listItem = self
+        listItem.titleTrailingAccessory = { AnyView(content()) }
         return listItem
     }
 

--- a/Sources/FluentUI_iOS/Components/TableViewListShared/TableViewCellTokenSet.swift
+++ b/Sources/FluentUI_iOS/Components/TableViewListShared/TableViewCellTokenSet.swift
@@ -223,6 +223,9 @@ extension TableViewCellTokenSet {
     /// The default horizontal spacing in the cell.
     static let horizontalSpacing: CGFloat = GlobalTokens.spacing(.size160)
 
+    /// The spacing between the `title` and content that appears immediately after it.
+    static let titleTrailingAccessorySpacing: CGFloat = GlobalTokens.spacing(.size80)
+
     /// The leading padding in the cell.
     static let paddingLeading: CGFloat = GlobalTokens.spacing(.size160)
 


### PR DESCRIPTION
### Platforms Impacted
- [X] iOS
- [X] visionOS
- [ ] macOS

### Description of changes
Adds a `titleTrailingAccessory` slot to `ListItem` for content that sits immediately trailing the `title` text, rather than against the trailing edge of the view like `trailingContent`. This is useful for status indicators that need to read as a sort of title metadata.

- `ListItem`: Adds the `titleTrailingAccessory` property. When set, the title is wrapped in an `HStack` with the accessory trailing it; when unset, the title renders exactly as before. Adds the `ListItemTitleTrailingAccessory` accessibility identifier.
- `ListItemModifiers`: Adds the public `.titleTrailingAccessory { }` modifier, taking a `@ViewBuilder` closure like the existing content slots.
- `TableViewCellTokenSet`: Adds `titleTrailingAccessorySpacing` (8pt) for the gap between the title and the accessory.
- `ListItemDemoController_SwiftUI`: Adds a "Show title trailing accessory" toggle to the SwiftUI demo.

The slot is exposed as a modifier since adding it to the existing init would have broken existing explicit `ListItem<...>` type annotations.

We use Text instead of Label because Label would make it so we lose VoiceOver support for the icon since out `ListItem` suppresses the accessibility drill in of its children so we only readout the top level and Label marks its icon as decorative.

### Verification
Added a "Show title trailing accessory" toggle to the SwiftUI `ListItem` demo and verified the accessory renders immediately after the title text, that the title's leading edge does not move when the accessory is added, and that the title returns to its original width when the accessory is removed — confirming no spacing is reserved while the slot is unset.

Existing `ListItem` call sites are unaffected: when `titleTrailingAccessory` is unset the title takes the original rendering path unchanged.

We use 

<details>
<summary>Visual Verification</summary>

| Before                                       | After                                      |
|----------------------------------------------|--------------------------------------------|
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/6892b7ee-899b-435a-b278-91c5d4272312" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/6c4ecd47-b269-4757-8a6d-0888c4eadcd0" /> |
| <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/e34b8293-f10d-4d10-b532-5b8eb252d0cf" /> | <img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/a69d5565-0bbb-45d6-8794-203394b2daf3" /> |
</details>

### Pull request checklist

This PR has considered:
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] Different resolutions (1x, 2x, 3x)
- [x] Internationalization and Right to Left layouts
- [x] VoiceOver and Keyboard Accessibility
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2284)