### PR TITLE
Update fluentGlassEffect on visionOS

### DIFF
--- a/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
+++ b/Sources/FluentUI_common/Core/Extensions/View+Modifiers.swift
@@ -26,7 +26,7 @@ public extension View {
         interactive: Bool = false,
         tint: Color? = nil,
         in shape: T = Capsule()
-    ) -> some View where T: Shape {
+    ) -> some View where T: InsettableShape {
         self.modifier(
             FluentGlassEffectModifier(
                 interactive: interactive,
@@ -58,7 +58,7 @@ private struct ShadowModifier: ViewModifier {
     }
 }
 
-private struct FluentGlassEffectModifier<T: Shape>: ViewModifier {
+private struct FluentGlassEffectModifier<T: InsettableShape>: ViewModifier {
     @Environment(\.fluentTheme) private var fluentTheme: FluentTheme
 
     let interactive: Bool
@@ -66,7 +66,10 @@ private struct FluentGlassEffectModifier<T: Shape>: ViewModifier {
     let shape: T
 
     func body(content: Content) -> some View {
-        #if os(visionOS) || compiler(<6.2)
+        #if os(visionOS)
+        content
+            .glassBackgroundEffect(in: shape)
+        #elseif compiler(<6.2)
         content
             .background(.regularMaterial, in: shape)
             .applyFluentShadow(shadowInfo: fluentTheme.shadow(.shadow08))


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS
- [x] visionOS
- [x] macOS

### Description of changes

Update `fluentGlassEffect` on visionOS to use `glassBackgroundEffect` instead of a material background. This requires an `InsettableShape`

### Pull request checklist

This PR has considered:
- [ ] Light and Dark appearances
- [ ] iOS supported versions (all major versions greater than or equal current target deployment version)
- [ ] VoiceOver and Keyboard Accessibility
- [ ] Internationalization and Right to Left layouts
- [ ] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [ ] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [ ] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2285)