### PR TITLE
[macOS] Use true glass buttons on macOS

### DIFF
--- a/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestGlassButtonController.swift
+++ b/Demos/FluentUIDemo_macOS/FluentUITestViewControllers/TestGlassButtonController.swift
@@ -10,18 +10,7 @@ import FluentUI
 class TestGlassButtonController: NSViewController {
 
 	// Create various styles of GlassButton
-	let displayedGlassButtons: [[NSView]] = glassButtons().map { glassButtons in
-		glassButtons.map { glassButton in
-			if #available(macOS 26.0, *) {
-				let glassView = NSGlassEffectView()
-				glassView.cornerRadius = .greatestFiniteMagnitude
-				glassView.contentView = glassButton
-				return glassView
-			} else {
-				return glassButton
-			}
-		}
-	}
+	let displayedGlassButtons: [[NSView]] = glassButtons()
 
 	override func loadView() {
 

--- a/Sources/FluentUI_macOS/Components/Button/Button.swift
+++ b/Sources/FluentUI_macOS/Components/Button/Button.swift
@@ -125,6 +125,11 @@ open class Button: NSButton {
 		}
 	}
 
+	/// Controls Fluent drawing and layout. System-bezel subclasses return `false`.
+	var usesFluentBezelDrawing: Bool {
+		return true
+	}
+
 	func setupBorderShadowsIfNeeded() {
 		// At the moment border shadows only apply for the Primary and Secondary Button Styles.
 		// Border shadows being meant for buttons and their corresponding States, that have ~some~
@@ -135,7 +140,7 @@ open class Button: NSButton {
 		// challenge. Therefore, unless it becomes necessary, these buttons will remain without shadows.
 		// And perhaps shadowPath is the way to go, where you can have the CALayer have a Clear
 		// background color and still show a shadow by setting a hollow shadowPath around the button.
-		self.usesBorderShadows = style == .primary || style == .secondary
+		self.usesBorderShadows = usesFluentBezelDrawing && (style == .primary || style == .secondary)
 	}
 
 	var firstOuterDropShadowLayer: CALayer?
@@ -190,6 +195,8 @@ open class Button: NSButton {
 				} else {
 					let imageView = NSImageView(image: trailingImage)
 					imageView.translatesAutoresizingMaskIntoConstraints = false
+					imageView.setAccessibilityElement(false)
+					imageView.cell?.setAccessibilityElement(false)
 					addSubview(imageView)
 					NSLayoutConstraint.activate([
 						imageView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -cell.horizontalPadding),
@@ -284,6 +291,11 @@ open class Button: NSButton {
 	}
 
 	open override func updateLayer() {
+		guard usesFluentBezelDrawing else {
+			super.updateLayer()
+			return
+		}
+
 		guard let layer = layer else {
 			return
 		}
@@ -333,6 +345,11 @@ open class Button: NSButton {
 	}
 
 	open override func drawFocusRingMask() {
+		guard usesFluentBezelDrawing else {
+			super.drawFocusRingMask()
+			return
+		}
+
 		// Ensure we draw the focus ring around the entire button bounds
 		// rather than just around the image or title.
 		let path = NSBezierPath(roundedRect: bounds, xRadius: cornerRadius, yRadius: cornerRadius)
@@ -643,7 +660,9 @@ open class Button: NSButton {
 		// Account for extra space needed by `trailingImage`
 		if let trailingImage = trailingImage,
 		   let cell = cell as? ButtonCell {
-			trailingImageAdjustment = trailingImage.size.width + cell.titleToImageSpacing
+			// Reserve both sides to keep AppKit's centered content clear of the trailing image.
+			let sides: CGFloat = usesFluentBezelDrawing ? 1 : 2
+			trailingImageAdjustment = sides * (trailingImage.size.width + cell.titleToImageSpacing)
 		} else {
 			trailingImageAdjustment = 0
 		}
@@ -685,7 +704,19 @@ class ButtonCell: NSButtonCell {
 	var titleToImageSpacing: CGFloat = 0
 	var titleToImageVerticalSpacingAdjustment: CGFloat = 0
 
+	/// Use Fluent layout for custom bezels or trailing images, which AppKit's layout ignores.
+	private var usesFluentLayout: Bool {
+		guard let button = controlView as? Button else {
+			return true
+		}
+		return button.usesFluentBezelDrawing || button.trailingImage != nil
+	}
+
 	override func imageRect(forBounds rect: NSRect) -> NSRect {
+		guard usesFluentLayout else {
+			return super.imageRect(forBounds: rect)
+		}
+
 		guard
 			let image = image,
 			let controlView = controlView,
@@ -735,14 +766,17 @@ class ButtonCell: NSButtonCell {
 		if xOffsetSign != 0 {
 			// Offset the Primary Image from the Title
 			x += CGFloat(xOffsetSign) * (titleSize.width + titleToImageSpacing) / 2
+		}
 
-			// Offset the Title from the Trailing Image
-			if let controlView = controlView as? Button,
-			   let trailingImage = controlView.trailingImage {
-				x += CGFloat(-1 * layoutDirectionSign) * (trailingImage.size.width + titleToImageSpacing) / 2
-			}
-		} else if yOffsetSign != 0 {
+		if yOffsetSign != 0 {
 			y += CGFloat(yOffsetSign) * (titleSize.height + titleToImageSpacing - titleToImageVerticalSpacingAdjustment) / 2
+		}
+
+		// Keep the primary image clear of the trailing image, even in `.imageOnly`.
+		if yOffsetSign == 0,
+		   let controlView = controlView as? Button,
+		   let trailingImage = controlView.trailingImage {
+			x += CGFloat(-1 * layoutDirectionSign) * (trailingImage.size.width + titleToImageSpacing) / 2
 		}
 
 		return NSRect(
@@ -754,6 +788,10 @@ class ButtonCell: NSButtonCell {
 	}
 
 	override func titleRect(forBounds rect: NSRect) -> NSRect {
+		guard usesFluentLayout else {
+			return super.titleRect(forBounds: rect)
+		}
+
 		guard
 			let font = font,
 			let controlView = controlView,
@@ -822,6 +860,10 @@ class ButtonCell: NSButtonCell {
 	}
 
 	override func drawingRect(forBounds rect: NSRect) -> NSRect {
+		guard usesFluentLayout else {
+			return super.drawingRect(forBounds: rect)
+		}
+
 		var width = rect.width - (horizontalPadding * 2)
 		var height = rect.height - (verticalPadding * 2)
 

--- a/Sources/FluentUI_macOS/Components/Button/GlassButton.swift
+++ b/Sources/FluentUI_macOS/Components/Button/GlassButton.swift
@@ -11,6 +11,8 @@ import AppKit
 // MARK: - Button
 
 /// A fluent styled button, with hover effects and a corner radius.
+///
+/// Uses AppKit's glass bezel on macOS 26+, falling back to FluentUI's translucent capsule.
 @objc(MSFGlassButton)
 open class GlassButton: Button {
 	/// Swift-only designated initializer accepting ButtonFormat struct.
@@ -27,8 +29,148 @@ open class GlassButton: Button {
 	) {
 		super.init(title: title, image: image, imagePosition: imagePosition, format: format)
 
-		// Update to use the established sizing for glass buttons
-		self.setSizeParameters(GlassButton.standardSizeParameters)
+		// Expose the button, since custom layout clears the cell's accessible content.
+		setAccessibilityElement(true)
+		setAccessibilityRole(.button)
+
+		if usesSystemGlassBezel, #available(macOS 26.0, *) {
+			configureSystemGlassBezel()
+
+			// Refresh colors now that the bezel is configured.
+			setColorValues(forStyle: style, accentColor: accentColor)
+			setSizeParameters(GlassButton.systemBezelSizeParameters)
+		}
+	}
+
+	open override func setAccessibilityLabel(_ accessibilityLabel: String?) {
+		explicitAccessibilityLabel = accessibilityLabel
+		super.setAccessibilityLabel(accessibilityLabel)
+	}
+
+	open override func accessibilityLabel() -> String? {
+		let label: String?
+		if let explicitAccessibilityLabel = explicitAccessibilityLabel {
+			label = explicitAccessibilityLabel
+		} else if !title.isEmpty {
+			label = title
+		} else if imagePosition != .noImage, let description = image?.accessibilityDescription {
+			label = description
+		} else {
+			label = super.accessibilityLabel()
+		}
+		return label
+	}
+
+	open override var image: NSImage? {
+		get {
+			return usesOwnContentLayout ? logicalImage : super.image
+		}
+		set {
+			logicalImage = newValue
+			guard usesOwnContentLayout else {
+				super.image = newValue
+				return
+			}
+			super.image = nil
+			configureOwnContentViewsIfNeeded()
+			primaryImageView?.image = newValue
+			primaryImageView?.isHidden = (newValue == nil)
+			invalidateIntrinsicContentSize()
+		}
+	}
+
+	open override var title: String {
+		get {
+			return usesOwnContentLayout ? logicalTitle : super.title
+		}
+		set {
+			logicalTitle = newValue
+			guard usesOwnContentLayout else {
+				super.title = newValue
+				return
+			}
+			super.title = ""
+			configureOwnContentViewsIfNeeded()
+			titleLabel?.stringValue = newValue
+			titleLabel?.isHidden = shouldHideTitleLabel
+			invalidateIntrinsicContentSize()
+		}
+	}
+
+	open override var imagePosition: NSControl.ImagePosition {
+		didSet {
+			guard usesOwnContentLayout, oldValue != imagePosition else {
+				return
+			}
+			titleLabel?.isHidden = shouldHideTitleLabel
+			invalidateIntrinsicContentSize()
+		}
+	}
+
+	open override var trailingImage: NSImage? {
+		didSet {
+			let wasOwnLayout = usesSystemGlassBezel && oldValue != nil
+			guard wasOwnLayout != usesOwnContentLayout else {
+				// Button's observer already updated the trailing image view.
+				return
+			}
+
+			if usesOwnContentLayout {
+				// Move AppKit's content into our subviews.
+				let currentImage = super.image
+				let currentTitle = super.title
+				logicalImage = currentImage
+				logicalTitle = currentTitle
+				super.image = nil
+				super.title = ""
+				configureOwnContentViewsIfNeeded()
+				primaryImageView?.image = currentImage
+				primaryImageView?.isHidden = (currentImage == nil)
+				titleLabel?.stringValue = currentTitle
+				titleLabel?.isHidden = shouldHideTitleLabel
+			} else {
+				// Restore AppKit's content.
+				super.image = logicalImage
+				super.title = logicalTitle
+				primaryImageView?.isHidden = true
+				titleLabel?.isHidden = true
+			}
+			// Tint handling changes with content ownership.
+			setColorValues(forStyle: style, accentColor: accentColor)
+			invalidateIntrinsicContentSize()
+		}
+	}
+
+	open override var intrinsicContentSize: CGSize {
+		guard usesSystemGlassBezel else {
+			return super.intrinsicContentSize
+		}
+
+		// AppKit's control sizes add too much padding for Fluent's compact 28pt capsule.
+		// Compute our own size while leaving bezel drawing to AppKit.
+		let imageSize = (imagePosition != .noImage) ? (image?.size ?? .zero) : .zero
+		let hasImage = imageSize != .zero
+		let hasTitle = imagePosition != .imageOnly && !title.isEmpty
+		let horizontalPadding = (cell as? ButtonCell)?.horizontalPadding ?? GlassButton.systemBezelSizeParameters.horizontalPadding
+
+		var width: CGFloat = 0
+		if hasImage {
+			width += imageSize.width
+		}
+		if hasTitle {
+			width += title.size(withAttributes: [.font: font as Any]).width
+		}
+		if hasImage, hasTitle, let cell = cell as? ButtonCell {
+			width += cell.titleToImageSpacing
+		}
+		width += horizontalPadding * 2
+
+		// Custom content layout needs trailing-image space on only one side.
+		if let trailingImage = trailingImage, let cell = cell as? ButtonCell {
+			width += trailingImage.size.width + cell.titleToImageSpacing
+		}
+
+		return CGSize(width: ceil(width), height: GlassButton.standardSizeParameters.minButtonHeight)
 	}
 
 	override public var style: ButtonStyle {
@@ -41,17 +183,45 @@ open class GlassButton: Button {
 		}
 	}
 
+	/// Glass buttons use fixed metrics regardless of `ButtonSize`.
+	override func setSizeParameters(_ parameters: ButtonSizeParameters) {
+		super.setSizeParameters(usesSystemGlassBezel ? GlassButton.systemBezelSizeParameters : GlassButton.standardSizeParameters)
+	}
+
+	override func updateContentTintColor() {
+		super.updateContentTintColor()
+		guard usesOwnContentLayout else {
+			return
+		}
+		primaryImageView?.contentTintColor = contentTintColor
+		titleLabel?.textColor = contentTintColor
+	}
+
 	override func setColorValues(forStyle: ButtonStyle, accentColor: NSColor) {
+		guard forStyle == .primary || forStyle == .secondary else {
+			preconditionFailure("Unsupported style for GlassButton: \(forStyle)")
+		}
+
+		if #available(macOS 26.0, *), usesSystemGlassBezel {
+			// AppKit owns background and border drawing in both content layouts.
+			let clearColorSet = ButtonColorSet(rest: .clear, pressed: .clear, hovered: .clear, disabled: .clear)
+			backgroundColorSet = clearColorSet
+			borderColorSet = clearColorSet
+			updateSystemGlassBezelTint()
+
+			if !usesOwnContentLayout {
+				// Avoid applying Fluent tints over AppKit's content.
+				contentTintColorSet = .init(rest: nil, pressed: nil, hovered: nil, disabled: nil)
+				updateContentTintColor()
+				return
+			}
+			// Custom content uses Fluent tints below; AppKit still draws the background and border.
+		}
 
 		// Use System Colors which respond correctly to accessibility settings like increase contrast
 		// https://developer.apple.com/documentation/appkit/nscolor/ui_element_colors
 		let increaseContrastBorderColor: NSColor = .textColor
-		let clearAlphaComponent: CGFloat
-		if #available(macOS 26.0, *) {
-			clearAlphaComponent = 0.05
-		} else {
-			clearAlphaComponent = 0.5
-		}
+		let clearAlphaComponent: CGFloat = 0.5
 
 		switch forStyle {
 		case .primary:
@@ -103,6 +273,10 @@ open class GlassButton: Button {
 		updateContentTintColor()
 	}
 
+	override var usesFluentBezelDrawing: Bool {
+		return !usesSystemGlassBezel
+	}
+
 	override var cornerRadius: CGFloat {
 		get {
 			return (bounds.size.height / 2.0)
@@ -112,7 +286,74 @@ open class GlassButton: Button {
 		}
 	}
 
-	static let standardSizeParameters = ButtonSizeParameters(
+	/// Pin content to the leading edge to reserve trailing-image space.
+	/// Avoid NSStackView's fitting constraints, which can widen the button beyond its intrinsic size.
+	private func configureOwnContentViewsIfNeeded() {
+		guard primaryImageView == nil else {
+			return
+		}
+		guard let cell = cell as? ButtonCell else {
+			return
+		}
+
+		let imageView = NSImageView()
+		imageView.translatesAutoresizingMaskIntoConstraints = false
+		imageView.imageScaling = .scaleNone
+		imageView.setAccessibilityElement(false)
+		// Ignoring a control does not ignore its cell.
+		imageView.cell?.setAccessibilityElement(false)
+		addSubview(imageView)
+		primaryImageView = imageView
+
+		let label = NSTextField(labelWithString: "")
+		label.translatesAutoresizingMaskIntoConstraints = false
+		label.font = font
+		label.lineBreakMode = .byClipping
+		label.setAccessibilityElement(false)
+		label.cell?.setAccessibilityElement(false)
+		addSubview(label)
+		titleLabel = label
+
+		NSLayoutConstraint.activate([
+			imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: cell.horizontalPadding),
+			imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+			label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: cell.titleToImageSpacing),
+			label.centerYAnchor.constraint(equalTo: centerYAnchor)
+		])
+	}
+
+	@available(macOS 26.0, *)
+	private func configureSystemGlassBezel() {
+		// A bordered push-in button enables system bezel drawing and highlighting.
+		isBordered = true
+		bezelStyle = .glass
+		borderShape = .capsule
+		setButtonType(.momentaryPushIn)
+
+		imageHugsTitle = true
+
+		// Use compact system metrics; intrinsicContentSize supplies the 28pt height.
+		controlSize = .regular
+
+		// Restore system disabled-image treatment, which Button opts out of.
+		(cell as? ButtonCell)?.imageDimsWhenDisabled = true
+
+		updateSystemGlassBezelTint()
+	}
+
+	@available(macOS 26.0, *)
+	private func updateSystemGlassBezelTint() {
+		switch style {
+		case .primary:
+			bezelColor = accentColor
+			tintProminence = .primary
+		default:
+			bezelColor = nil
+			tintProminence = .automatic
+		}
+	}
+
+	private static let standardSizeParameters = ButtonSizeParameters(
 		fontSize: 13,  // line height: 17
 		cornerRadius: 0.0, // unused
 		verticalPadding: 4.0, // overall height: 28
@@ -122,4 +363,42 @@ open class GlassButton: Button {
 		titleToImageVerticalSpacingAdjustment: 7,
 		minButtonHeight: 28
 	)
+
+	private static let systemBezelSizeParameters = ButtonSizeParameters(
+		fontSize: NSFont.systemFontSize(for: .regular),
+		cornerRadius: 0.0, // unused
+		verticalPadding: 0.0, // unused
+		horizontalPadding: 8.0,
+		titleVerticalPositionAdjustment: 0,
+		titleToImageSpacing: 4.0,
+		titleToImageVerticalSpacingAdjustment: 0,
+		minButtonHeight: 0
+	)
+
+	private lazy var usesSystemGlassBezel: Bool = {
+		guard #available(macOS 26.0, *) else {
+			return false
+		}
+		return true
+	}()
+
+	/// AppKit's glass content drawing ignores cell layout overrides and `trailingImage`.
+	/// Clear its image/title and use subviews when a trailing image needs reserved space.
+	private var usesOwnContentLayout: Bool {
+		return usesSystemGlassBezel && trailingImage != nil
+	}
+
+	/// Preserve image/title while custom layout keeps AppKit's storage empty.
+	private var logicalImage: NSImage?
+	private var logicalTitle: String = ""
+
+	private var primaryImageView: NSImageView?
+	private var titleLabel: NSTextField?
+
+	private var explicitAccessibilityLabel: String?
+
+	/// `.imageOnly` can hide the title without clearing it.
+	private var shouldHideTitleLabel: Bool {
+		return logicalTitle.isEmpty || imagePosition == .imageOnly
+	}
 }

--- a/Sources/FluentUI_macOS/Components/Button/GlassButton.swift
+++ b/Sources/FluentUI_macOS/Components/Button/GlassButton.swift
@@ -74,7 +74,7 @@ open class GlassButton: Button {
 			super.image = nil
 			configureOwnContentViewsIfNeeded()
 			primaryImageView?.image = newValue
-			primaryImageView?.isHidden = (newValue == nil)
+			updateOwnContentLayout()
 			invalidateIntrinsicContentSize()
 		}
 	}
@@ -92,7 +92,7 @@ open class GlassButton: Button {
 			super.title = ""
 			configureOwnContentViewsIfNeeded()
 			titleLabel?.stringValue = newValue
-			titleLabel?.isHidden = shouldHideTitleLabel
+			updateOwnContentLayout()
 			invalidateIntrinsicContentSize()
 		}
 	}
@@ -102,7 +102,7 @@ open class GlassButton: Button {
 			guard usesOwnContentLayout, oldValue != imagePosition else {
 				return
 			}
-			titleLabel?.isHidden = shouldHideTitleLabel
+			updateOwnContentLayout()
 			invalidateIntrinsicContentSize()
 		}
 	}
@@ -115,6 +115,7 @@ open class GlassButton: Button {
 				return
 			}
 
+			let currentImagePosition = imagePosition
 			if usesOwnContentLayout {
 				// Move AppKit's content into our subviews.
 				let currentImage = super.image
@@ -125,15 +126,18 @@ open class GlassButton: Button {
 				super.title = ""
 				configureOwnContentViewsIfNeeded()
 				primaryImageView?.image = currentImage
-				primaryImageView?.isHidden = (currentImage == nil)
 				titleLabel?.stringValue = currentTitle
-				titleLabel?.isHidden = shouldHideTitleLabel
 			} else {
 				// Restore AppKit's content.
 				super.image = logicalImage
 				super.title = logicalTitle
 				primaryImageView?.isHidden = true
 				titleLabel?.isHidden = true
+			}
+			// AppKit may change imagePosition when restoring its image and title.
+			imagePosition = currentImagePosition
+			if usesOwnContentLayout {
+				updateOwnContentLayout()
 			}
 			// Tint handling changes with content ownership.
 			setColorValues(forStyle: style, accentColor: accentColor)
@@ -151,7 +155,14 @@ open class GlassButton: Button {
 		let imageSize = (imagePosition != .noImage) ? (image?.size ?? .zero) : .zero
 		let hasImage = imageSize != .zero
 		let hasTitle = imagePosition != .imageOnly && !title.isEmpty
-		let horizontalPadding = (cell as? ButtonCell)?.horizontalPadding ?? GlassButton.systemBezelSizeParameters.horizontalPadding
+
+		// We use a narrower padding when it's icon-only to make the button look round.
+		let horizontalPadding: CGFloat
+		if hasImage && !hasTitle && trailingImage == nil {
+			horizontalPadding = 4.0
+		} else {
+			horizontalPadding = (cell as? ButtonCell)?.horizontalPadding ?? GlassButton.systemBezelSizeParameters.horizontalPadding
+		}
 
 		var width: CGFloat = 0
 		if hasImage {
@@ -317,9 +328,24 @@ open class GlassButton: Button {
 		NSLayoutConstraint.activate([
 			imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: cell.horizontalPadding),
 			imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
-			label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: cell.titleToImageSpacing),
 			label.centerYAnchor.constraint(equalTo: centerYAnchor)
 		])
+	}
+
+	private func updateOwnContentLayout() {
+		guard let imageView = primaryImageView, let label = titleLabel, let cell = cell as? ButtonCell else {
+			return
+		}
+
+		let hideImage = imagePosition == .noImage || logicalImage == nil
+		imageView.isHidden = hideImage
+		label.isHidden = shouldHideTitleLabel
+
+		titleLeadingConstraint?.isActive = false
+		titleLeadingConstraint = hideImage
+			? label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: cell.horizontalPadding)
+			: label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: cell.titleToImageSpacing)
+		titleLeadingConstraint?.isActive = true
 	}
 
 	@available(macOS 26.0, *)
@@ -396,6 +422,8 @@ open class GlassButton: Button {
 	private var titleLabel: NSTextField?
 
 	private var explicitAccessibilityLabel: String?
+
+	private var titleLeadingConstraint: NSLayoutConstraint?
 
 	/// `.imageOnly` can hide the title without clearing it.
 	private var shouldHideTitleLabel: Bool {

--- a/Tests/FluentUI_macOS_Tests/GlassButtonTests.swift
+++ b/Tests/FluentUI_macOS_Tests/GlassButtonTests.swift
@@ -1,0 +1,189 @@
+//
+//  Copyright (c) Microsoft Corporation. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import AppKit
+import XCTest
+@testable import FluentUI_macos
+
+class GlassButtonTests: XCTestCase {
+	func testSingleAccessibleButton() {
+		let button = makeButton()
+
+		for trailingImage in [nil, makeImage(description: "Chevron"), nil] {
+			button.trailingImage = trailingImage
+
+			XCTAssertTrue(button.isAccessibilityElement())
+			XCTAssertEqual(button.accessibilityRole(), .button)
+			XCTAssertTrue((NSAccessibility.unignoredDescendant(of: button) as? NSView) === button)
+			XCTAssertTrue(button.accessibilityChildren()?.isEmpty ?? true)
+			XCTAssertTrue(button.subviews.filter { $0 is NSImageView || $0 is NSTextField }.allSatisfy {
+				!$0.isAccessibilityElement()
+			})
+		}
+	}
+
+	func testDecorativeContentIsIgnoredByWindowHitTesting() throws {
+		let button = makeButton()
+		let window = NSWindow(
+			contentRect: NSRect(x: 100, y: 100, width: 320, height: 120),
+			styleMask: [.titled],
+			backing: .buffered,
+			defer: false
+		)
+		window.isReleasedWhenClosed = false
+		let contentView = try XCTUnwrap(window.contentView)
+		contentView.addSubview(button)
+		button.setFrameOrigin(NSPoint(x: 20, y: 20))
+		window.orderBack(nil)
+		defer { window.orderOut(nil) }
+
+		for trailingImage in [makeImage(description: "Chevron"), makeImage(description: "Menu"), nil, makeImage(description: "Chevron")] {
+			button.trailingImage = trailingImage
+
+			for imagePosition: NSControl.ImagePosition in [.imageLeading, .imageOnly] {
+				button.imagePosition = imagePosition
+				button.setFrameSize(button.intrinsicContentSize)
+				button.layoutSubtreeIfNeeded()
+
+				let decorativeViews = button.subviews.filter { $0 is NSImageView || $0 is NSTextField }
+				if #available(macOS 26.0, *), trailingImage != nil {
+					XCTAssertEqual(decorativeViews.count, 3)
+				}
+				for view in decorativeViews {
+					XCTAssertNil(NSAccessibility.unignoredDescendant(of: view), "\(type(of: view)) exposes an accessibility descendant")
+					if !view.isHidden {
+						XCTAssertFalse(view.bounds.isEmpty)
+						let center = NSPoint(x: view.bounds.midX, y: view.bounds.midY)
+						let screenPoint = window.convertPoint(toScreen: view.convert(center, to: nil))
+						XCTAssertTrue(
+							(window.accessibilityHitTest(screenPoint) as? NSView) === button,
+							"Hit-testing \(type(of: view)) should return the button"
+						)
+					}
+				}
+			}
+		}
+	}
+
+	func testLabelFollowsTitleAndLayoutChanges() {
+		let button = makeButton()
+		XCTAssertEqual(button.accessibilityLabel(), "Share")
+
+		button.trailingImage = makeImage(description: "Chevron")
+		XCTAssertEqual(button.accessibilityLabel(), "Share")
+
+		button.title = "Share document"
+		XCTAssertEqual(button.accessibilityLabel(), "Share document")
+
+		button.imagePosition = .imageOnly
+		XCTAssertEqual(button.accessibilityLabel(), "Share document")
+
+		button.imagePosition = .imageLeading
+		button.trailingImage = nil
+		XCTAssertEqual(button.accessibilityLabel(), "Share document")
+
+		button.trailingImage = makeImage(description: "Chevron")
+		XCTAssertEqual(button.accessibilityLabel(), "Share document")
+	}
+
+	func testImageOnlyLabelFollowsImageDescription() {
+		let button = makeButton()
+		button.title = ""
+		button.imagePosition = .imageOnly
+		button.image = makeImage(description: "Share document")
+		button.trailingImage = makeImage(description: "Chevron")
+		XCTAssertEqual(button.accessibilityLabel(), "Share document")
+
+		button.image = makeImage(description: "More options")
+		XCTAssertEqual(button.accessibilityLabel(), "More options")
+
+		button.image?.accessibilityDescription = "Additional options"
+		XCTAssertEqual(button.accessibilityLabel(), "Additional options")
+
+		button.trailingImage = nil
+		XCTAssertEqual(button.accessibilityLabel(), "Additional options")
+	}
+
+	func testExplicitLabelSurvivesContentAndLayoutChanges() {
+		let button = makeButton()
+		button.setAccessibilityLabel("Sharing options")
+		button.trailingImage = makeImage(description: "Chevron")
+		button.title = "Share document"
+		button.image = makeImage(description: "Share icon")
+		button.imagePosition = .imageOnly
+		XCTAssertEqual(button.accessibilityLabel(), "Sharing options")
+
+		button.trailingImage = nil
+		XCTAssertEqual(button.accessibilityLabel(), "Sharing options")
+
+		button.setAccessibilityLabel("")
+		XCTAssertEqual(button.accessibilityLabel(), "")
+
+		button.trailingImage = makeImage(description: "Chevron")
+		button.setAccessibilityLabel(nil)
+		XCTAssertEqual(button.accessibilityLabel(), "Share document")
+
+		button.title = ""
+		XCTAssertEqual(button.accessibilityLabel(), "Share icon")
+	}
+
+	func testAccessibilityMetadataIsPreserved() {
+		let button = makeButton()
+		button.toolTip = "Share this document"
+		button.setAccessibilityIdentifier("shareButton")
+		button.setAccessibilityHelp("Choose who can access this document")
+		button.setAccessibilityTitle("Document sharing")
+
+		for trailingImage in [nil, makeImage(description: "Chevron"), nil] {
+			button.trailingImage = trailingImage
+			XCTAssertEqual(button.accessibilityIdentifier(), "shareButton")
+			XCTAssertEqual(button.accessibilityHelp(), "Choose who can access this document")
+			XCTAssertEqual(button.accessibilityTitle(), "Document sharing")
+		}
+	}
+
+	func testPressAndDisabledState() {
+		let button = makeButton()
+		let receiver = ActionReceiver()
+		button.target = receiver
+		button.action = #selector(ActionReceiver.press(_:))
+
+		for trailingImage in [nil, makeImage(description: "Chevron"), nil] {
+			button.trailingImage = trailingImage
+			button.isEnabled = true
+			XCTAssertTrue(button.isAccessibilityEnabled())
+			let previousCount = receiver.pressCount
+			_ = button.accessibilityPerformPress()
+			XCTAssertEqual(receiver.pressCount, previousCount + 1)
+			XCTAssertTrue(receiver.lastSender === button)
+
+			button.isEnabled = false
+			XCTAssertFalse(button.isAccessibilityEnabled())
+			_ = button.accessibilityPerformPress()
+			XCTAssertEqual(receiver.pressCount, previousCount + 1)
+		}
+	}
+
+	private func makeButton() -> GlassButton {
+		_ = NSApplication.shared
+		return GlassButton(title: "Share", image: makeImage(description: "Share icon"))
+	}
+
+	private func makeImage(description: String) -> NSImage {
+		let image = NSImage(size: NSSize(width: 16, height: 16))
+		image.accessibilityDescription = description
+		return image
+	}
+}
+
+private class ActionReceiver: NSObject {
+	var pressCount: Int = 0
+	weak var lastSender: NSButton?
+
+	@objc func press(_ sender: NSButton) {
+		pressCount += 1
+		lastSender = sender
+	}
+}

--- a/Tests/FluentUI_macOS_Tests/GlassButtonTests.swift
+++ b/Tests/FluentUI_macOS_Tests/GlassButtonTests.swift
@@ -8,6 +8,111 @@ import XCTest
 @testable import FluentUI_macos
 
 class GlassButtonTests: XCTestCase {
+	func testIconOnlySystemButtonUsesCompactPadding() throws {
+		guard #available(macOS 26.0, *) else {
+			throw XCTSkip("System glass requires macOS 26.")
+		}
+
+		let button = makeButton()
+		let image = makeImage(description: "Search")
+		image.size = NSSize(width: 20, height: 20)
+		button.image = image
+		button.title = ""
+
+		for imagePosition: NSControl.ImagePosition in [.imageLeading, .imageOnly] {
+			button.imagePosition = imagePosition
+			XCTAssertEqual(button.intrinsicContentSize, NSSize(width: 28, height: 28))
+		}
+
+		button.title = "Search"
+		button.imagePosition = .imageOnly
+		XCTAssertEqual(button.intrinsicContentSize, NSSize(width: 28, height: 28))
+
+		button.title = ""
+		button.image = nil
+		XCTAssertEqual(button.intrinsicContentSize.width, 16)
+	}
+
+	func testSystemButtonKeepsStandardPaddingForTitleOrChevron() throws {
+		guard #available(macOS 26.0, *) else {
+			throw XCTSkip("System glass requires macOS 26.")
+		}
+
+		let button = makeButton()
+		let image = makeImage(description: "Share")
+		image.size = NSSize(width: 20, height: 20)
+		button.image = image
+		let font = try XCTUnwrap(button.font)
+		let titleWidth = button.title.size(withAttributes: [.font: font]).width
+		XCTAssertEqual(button.intrinsicContentSize.width, ceil(20 + 4 + titleWidth + 16))
+
+		button.trailingImage = makeImage(description: "Chevron")
+		button.title = ""
+		XCTAssertEqual(button.intrinsicContentSize.width, 20 + 4 + 16 + 16)
+
+		button.imagePosition = .imageOnly
+		XCTAssertEqual(button.intrinsicContentSize.width, 20 + 4 + 16 + 16)
+
+		button.trailingImage = nil
+		XCTAssertEqual(button.intrinsicContentSize, NSSize(width: 28, height: 28))
+
+		button.title = "Share"
+		button.imagePosition = .imageLeading
+		XCTAssertEqual(button.intrinsicContentSize.width, ceil(20 + 4 + titleWidth + 16))
+
+		button.imagePosition = .noImage
+		XCTAssertEqual(button.intrinsicContentSize.width, ceil(titleWidth + 16))
+	}
+
+	func testCustomContentImagePositionControlsLayout() throws {
+		guard #available(macOS 26.0, *) else {
+			throw XCTSkip("System glass requires macOS 26.")
+		}
+
+		let button = makeButton()
+		button.trailingImage = makeImage(description: "Chevron")
+
+		for imagePosition: NSControl.ImagePosition in [.imageLeading, .noImage, .imageOnly, .imageLeading, .noImage] {
+			button.imagePosition = imagePosition
+			try assertCustomContentLayout(
+				button,
+				imageIsHidden: imagePosition == .noImage,
+				titleIsHidden: imagePosition == .imageOnly
+			)
+		}
+	}
+
+	func testNoImageSurvivesCustomContentChanges() throws {
+		guard #available(macOS 26.0, *) else {
+			throw XCTSkip("System glass requires macOS 26.")
+		}
+
+		let button = makeButton()
+		button.imagePosition = .noImage
+		button.trailingImage = makeImage(description: "Chevron")
+		try assertCustomContentLayout(button, imageIsHidden: true, titleIsHidden: false)
+
+		for image in [makeImage(description: "Replacement"), nil, makeImage(description: "Restored")] {
+			button.image = image
+			try assertCustomContentLayout(button, imageIsHidden: true, titleIsHidden: false)
+		}
+
+		button.title = "Sharing options"
+		try assertCustomContentLayout(button, imageIsHidden: true, titleIsHidden: false)
+
+		button.trailingImage = nil
+		button.trailingImage = makeImage(description: "Menu")
+		try assertCustomContentLayout(button, imageIsHidden: true, titleIsHidden: false)
+
+		button.imagePosition = .imageLeading
+		try assertCustomContentLayout(button, imageIsHidden: false, titleIsHidden: false)
+
+		button.image = nil
+		try assertCustomContentLayout(button, imageIsHidden: true, titleIsHidden: false)
+		button.image = makeImage(description: "Share icon")
+		try assertCustomContentLayout(button, imageIsHidden: false, titleIsHidden: false)
+	}
+
 	func testSingleAccessibleButton() {
 		let button = makeButton()
 
@@ -42,7 +147,7 @@ class GlassButtonTests: XCTestCase {
 		for trailingImage in [makeImage(description: "Chevron"), makeImage(description: "Menu"), nil, makeImage(description: "Chevron")] {
 			button.trailingImage = trailingImage
 
-			for imagePosition: NSControl.ImagePosition in [.imageLeading, .imageOnly] {
+			for imagePosition: NSControl.ImagePosition in [.imageLeading, .noImage, .imageOnly] {
 				button.imagePosition = imagePosition
 				button.setFrameSize(button.intrinsicContentSize)
 				button.layoutSubtreeIfNeeded()
@@ -163,6 +268,34 @@ class GlassButtonTests: XCTestCase {
 			XCTAssertFalse(button.isAccessibilityEnabled())
 			_ = button.accessibilityPerformPress()
 			XCTAssertEqual(receiver.pressCount, previousCount + 1)
+		}
+	}
+
+	private func assertCustomContentLayout(
+		_ button: GlassButton,
+		imageIsHidden: Bool,
+		titleIsHidden: Bool,
+		file: StaticString = #filePath,
+		line: UInt = #line
+	) throws {
+		let imageViews = button.subviews.compactMap { $0 as? NSImageView }
+		let imageView = try XCTUnwrap(imageViews.first { $0.image === button.image }, file: file, line: line)
+		let trailingImageView = try XCTUnwrap(imageViews.first { $0.image === button.trailingImage }, file: file, line: line)
+		let label = try XCTUnwrap(button.subviews.compactMap { $0 as? NSTextField }.first, file: file, line: line)
+		let cell = try XCTUnwrap(button.cell as? ButtonCell, file: file, line: line)
+		button.setFrameSize(button.intrinsicContentSize)
+		button.layoutSubtreeIfNeeded()
+
+		XCTAssertEqual(imageView.isHidden, imageIsHidden, file: file, line: line)
+		XCTAssertEqual(label.isHidden, titleIsHidden, file: file, line: line)
+		XCTAssertFalse(trailingImageView.isHidden, file: file, line: line)
+		if !titleIsHidden {
+			let imageRect = imageView.alignmentRect(forFrame: imageView.frame)
+			let titleRect = label.alignmentRect(forFrame: label.frame)
+			let trailingImageRect = trailingImageView.alignmentRect(forFrame: trailingImageView.frame)
+			let expectedLeading = imageIsHidden ? cell.horizontalPadding : imageRect.maxX + cell.titleToImageSpacing
+			XCTAssertEqual(titleRect.minX, expectedLeading, accuracy: 0.01, file: file, line: line)
+			XCTAssertLessThanOrEqual(titleRect.maxX + cell.titleToImageSpacing, trailingImageRect.minX + 0.01, file: file, line: line)
 		}
 	}
 

--- a/Tests/FluentUI_macOS_Tests/GlassButtonTests.swift
+++ b/Tests/FluentUI_macOS_Tests/GlassButtonTests.swift
@@ -129,49 +129,6 @@ class GlassButtonTests: XCTestCase {
 		}
 	}
 
-	func testDecorativeContentIsIgnoredByWindowHitTesting() throws {
-		let button = makeButton()
-		let window = NSWindow(
-			contentRect: NSRect(x: 100, y: 100, width: 320, height: 120),
-			styleMask: [.titled],
-			backing: .buffered,
-			defer: false
-		)
-		window.isReleasedWhenClosed = false
-		let contentView = try XCTUnwrap(window.contentView)
-		contentView.addSubview(button)
-		button.setFrameOrigin(NSPoint(x: 20, y: 20))
-		window.orderBack(nil)
-		defer { window.orderOut(nil) }
-
-		for trailingImage in [makeImage(description: "Chevron"), makeImage(description: "Menu"), nil, makeImage(description: "Chevron")] {
-			button.trailingImage = trailingImage
-
-			for imagePosition: NSControl.ImagePosition in [.imageLeading, .noImage, .imageOnly] {
-				button.imagePosition = imagePosition
-				button.setFrameSize(button.intrinsicContentSize)
-				button.layoutSubtreeIfNeeded()
-
-				let decorativeViews = button.subviews.filter { $0 is NSImageView || $0 is NSTextField }
-				if #available(macOS 26.0, *), trailingImage != nil {
-					XCTAssertEqual(decorativeViews.count, 3)
-				}
-				for view in decorativeViews {
-					XCTAssertNil(NSAccessibility.unignoredDescendant(of: view), "\(type(of: view)) exposes an accessibility descendant")
-					if !view.isHidden {
-						XCTAssertFalse(view.bounds.isEmpty)
-						let center = NSPoint(x: view.bounds.midX, y: view.bounds.midY)
-						let screenPoint = window.convertPoint(toScreen: view.convert(center, to: nil))
-						XCTAssertTrue(
-							(window.accessibilityHitTest(screenPoint) as? NSView) === button,
-							"Hit-testing \(type(of: view)) should return the button"
-						)
-					}
-				}
-			}
-		}
-	}
-
 	func testLabelFollowsTitleAndLayoutChanges() {
 		let button = makeButton()
 		XCTAssertEqual(button.accessibilityLabel(), "Share")


### PR DESCRIPTION
### Platforms Impacted
- [ ] iOS
- [ ] visionOS
- [x] macOS

### Description of changes

Updating the macOS `GlassButton` to use true glass effects on macOS 26 and later.

### Verification

* Ensured the buttons continue to behave as expected on macOS 26, 27, and 15.
* Accessibility is good!

<details>
<summary>Visual Verification</summary>

| With glass (macOS 26+)                                      | Fallback (macOS <26)                                      |
|----------------------------------------------|--------------------------------------------| 
| <img width="912" height="726" alt="Screenshot 2026-09-09 at 8 50 16 PM" src="https://github.com/user-attachments/assets/dc3e0e28-04b5-4350-a3cf-5b2310d89c92" /> | <img width="912" height="726" alt="Screenshot 2026-09-09 at 8 55 00 PM" src="https://github.com/user-attachments/assets/24adfaf2-29ed-4494-b9d5-cebf72d3cf6f" /> |
</details>


### Pull request checklist

This PR has considered:

- [x] Light and Dark appearances
- [x] macOS supported versions (all major versions greater than or equal current target deployment version)
- [x] VoiceOver and Keyboard Accessibility
- [x] Internationalization and Right to Left layouts
- [x] Different resolutions (1x, 2x, 3x)
- [ ] Size classes and window sizes (iPhone vs iPad, notched devices, multitasking, different window sizes, etc)
- [ ] iPad [Pointer interaction](https://developer.apple.com/documentation/uikit/pointer_interactions)
- [x] [SwiftUI](https://developer.apple.com/tutorials/swiftui) consumption (validation or new demo scenarios needed)
- [x] Objective-C exposure (provide it only if needed)
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoft/fluentui-apple/pull/2291)