### PR TITLE
Fix Mac Catalyst build

### DIFF
--- a/Sources/FluentUI_common/Core/Extensions/NSFont+Extensions.swift
+++ b/Sources/FluentUI_common/Core/Extensions/NSFont+Extensions.swift
@@ -3,7 +3,7 @@
 //  Licensed under the MIT License.
 //
 
-#if canImport(AppKit)
+#if canImport(AppKit) && !targetEnvironment(macCatalyst)
 import AppKit
 import SwiftUI
 
@@ -127,4 +127,4 @@ extension NSFont {
         }
     }
 }
-#endif // canImport(AppKit)
+#endif // canImport(AppKit) && !targetEnvironment(macCatalyst)

--- a/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/BottomSheetController.swift
@@ -181,6 +181,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     /// Defaults to `false` to preserve existing behavior. Requires iOS 18+.
     /// Note: This will cause more layout passes during animations, which may impact performance.
     @available(iOS 18.0, visionOS 2.0, *)
+    @available(macCatalyst, unavailable)
     open var usesCustomSpringAnimator: Bool {
         get { _usesCustomSpringAnimator }
         set { _usesCustomSpringAnimator = newValue }
@@ -193,6 +194,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
     /// Defaults to `true`. Only takes effect when `usesCustomSpringAnimator` is also `true`.
     /// Requires iOS 18+.
     @available(iOS 18.0, visionOS 2.0, *)
+    @available(macCatalyst, unavailable)
     open var usesHighFrameRatePanning: Bool {
         get { _usesHighFrameRatePanning }
         set { _usesHighFrameRatePanning = newValue }
@@ -1040,9 +1042,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         switch sender.state {
         case .began:
             completeAnimationsIfNeeded()
+#if !targetEnvironment(macCatalyst)
             if #available(iOS 18.0, visionOS 2.0, *), usesCustomSpringAnimator && usesHighFrameRatePanning {
                 sheetAnimator.wantsHighFrameRateIdle = true
             }
+#endif // !targetEnvironment(macCatalyst)
             delegate?.bottomSheetStartedPan?(self, from: currentExpansionState)
             currentExpansionState = .transitioning
             fallthrough
@@ -1051,9 +1055,11 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             sender.setTranslation(.zero, in: view)
         case .ended, .cancelled, .failed:
             completePan(with: sender.velocity(in: view).y)
+#if !targetEnvironment(macCatalyst)
             if #available(iOS 18.0, visionOS 2.0, *), usesCustomSpringAnimator && usesHighFrameRatePanning {
                 sheetAnimator.wantsHighFrameRateIdle = false
             }
+#endif // !targetEnvironment(macCatalyst)
         default:
             break
         }
@@ -1234,29 +1240,32 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         if currentSheetVerticalOffset != offset(for: targetExpansionState) {
             delegate?.bottomSheetController?(self, willMoveTo: targetExpansionState, interaction: interaction)
 
+#if !targetEnvironment(macCatalyst)
             if animated, #available(iOS 18.0, visionOS 2.0, *), usesCustomSpringAnimator {
                 moveWithSpringAnimator(to: targetExpansionState,
-                                    velocity: velocity,
-                                    interaction: interaction,
-                                    shouldNotifyDelegate: shouldNotifyDelegate,
-                                    completion: completion)
-            } else {
-                let animator = stateChangeAnimator(to: targetExpansionState,
-                                                   velocity: velocity,
-                                                   interaction: interaction,
-                                                   shouldNotifyDelegate: shouldNotifyDelegate)
-                animator.addCompletion({ finalPosition in
-                    completion?(finalPosition)
-                })
+                                       velocity: velocity,
+                                       interaction: interaction,
+                                       shouldNotifyDelegate: shouldNotifyDelegate,
+                                       completion: completion)
+                return
+            }
+#endif // !targetEnvironment(macCatalyst)
 
-                if animated {
-                    currentStateChangeAnimator = animator
-                    animator.startAnimation()
-                } else {
-                    animator.startAnimation() // moves the animator into active state so it can be stopped
-                    animator.stopAnimation(false)
-                    animator.finishAnimation(at: .end)
-                }
+            let animator = stateChangeAnimator(to: targetExpansionState,
+                                               velocity: velocity,
+                                               interaction: interaction,
+                                               shouldNotifyDelegate: shouldNotifyDelegate)
+            animator.addCompletion({ finalPosition in
+                completion?(finalPosition)
+            })
+
+            if animated {
+                currentStateChangeAnimator = animator
+                animator.startAnimation()
+            } else {
+                animator.startAnimation() // moves the animator into active state so it can be stopped
+                animator.stopAnimation(false)
+                animator.finishAnimation(at: .end)
             }
         } else {
             handleCompletedStateChange(to: targetExpansionState, interaction: interaction, shouldNotifyDelegate: shouldNotifyDelegate)
@@ -1325,12 +1334,13 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         return translationAnimator
     }
 
+#if !targetEnvironment(macCatalyst)
     @available(iOS 18.0, visionOS 2.0, *)
     private func moveWithSpringAnimator(to targetExpansionState: BottomSheetExpansionState,
-                                     velocity: CGFloat,
-                                     interaction: BottomSheetInteraction,
-                                     shouldNotifyDelegate: Bool,
-                                     completion: ((UIViewAnimatingPosition) -> Void)?) {
+                                        velocity: CGFloat,
+                                        interaction: BottomSheetInteraction,
+                                        shouldNotifyDelegate: Bool,
+                                        completion: ((UIViewAnimatingPosition) -> Void)?) {
         let targetVerticalOffset = offset(for: targetExpansionState)
         let fromOffset = currentSheetVerticalOffset
 
@@ -1369,6 +1379,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             completion?(.end)
         }
     }
+#endif // !targetEnvironment(macCatalyst)
 
     // Vertical offset of bottomSheetView.origin for the given expansion state
     //
@@ -1435,6 +1446,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
             currentStateChangeAnimator = nil
         }
 
+#if !targetEnvironment(macCatalyst)
         if #available(iOS 18.0, visionOS 2.0, *), sheetAnimator.isRunning {
             if skipToEnd {
                 sheetAnimator.skipToEnd()
@@ -1442,6 +1454,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
                 sheetAnimator.stop()
             }
         }
+#endif // !targetEnvironment(macCatalyst)
     }
 
     private func makeLayoutGuideConstraints() -> [NSLayoutConstraint] {
@@ -1551,6 +1564,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
 
     private var currentStateChangeAnimator: UIViewPropertyAnimator?
 
+#if !targetEnvironment(macCatalyst)
     @available(iOS 18.0, visionOS 2.0, *)
     private var sheetAnimator: SheetAnimator {
         if let existing = _sheetAnimator as? SheetAnimator {
@@ -1561,6 +1575,7 @@ public class BottomSheetController: UIViewController, Shadowable, TokenizedContr
         return animator
     }
     private var _sheetAnimator: AnyObject?
+#endif // !targetEnvironment(macCatalyst)
 
     private var currentExpansionState: BottomSheetExpansionState = .collapsed
 

--- a/Sources/FluentUI_iOS/Components/BottomSheet/SheetAnimator.swift
+++ b/Sources/FluentUI_iOS/Components/BottomSheet/SheetAnimator.swift
@@ -3,6 +3,7 @@
 //  Licensed under the MIT License.
 //
 
+#if !targetEnvironment(macCatalyst)
 import UIKit
 
 /// A `UIUpdateLink`-driven spring animator designed for sheet transitions.
@@ -219,3 +220,4 @@ public class SheetAnimator {
         stopUpdateLink()
     }
 }
+#endif // !targetEnvironment(macCatalyst)


### PR DESCRIPTION
### Platforms Impacted
- [x] iOS / Mac Catalyst
- [ ] visionOS
- [ ] macOS

### Description of changes

Fixes compilation of the FluentUI Swift package for Mac Catalyst.

Mac Catalyst compilation regressed after:

- #2249 introduced the `UIUpdateLink`-based custom bottom-sheet animator, which is unavailable on Mac Catalyst.
- #2251 moved the `NSFont` extensions into the common target behind `canImport(AppKit)`. That condition also succeeds for Mac Catalyst even though the required AppKit font APIs are unavailable there.

This change:

- Excludes the AppKit-specific `NSFont` extensions from Mac Catalyst.
- Excludes the `UIUpdateLink`-based `SheetAnimator` implementation from Mac Catalyst.
- Marks the custom spring animator APIs as unavailable on Mac Catalyst.
- Uses the existing `UIViewPropertyAnimator` path for bottom-sheet animations on Mac Catalyst.

Existing iOS and visionOS behavior remains unchanged.

### Binary change

No meaningful binary-size impact is expected. This change only adjusts platform-specific compilation.

### Verification

Verified that the `FluentUI` scheme builds for the generic Mac Catalyst destination in Release configuration.

<details>
<summary>Visual Verification</summary>

Not applicable; this is a build compatibility change with no intended visual impact.
</details>

### Pull request checklist

This PR has considered:
- [x] Light and Dark appearances
- [x] iOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [x] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [x] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)

No changes to appearance, accessibility, localization, layout, pointer interaction, SwiftUI consumption, or Objective-C exposure are expected.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2290)